### PR TITLE
Feature/jwt

### DIFF
--- a/src/main/java/com/trackery/trackerybackapiserver/config/JwtFilter.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/config/JwtFilter.java
@@ -1,6 +1,7 @@
 package com.trackery.trackerybackapiserver.config;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Optional;
 
 import org.springframework.lang.NonNull;
@@ -17,6 +18,7 @@ import com.trackery.trackerybackapiserver.domain.user.entity.CustomUserDetails;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -55,15 +57,17 @@ public class JwtFilter extends OncePerRequestFilter {
 	protected void doFilterInternal(HttpServletRequest request, @NonNull HttpServletResponse response,
 		@NonNull FilterChain filterChain) throws ServletException, IOException {
 
-		String authHeader = Optional.ofNullable(request.getHeader("Authorization"))
-			.filter(header -> header.startsWith("Bearer "))
-			.orElseThrow(() -> new ApiException(ErrorCode.UNAUTHORIZED_MISSING_AUTH_HEADER));
+		String requestToken = Optional.ofNullable(request.getCookies())
+			.flatMap(cookies -> Arrays.stream(cookies)
+				.filter(cookie -> "accessToken".equals(cookie.getName()))
+				.findFirst()
+				.map(Cookie::getValue))
+			.orElseThrow(() -> new ApiException(ErrorCode.UNAUTHORIZED));
 
-		String token = authHeader.substring(7);
-		DecodedJWT jwt = jwtUtil.verifyJwt(token);
+		DecodedJWT jwt = jwtUtil.verifyJwt(requestToken);
 
 		Long userId = Long.valueOf(jwt.getSubject());
-		Long roleId = jwt.getClaim("roleId").asLong();
+		Long roleId = jwt.getClaim("role").asLong();
 
 		UserDetails userDetails = CustomUserDetails.builder().userId(userId).roleId(roleId).build();
 

--- a/src/main/java/com/trackery/trackerybackapiserver/config/SecurityConfig.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/config/SecurityConfig.java
@@ -11,7 +11,9 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -53,14 +55,18 @@ public class SecurityConfig {
 
 	@Bean
 	@Order(2)
-	public SecurityFilterChain protectedFilterChain(HttpSecurity http) throws Exception {
+	public SecurityFilterChain protectedFilterChain(HttpSecurity http, AuthenticationEntryPoint entryPoint,
+		AccessDeniedHandler accessDeniedHandler) throws Exception {
 		http
 			.cors(Customizer.withDefaults())
 			.csrf(AbstractHttpConfigurer::disable)
 			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers("/error").permitAll().anyRequest().authenticated())
-			.addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
+			.addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class)
+			.exceptionHandling(handler -> handler
+				.authenticationEntryPoint(entryPoint)
+				.accessDeniedHandler(accessDeniedHandler));
 
 		return http.build();
 	}
@@ -70,7 +76,8 @@ public class SecurityConfig {
 		CorsConfiguration config = new CorsConfiguration();
 		config.setAllowedOrigins(List.of(projectDomain, localDomain));
 		config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH"));
-		config.setAllowedHeaders(List.of("Authorization", "Content-Type"));
+		config.setAllowedHeaders(List.of("Content-Type"));
+		config.setAllowCredentials(true);
 		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
 		source.registerCorsConfiguration("/**", config);
 		return source;

--- a/src/main/java/com/trackery/trackerybackapiserver/config/SecurityConfig.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/config/SecurityConfig.java
@@ -55,18 +55,14 @@ public class SecurityConfig {
 
 	@Bean
 	@Order(2)
-	public SecurityFilterChain protectedFilterChain(HttpSecurity http, AuthenticationEntryPoint entryPoint,
-		AccessDeniedHandler accessDeniedHandler) throws Exception {
+	public SecurityFilterChain protectedFilterChain(HttpSecurity http) throws Exception {
 		http
 			.cors(Customizer.withDefaults())
 			.csrf(AbstractHttpConfigurer::disable)
 			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers("/error").permitAll().anyRequest().authenticated())
-			.addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class)
-			.exceptionHandling(handler -> handler
-				.authenticationEntryPoint(entryPoint)
-				.accessDeniedHandler(accessDeniedHandler));
+			.addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
 
 		return http.build();
 	}

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/controller/UserController.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/controller/UserController.java
@@ -1,6 +1,10 @@
 package com.trackery.trackerybackapiserver.domain.user.controller;
 
+import java.time.Duration;
+
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -31,10 +35,19 @@ public class UserController {
 	 */
 	@PostMapping("/register")
 	public ResponseEntity<ApiResponse<String>> registerUser(@Valid @RequestBody UserRegisterDto userRegisterDto) {
-		String authHeader = userService.registerUser(userRegisterDto);
+		String jwt = userService.registerUser(userRegisterDto);
+
+		ResponseCookie cookie = ResponseCookie.from("accessToken", jwt)
+			.httpOnly(true)
+			.secure(false)
+			.path("/")
+			.maxAge(Duration.ofDays(7))
+			.sameSite("Strict")
+			.build();
+
 		return ResponseEntity
 			.status(HttpStatus.CREATED)
-			.header("Authorization", authHeader)
+			.header(HttpHeaders.SET_COOKIE, cookie.toString())
 			.body(ApiResponse.success(SuccessCode.CREATED));
 	}
 

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/UserService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/UserService.java
@@ -5,8 +5,6 @@ import java.time.LocalDateTime;
 
 import org.springframework.stereotype.Service;
 
-import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
-import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
 import com.trackery.trackerybackapiserver.domain.common.util.JwtUtil;
 import com.trackery.trackerybackapiserver.domain.common.util.PasswordUtil;
 import com.trackery.trackerybackapiserver.domain.user.dto.UserRegisterDto;
@@ -53,9 +51,7 @@ public class UserService {
 
 		userMapper.insertUserRole(userRole);
 
-		String jwt = jwtUtil.generateJwt(user.getUserId(), user.getUserName(), userRole.getRoleId());
-
-		return String.format("Bearer %s", jwt);
+		return jwtUtil.generateJwt(user.getUserId(), user.getUserName(), userRole.getRoleId());
 	}
 
 	/**

--- a/src/main/resources/mapper/UserMapper.xml
+++ b/src/main/resources/mapper/UserMapper.xml
@@ -14,7 +14,7 @@
     </select>
 
     <select id = "findById" parameterType="Long" resultType="com.trackery.trackerybackapiserver.domain.user.entity.User">
-        SELECT * FROM users WHERE user_id = #{userId}
+        SELECT * FROM user WHERE user_id = #{userId}
     </select>
 
     <insert id="insertUserRole" parameterType="com.trackery.trackerybackapiserver.domain.user.entity.UserRole" useGeneratedKeys="true" keyProperty="userRoleId" >

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/common/util/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/common/util/GlobalExceptionHandlerTest.java
@@ -11,7 +11,6 @@ import org.mockito.Spy;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/user/controller/UserControllerTest.java
@@ -1,5 +1,6 @@
 package com.trackery.trackerybackapiserver.domain.user.controller;
 
+import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
@@ -54,7 +55,7 @@ class UserControllerTest extends CommonMockMvcControllerTestSetUp {
 		ReflectionTestUtils.setField(dto, "nickname", "김커피");
 		ReflectionTestUtils.setField(dto, "password", "Qwerasdf1234!!asdf");
 
-		when(userService.registerUser(any())).thenReturn("Bearer jwt");
+		when(userService.registerUser(any())).thenReturn("jwt");
 
 		ResultActions result = mockMvc
 			.perform(post("/api/users/register")
@@ -65,8 +66,9 @@ class UserControllerTest extends CommonMockMvcControllerTestSetUp {
 
 		result
 			.andExpect(status().isCreated())
-			.andExpect(header().exists("Authorization"))
-			.andExpect(header().string("Authorization", "Bearer jwt"));
+			.andExpect(cookie().exists("accessToken"))
+			.andExpect(cookie().httpOnly("accessToken", true))
+			.andExpect(cookie().value("accessToken", notNullValue()));
 	}
 
 	@Test

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/user/service/UserServiceTest.java
@@ -69,7 +69,7 @@ class UserServiceTest {
 
 			String result =  userService.registerUser(dto);
 
-			assertEquals("Bearer jwt token", result);
+			assertEquals("jwt token", result);
 
 			verify(userMapper, times(1)).insertUser(any(User.class));
 			verify(userMapper, times(1)).insertUserRole(any(UserRole.class));


### PR DESCRIPTION
회원가입 완료 시 기존 Authorization 헤더로 반환하는 방식에서  set-cookie를 통해 http-only 쿠키에 jwt 액세스 토큰이 저장되도록 변경하고 오타를 수정했습니다.