### PR TITLE
Feature/jwt/refresh token

### DIFF
--- a/.run/프로젝트 전체 커버리지.run.xml
+++ b/.run/프로젝트 전체 커버리지.run.xml
@@ -1,0 +1,69 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="프로젝트 전체 커버리지" type="JUnit" factoryName="JUnit">
+    <module name="Trackery-BackAPIServer" />
+    <extension name="coverage" runner="jacoco">
+      <pattern>
+        <option name="PATTERN" value="com.trackery.trackerybackapiserver.config.*" />
+        <option name="ENABLED" value="true" />
+        <option name="INCLUDE" value="false" />
+      </pattern>
+      <pattern>
+        <option name="PATTERN" value="com.trackery.trackerybackapiserver.domain.auth.dto.*" />
+        <option name="ENABLED" value="true" />
+        <option name="INCLUDE" value="false" />
+      </pattern>
+      <pattern>
+        <option name="PATTERN" value="com.trackery.trackerybackapiserver.domain.common.*" />
+        <option name="ENABLED" value="true" />
+        <option name="INCLUDE" value="false" />
+      </pattern>
+      <pattern>
+        <option name="PATTERN" value="com.trackery.trackerybackapiserver.domain.home.entity.*" />
+        <option name="ENABLED" value="true" />
+        <option name="INCLUDE" value="false" />
+      </pattern>
+      <pattern>
+        <option name="PATTERN" value="com.trackery.trackerybackapiserver.domain.home.mapper.*" />
+        <option name="ENABLED" value="true" />
+        <option name="INCLUDE" value="false" />
+      </pattern>
+      <pattern>
+        <option name="PATTERN" value="com.trackery.trackerybackapiserver.domain.home.dto.*" />
+        <option name="ENABLED" value="true" />
+        <option name="INCLUDE" value="false" />
+      </pattern>
+      <pattern>
+        <option name="PATTERN" value="com.trackery.trackerybackapiserver.domain.jwt.dto.*" />
+        <option name="ENABLED" value="true" />
+        <option name="INCLUDE" value="false" />
+      </pattern>
+      <pattern>
+        <option name="PATTERN" value="com.trackery.trackerybackapiserver.domain.user.dto.*" />
+        <option name="ENABLED" value="true" />
+        <option name="INCLUDE" value="false" />
+      </pattern>
+      <pattern>
+        <option name="PATTERN" value="com.trackery.trackerybackapiserver.domain.user.entity.*" />
+        <option name="ENABLED" value="true" />
+        <option name="INCLUDE" value="false" />
+      </pattern>
+      <pattern>
+        <option name="PATTERN" value="com.trackery.trackerybackapiserver.domain.user.enums.*" />
+        <option name="ENABLED" value="true" />
+        <option name="INCLUDE" value="false" />
+      </pattern>
+      <pattern>
+        <option name="PATTERN" value="com.trackery.trackerybackapiserver.domain.user.mapper.*" />
+        <option name="ENABLED" value="true" />
+        <option name="INCLUDE" value="false" />
+      </pattern>
+    </extension>
+    <option name="MAIN_CLASS_NAME" value="" />
+    <option name="METHOD_NAME" value="" />
+    <option name="TEST_OBJECT" value="directory" />
+    <dir value="$PROJECT_DIR$/src/test/java" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/src/main/java/com/trackery/trackerybackapiserver/config/JwtFilter.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/config/JwtFilter.java
@@ -14,6 +14,7 @@ import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
+import com.trackery.trackerybackapiserver.domain.jwt.dto.JwtUserInfoDto;
 import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
 import com.trackery.trackerybackapiserver.domain.user.entity.CustomUserDetails;
 
@@ -40,10 +41,8 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
 
-	/**
-	 * 토큰 검증 및 파싱을 담당하는 JWT 유틸리티 클래스
-	 */
 	private final JwtService jwtService;
+	private static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
 
 	/**
 	 * JWT 인증/인가를 해주는 필터
@@ -58,40 +57,51 @@ public class JwtFilter extends OncePerRequestFilter {
 	 * @throws IOException : 입출력 처리 중 발생할 수 있는 예외
 	 */
 	@Override
-	protected void doFilterInternal(HttpServletRequest request, @NonNull HttpServletResponse response,
+	protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response,
 		@NonNull FilterChain filterChain) throws ServletException, IOException {
 
-		String requestToken = Optional.ofNullable(request.getCookies())
+		String accessToken = getAccessTokenFromCookie(request);
+
+		JwtUserInfoDto userInfo = verifyAndParseJwt(accessToken);
+
+		setAuthentication(userInfo);
+
+		filterChain.doFilter(request, response);
+	}
+
+	private String getAccessTokenFromCookie(HttpServletRequest request) {
+		return Optional.ofNullable(request.getCookies())
 			.flatMap(cookies -> Arrays.stream(cookies)
-				.filter(cookie -> "accessToken".equals(cookie.getName()))
+				.filter(cookie -> ACCESS_TOKEN_COOKIE_NAME.equals(cookie.getName()))
 				.findFirst()
 				.map(Cookie::getValue))
 			.orElseThrow(() -> new ApiException(ErrorCode.UNAUTHORIZED));
+	}
 
-		DecodedJWT jwt;
-
+	private JwtUserInfoDto verifyAndParseJwt(String accessToken) {
 		try {
-			jwt = jwtService.verifyJwt(requestToken);
+			DecodedJWT jwt = jwtService.verifyJwt(accessToken);
+			Long userId = Long.valueOf(jwt.getSubject());
+			String userName = jwt.getClaim("username").asString();
+			Long roleId = jwt.getClaim("role").asLong();
+
+			return new JwtUserInfoDto(userId, userName, roleId);
 		} catch (JWTVerificationException e) {
-			log.error(e.getMessage());
+			log.error("JWT 검증 실패: {}", e.getMessage());
 			throw new ApiException(ErrorCode.UNAUTHORIZED_JWT_VERIFY_FAILED);
 		}
+	}
 
-		Long userId = Long.valueOf(jwt.getSubject());
-		String userName = jwt.getClaim("username").asString();
-		Long roleId = jwt.getClaim("role").asLong();
-
+	private void setAuthentication(JwtUserInfoDto userInfo) {
 		UserDetails userDetails = CustomUserDetails.builder()
-			.userId(userId)
-			.userName(userName)
-			.roleId(roleId)
+			.userId(userInfo.userId())
+			.userName(userInfo.username())
+			.roleId(userInfo.roleId())
 			.build();
 
 		UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(userDetails,
 			null, userDetails.getAuthorities());
 
 		SecurityContextHolder.getContext().setAuthentication(authenticationToken);
-
-		filterChain.doFilter(request, response);
 	}
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/config/JwtFilter.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/config/JwtFilter.java
@@ -14,7 +14,7 @@ import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
-import com.trackery.trackerybackapiserver.domain.common.util.JwtUtil;
+import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
 import com.trackery.trackerybackapiserver.domain.user.entity.CustomUserDetails;
 
 import jakarta.servlet.FilterChain;
@@ -43,7 +43,7 @@ public class JwtFilter extends OncePerRequestFilter {
 	/**
 	 * 토큰 검증 및 파싱을 담당하는 JWT 유틸리티 클래스
 	 */
-	private final JwtUtil jwtUtil;
+	private final JwtService jwtService;
 
 	/**
 	 * JWT 인증/인가를 해주는 필터
@@ -71,7 +71,7 @@ public class JwtFilter extends OncePerRequestFilter {
 		DecodedJWT jwt;
 
 		try {
-			jwt = jwtUtil.verifyJwt(requestToken);
+			jwt = jwtService.verifyJwt(requestToken);
 		} catch (JWTVerificationException e) {
 			log.error(e.getMessage());
 			throw new ApiException(ErrorCode.UNAUTHORIZED_JWT_VERIFY_FAILED);

--- a/src/main/java/com/trackery/trackerybackapiserver/config/SecurityConfig.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/config/SecurityConfig.java
@@ -20,7 +20,6 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import com.trackery.trackerybackapiserver.config.filter.ExceptionHandlerFilter;
 import com.trackery.trackerybackapiserver.config.filter.JwtAuthenticationFilter;
 import com.trackery.trackerybackapiserver.config.filter.JwtResolverFilter;
-import com.trackery.trackerybackapiserver.domain.jwt.service.JwtRedisService;
 import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
 import com.trackery.trackerybackapiserver.domain.user.service.UserService;
 
@@ -50,7 +49,6 @@ public class SecurityConfig {
 	 * JWT 토큰을 검증하는 유틸리티 클래스
 	 */
 	private final JwtService jwtService;
-	private final JwtRedisService jwtRedisService;
 	private final UserService userService;
 
 	/**
@@ -117,7 +115,7 @@ public class SecurityConfig {
 				.requestMatchers("/error").permitAll().anyRequest().authenticated())
 			.addFilterBefore(new JwtAuthenticationFilter(jwtService),
 				UsernamePasswordAuthenticationFilter.class)
-			.addFilterBefore(new JwtResolverFilter(jwtService, jwtRedisService, userService),
+			.addFilterBefore(new JwtResolverFilter(jwtService, userService),
 				JwtAuthenticationFilter.class)
 			.addFilterBefore(new ExceptionHandlerFilter(), JwtResolverFilter.class);
 

--- a/src/main/java/com/trackery/trackerybackapiserver/config/SecurityConfig.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/config/SecurityConfig.java
@@ -17,6 +17,9 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import com.trackery.trackerybackapiserver.config.filter.JwtAuthenticationFilter;
+import com.trackery.trackerybackapiserver.config.filter.JwtResolverFilter;
+import com.trackery.trackerybackapiserver.domain.jwt.service.JwtRedisService;
 import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
 
 import lombok.RequiredArgsConstructor;
@@ -45,6 +48,7 @@ public class SecurityConfig {
 	 * JWT 토큰을 검증하는 유틸리티 클래스
 	 */
 	private final JwtService jwtService;
+	private final JwtRedisService jwtRedisService;
 
 	/**
 	 * 인증 없이 접근 가능한 공개 API 목록
@@ -108,8 +112,10 @@ public class SecurityConfig {
 			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers("/error").permitAll().anyRequest().authenticated())
-			.addFilterBefore(new JwtFilter(jwtService), UsernamePasswordAuthenticationFilter.class)
-			.addFilterBefore(new ExceptionHandlerFilter(), JwtFilter.class);
+			.addFilterBefore(new ExceptionHandlerFilter(), JwtResolverFilter.class)
+			.addFilterBefore(new JwtResolverFilter(jwtService, jwtRedisService),
+				UsernamePasswordAuthenticationFilter.class)
+			.addFilterAfter(new JwtAuthenticationFilter(jwtService), JwtResolverFilter.class);
 
 		return http.build();
 	}

--- a/src/main/java/com/trackery/trackerybackapiserver/config/SecurityConfig.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/config/SecurityConfig.java
@@ -17,10 +17,12 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import com.trackery.trackerybackapiserver.config.filter.ExceptionHandlerFilter;
 import com.trackery.trackerybackapiserver.config.filter.JwtAuthenticationFilter;
 import com.trackery.trackerybackapiserver.config.filter.JwtResolverFilter;
 import com.trackery.trackerybackapiserver.domain.jwt.service.JwtRedisService;
 import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
+import com.trackery.trackerybackapiserver.domain.user.service.UserService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -49,6 +51,7 @@ public class SecurityConfig {
 	 */
 	private final JwtService jwtService;
 	private final JwtRedisService jwtRedisService;
+	private final UserService userService;
 
 	/**
 	 * 인증 없이 접근 가능한 공개 API 목록
@@ -112,10 +115,11 @@ public class SecurityConfig {
 			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers("/error").permitAll().anyRequest().authenticated())
-			.addFilterBefore(new ExceptionHandlerFilter(), JwtResolverFilter.class)
-			.addFilterBefore(new JwtResolverFilter(jwtService, jwtRedisService),
+			.addFilterBefore(new JwtAuthenticationFilter(jwtService),
 				UsernamePasswordAuthenticationFilter.class)
-			.addFilterAfter(new JwtAuthenticationFilter(jwtService), JwtResolverFilter.class);
+			.addFilterBefore(new JwtResolverFilter(jwtService, jwtRedisService, userService),
+				JwtAuthenticationFilter.class)
+			.addFilterBefore(new ExceptionHandlerFilter(), JwtResolverFilter.class);
 
 		return http.build();
 	}

--- a/src/main/java/com/trackery/trackerybackapiserver/config/SecurityConfig.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/config/SecurityConfig.java
@@ -17,7 +17,7 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import com.trackery.trackerybackapiserver.domain.common.util.JwtUtil;
+import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -44,7 +44,7 @@ public class SecurityConfig {
 	/**
 	 * JWT 토큰을 검증하는 유틸리티 클래스
 	 */
-	private final JwtUtil jwtUtil;
+	private final JwtService jwtService;
 
 	/**
 	 * 인증 없이 접근 가능한 공개 API 목록
@@ -108,7 +108,7 @@ public class SecurityConfig {
 			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers("/error").permitAll().anyRequest().authenticated())
-			.addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class)
+			.addFilterBefore(new JwtFilter(jwtService), UsernamePasswordAuthenticationFilter.class)
 			.addFilterBefore(new ExceptionHandlerFilter(), JwtFilter.class);
 
 		return http.build();

--- a/src/main/java/com/trackery/trackerybackapiserver/config/filter/ExceptionHandlerFilter.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/config/filter/ExceptionHandlerFilter.java
@@ -2,7 +2,6 @@ package com.trackery.trackerybackapiserver.config.filter;
 
 import java.io.IOException;
 
-import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.lang.NonNull;
 import org.springframework.web.filter.OncePerRequestFilter;

--- a/src/main/java/com/trackery/trackerybackapiserver/config/filter/ExceptionHandlerFilter.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/config/filter/ExceptionHandlerFilter.java
@@ -1,7 +1,8 @@
-package com.trackery.trackerybackapiserver.config;
+package com.trackery.trackerybackapiserver.config.filter;
 
 import java.io.IOException;
 
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.lang.NonNull;
 import org.springframework.web.filter.OncePerRequestFilter;

--- a/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtAuthenticationFilter.java
@@ -2,6 +2,7 @@ package com.trackery.trackerybackapiserver.config.filter;
 
 import java.io.IOException;
 
+import org.springframework.core.annotation.Order;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;

--- a/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,84 @@
+package com.trackery.trackerybackapiserver.config.filter;
+
+import java.io.IOException;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
+import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
+import com.trackery.trackerybackapiserver.domain.jwt.dto.JwtUserInfoDto;
+import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
+import com.trackery.trackerybackapiserver.domain.user.entity.CustomUserDetails;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * packageName    : com.trackery.trackerybackapiserver.config.customFilter
+ * fileName       : JwtAuthenticationFilter
+ * author         : durururuk
+ * date           : 25. 3. 28.
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 25. 3. 28.        durururuk      최초 생성
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+	private final JwtService jwtService;
+
+	@Override
+	protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response,
+		@NonNull FilterChain filterChain) throws ServletException, IOException {
+
+		String accessToken = (String)request.getAttribute("accessToken");
+
+		if (accessToken != null) {
+			JwtUserInfoDto userInfo = verifyAndParseJwt(accessToken);
+
+			setAuthentication(userInfo);
+		}
+
+		filterChain.doFilter(request, response);
+
+	}
+
+	private JwtUserInfoDto verifyAndParseJwt(String accessToken) {
+		try {
+			DecodedJWT jwt = jwtService.verifyJwt(accessToken);
+			Long userId = Long.valueOf(jwt.getSubject());
+			String userName = jwt.getClaim("username").asString();
+			Long roleId = jwt.getClaim("role").asLong();
+
+			return new JwtUserInfoDto(userId, userName, roleId);
+		} catch (JWTVerificationException e) {
+			log.error("JWT 검증 실패: {}", e.getMessage());
+			throw new ApiException(ErrorCode.UNAUTHORIZED_JWT_VERIFY_FAILED);
+		}
+	}
+
+	private void setAuthentication(JwtUserInfoDto userInfo) {
+		UserDetails userDetails = CustomUserDetails.builder()
+			.userId(userInfo.userId())
+			.userName(userInfo.username())
+			.roleId(userInfo.roleId())
+			.build();
+
+		UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(userDetails,
+			null, userDetails.getAuthorities());
+
+		SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+	}
+}

--- a/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtAuthenticationFilter.java
@@ -2,7 +2,6 @@ package com.trackery.trackerybackapiserver.config.filter;
 
 import java.io.IOException;
 
-import org.springframework.core.annotation.Order;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;

--- a/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtAuthenticationFilter.java
@@ -28,7 +28,7 @@ import lombok.extern.slf4j.Slf4j;
  * fileName       : JwtAuthenticationFilter
  * author         : durururuk
  * date           : 25. 3. 28.
- * description    :
+ * description    : 액세스 토큰을 검증하고 파싱해서 유저 인증 정보를 시큐리티 컨텍스트 홀더에 저장합니다.
  * ===========================================================
  * DATE              AUTHOR             NOTE
  * -----------------------------------------------------------
@@ -39,22 +39,34 @@ import lombok.extern.slf4j.Slf4j;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	private final JwtService jwtService;
 
+	/**
+	 * 필터 흐름
+	 *  1. Attribute에서 액세스 토큰을 받아옵니다.
+	 *  2. 액세스 토큰을 검증하고 파싱해서 유저 정보를 가져옵니다.
+	 *  3. 가져온 유저 정보를 스프링 시큐리티 컨텍스트 홀더에 저장합니다.
+	 */
 	@Override
 	protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response,
 		@NonNull FilterChain filterChain) throws ServletException, IOException {
 
 		String accessToken = (String)request.getAttribute("accessToken");
 
-		if (accessToken != null) {
-			JwtUserInfoDto userInfo = verifyAndParseJwt(accessToken);
-
-			setAuthentication(userInfo);
+		if (accessToken == null) {
+			throw new ApiException(ErrorCode.UNAUTHORIZED);
 		}
+
+		JwtUserInfoDto userInfo = verifyAndParseJwt(accessToken);
+		setAuthentication(userInfo);
 
 		filterChain.doFilter(request, response);
 
 	}
 
+	/**
+	 * 액세스 토큰 검증, 파싱, DTO로 변환해서 반환하는 메서드
+	 * @param accessToken : 액세스 토큰
+	 * @return : userId, userName, roleID를 담고있는 DTO
+	 */
 	private JwtUserInfoDto verifyAndParseJwt(String accessToken) {
 		try {
 			DecodedJWT jwt = jwtService.verifyJwt(accessToken);
@@ -69,6 +81,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		}
 	}
 
+	/**
+	 * 유저 정보를 받아서 시큐리티 컨텍스트 홀더에 저장하는 메서드
+	 * @param userInfo : userId, userName, roleID를 담고있는 DTO
+	 */
 	private void setAuthentication(JwtUserInfoDto userInfo) {
 		UserDetails userDetails = CustomUserDetails.builder()
 			.userId(userInfo.userId())

--- a/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtResolverFilter.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtResolverFilter.java
@@ -50,16 +50,12 @@ public class JwtResolverFilter extends OncePerRequestFilter {
 	private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
 
 	/**
-	 * JWT 인증/인가를 해주는 필터
-	 * 1. 인증 헤더가 올바르지 않으면 예외 처리
-	 * 2. jwt 토큰 파싱, 검증
-	 * 3. 인증 정보를 SecurityContext에 담고 필터 통과
+	 * 필터 흐름
+	 *  1. 쿠키에서 액세스 토큰을 가져옵니다.
+	 *   1.1. 액세스 토큰이 없고 리프레시 토큰은 있다면 액세스 토큰을 재발급합니다.
+	 *   1.2. 액세스 토큰과 리프레시 토큰이 모두 없다면 401 에러를 반환합니다.
 	 *
-	 * @param request : 클라이언트의 http 요청 객체
-	 * @param response : 서버의 http 응답 객체
-	 * @param filterChain : 다음 필터 혹은 리소스로 넘겨주는 필터체인 객체
-	 * @throws ServletException : 필터 처리 중 발생할 수 있는 서블릿 관련 예외
-	 * @throws IOException : 입출력 처리 중 발생할 수 있는 예외
+	 *  2. 액세스 토큰을 Attribute에 담아서 필터체인을 진행합니다.
 	 */
 	@Override
 	protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response,
@@ -70,6 +66,12 @@ public class JwtResolverFilter extends OncePerRequestFilter {
 		filterChain.doFilter(request, response);
 	}
 
+	/**
+	 * 액세스 토큰을 쿠키에서 가져옵니다.
+	 * 만약 액세스 토큰이 없다면 리프레시 토큰을 가져오는 메서드로 진행됩니다.
+	 *
+	 * @return : 액세스 토큰
+	 */
 	private String getAccessTokenFromCookie(HttpServletRequest request, HttpServletResponse response) {
 		return Optional.ofNullable(request.getCookies())
 			.flatMap(cookies -> Arrays.stream(cookies)
@@ -79,7 +81,14 @@ public class JwtResolverFilter extends OncePerRequestFilter {
 			.orElseGet(() -> reissueAccessTokenViaRefreshToken(request, response));
 	}
 
+	/**
+	 * 리프레시 토큰을 쿠키에서 가져옵니다. 만약 없다면 401 에러를 반환합니다.
+	 * 리프레시 토큰이 있다면 액세스 토큰을 재발급해서 반환합니다.
+	 *
+	 * @return : 액세스 토큰
+	 */
 	private String reissueAccessTokenViaRefreshToken(HttpServletRequest request, HttpServletResponse response) {
+		//쿠키에서 리프레시 토큰을 가져옵니다. 만약 없다면 401 에러를 반환합니다.
 		String refreshToken = Optional.ofNullable(request.getCookies())
 			.flatMap(cookies -> Arrays.stream(cookies)
 				.filter(cookie -> REFRESH_TOKEN_COOKIE_NAME.equals(cookie.getName()))
@@ -87,6 +96,9 @@ public class JwtResolverFilter extends OncePerRequestFilter {
 				.map(Cookie::getValue))
 			.orElseThrow(() -> new ApiException(ErrorCode.UNAUTHORIZED));
 
+		/*
+		리프레시 토큰을 파싱하고 서버에 저장된 리프레시 토큰의 정보와 일치하는지 대조합니다.
+		 */
 		DecodedJWT decodedRefreshToken = jwtService.verifyJwt(refreshToken);
 		RefreshTokenDto refreshTokenDto = jwtRedisService.getRefreshTokenInfo(refreshToken);
 
@@ -99,6 +111,7 @@ public class JwtResolverFilter extends OncePerRequestFilter {
 
 		jwtRedisService.deleteRefreshToken(refreshToken);
 
+		//액세스 토큰 재발급해서 쿠키에 담고 HttpServletResponse header에 추가합니다.
 		AuthTokenDto authTokenDto = jwtService.generateAccessTokenAndRefreshToken(jwtUserInfoDto.userId(),
 			jwtUserInfoDto.username(), jwtUserInfoDto.roleId());
 

--- a/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtResolverFilter.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtResolverFilter.java
@@ -12,7 +12,6 @@ import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiEx
 import com.trackery.trackerybackapiserver.domain.common.util.CookieUtil;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.AuthTokenDto;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.JwtUserInfoDto;
-import com.trackery.trackerybackapiserver.domain.jwt.service.JwtRedisService;
 import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
 import com.trackery.trackerybackapiserver.domain.user.service.UserService;
 
@@ -39,7 +38,6 @@ import lombok.extern.slf4j.Slf4j;
 public class JwtResolverFilter extends OncePerRequestFilter {
 
 	private final JwtService jwtService;
-	private final JwtRedisService jwtRedisService;
 	private final UserService userService;
 	private static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
 	private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
@@ -73,7 +71,10 @@ public class JwtResolverFilter extends OncePerRequestFilter {
 				throw new ApiException(ErrorCode.UNAUTHORIZED);
 			});
 
-		JwtUserInfoDto jwtUserInfoDto = jwtService.parseAndVerifyRefreshToken(refreshToken);
+		Long userId = jwtService.parseAndVerifyRefreshToken(refreshToken);
+
+		JwtUserInfoDto jwtUserInfoDto = userService.getUserInfoById(userId);
+
 
 		AuthTokenDto authTokenDto = jwtService.generateAccessTokenAndRefreshToken(jwtUserInfoDto.userId(),
 			jwtUserInfoDto.username(), jwtUserInfoDto.roleId());

--- a/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtResolverFilter.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtResolverFilter.java
@@ -50,16 +50,12 @@ public class JwtResolverFilter extends OncePerRequestFilter {
 	private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
 
 	/**
-	 * JWT 인증/인가를 해주는 필터
-	 * 1. 인증 헤더가 올바르지 않으면 예외 처리
-	 * 2. jwt 토큰 파싱, 검증
-	 * 3. 인증 정보를 SecurityContext에 담고 필터 통과
+	 * 필터 흐름
+	 *  1. 쿠키에서 액세스 토큰을 가져옵니다.
+	 *   1.1. 액세스 토큰이 없고 리프레시 토큰은 있다면 액세스 토큰을 재발급합니다.
+	 *   1.2. 액세스 토큰과 리프레시 토큰이 모두 없다면 401 에러를 반환합니다.
 	 *
-	 * @param request : 클라이언트의 http 요청 객체
-	 * @param response : 서버의 http 응답 객체
-	 * @param filterChain : 다음 필터 혹은 리소스로 넘겨주는 필터체인 객체
-	 * @throws ServletException : 필터 처리 중 발생할 수 있는 서블릿 관련 예외
-	 * @throws IOException : 입출력 처리 중 발생할 수 있는 예외
+	 *  2. 액세스 토큰을 Attribute에 담아서 필터체인을 진행합니다.
 	 */
 	@Override
 	protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response,
@@ -70,6 +66,12 @@ public class JwtResolverFilter extends OncePerRequestFilter {
 		filterChain.doFilter(request, response);
 	}
 
+	/**
+	 * 액세스 토큰을 쿠키에서 가져옵니다.
+	 * 만약 액세스 토큰이 없다면 리프레시 토큰을 가져오는 메서드로 진행됩니다.
+	 *
+	 * @return : 액세스 토큰
+	 */
 	private String getAccessTokenFromCookie(HttpServletRequest request, HttpServletResponse response) {
 		return Optional.ofNullable(request.getCookies())
 			.flatMap(cookies -> Arrays.stream(cookies)
@@ -79,7 +81,14 @@ public class JwtResolverFilter extends OncePerRequestFilter {
 			.orElseGet(() -> reissueAccessTokenViaRefreshToken(request, response));
 	}
 
+	/**
+	 * 리프레시 토큰을 쿠키에서 가져옵니다. 만약 없다면 401 에러를 반환합니다.
+	 * 리프레시 토큰이 있다면 액세스 토큰을 재발급해서 반환합니다.
+	 *
+	 * @return : 액세스 토큰
+	 */
 	private String reissueAccessTokenViaRefreshToken(HttpServletRequest request, HttpServletResponse response) {
+		//쿠키에서 리프레시 토큰을 가져옵니다. 만약 없다면 401 에러를 반환합니다.
 		String refreshToken = Optional.ofNullable(request.getCookies())
 			.flatMap(cookies -> Arrays.stream(cookies)
 				.filter(cookie -> REFRESH_TOKEN_COOKIE_NAME.equals(cookie.getName()))
@@ -87,6 +96,8 @@ public class JwtResolverFilter extends OncePerRequestFilter {
 				.map(Cookie::getValue))
 			.orElseThrow(() -> new ApiException(ErrorCode.UNAUTHORIZED));
 
+
+		//리프레시 토큰을 파싱하고 서버에 저장된 리프레시 토큰의 정보와 일치하는지 대조합니다.
 		DecodedJWT decodedRefreshToken = jwtService.verifyJwt(refreshToken);
 		RefreshTokenDto refreshTokenDto = jwtRedisService.getRefreshTokenInfo(refreshToken);
 
@@ -99,6 +110,7 @@ public class JwtResolverFilter extends OncePerRequestFilter {
 
 		jwtRedisService.deleteRefreshToken(refreshToken);
 
+		//액세스 토큰 재발급해서 쿠키에 담고 HttpServletResponse header에 추가합니다.
 		AuthTokenDto authTokenDto = jwtService.generateAccessTokenAndRefreshToken(jwtUserInfoDto.userId(),
 			jwtUserInfoDto.username(), jwtUserInfoDto.roleId());
 

--- a/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtResolverFilter.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtResolverFilter.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import org.springframework.http.ResponseCookie;
 import org.springframework.lang.NonNull;
@@ -54,31 +55,24 @@ public class JwtResolverFilter extends OncePerRequestFilter {
 	 *  1. 쿠키에서 액세스 토큰을 가져옵니다.
 	 *   1.1. 액세스 토큰이 없고 리프레시 토큰은 있다면 액세스 토큰을 재발급합니다.
 	 *   1.2. 액세스 토큰과 리프레시 토큰이 모두 없다면 401 에러를 반환합니다.
-	 *
 	 *  2. 액세스 토큰을 Attribute에 담아서 필터체인을 진행합니다.
 	 */
 	@Override
 	protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response,
 		@NonNull FilterChain filterChain) throws ServletException, IOException {
-		String accessToken = getAccessTokenFromCookie(request, response);
+		String accessToken = extractToken(request, ACCESS_TOKEN_COOKIE_NAME, () -> reissueAccessTokenViaRefreshToken(request, response));
 
 		request.setAttribute(ACCESS_TOKEN_COOKIE_NAME, accessToken);
 		filterChain.doFilter(request, response);
 	}
 
-	/**
-	 * 액세스 토큰을 쿠키에서 가져옵니다.
-	 * 만약 액세스 토큰이 없다면 리프레시 토큰을 가져오는 메서드로 진행됩니다.
-	 *
-	 * @return : 액세스 토큰
-	 */
-	private String getAccessTokenFromCookie(HttpServletRequest request, HttpServletResponse response) {
+	private String extractToken(HttpServletRequest request, String cookieName, Supplier<String> ifAbsent) {
 		return Optional.ofNullable(request.getCookies())
 			.flatMap(cookies -> Arrays.stream(cookies)
-				.filter(cookie -> ACCESS_TOKEN_COOKIE_NAME.equals(cookie.getName()))
+				.filter(cookie -> cookieName.equals(cookie.getName()))
 				.findFirst()
 				.map(Cookie::getValue))
-			.orElseGet(() -> reissueAccessTokenViaRefreshToken(request, response));
+			.orElseGet(ifAbsent);
 	}
 
 	/**
@@ -88,32 +82,20 @@ public class JwtResolverFilter extends OncePerRequestFilter {
 	 * @return : 액세스 토큰
 	 */
 	private String reissueAccessTokenViaRefreshToken(HttpServletRequest request, HttpServletResponse response) {
-		//쿠키에서 리프레시 토큰을 가져옵니다. 만약 없다면 401 에러를 반환합니다.
-		String refreshToken = Optional.ofNullable(request.getCookies())
-			.flatMap(cookies -> Arrays.stream(cookies)
-				.filter(cookie -> REFRESH_TOKEN_COOKIE_NAME.equals(cookie.getName()))
-				.findFirst()
-				.map(Cookie::getValue))
-			.orElseThrow(() -> new ApiException(ErrorCode.UNAUTHORIZED));
+		String refreshToken =  extractToken(request, REFRESH_TOKEN_COOKIE_NAME,
+			() -> { throw new ApiException(ErrorCode.UNAUTHORIZED); });
 
+		JwtUserInfoDto jwtUserInfoDto = parseAndVerifyRefreshToken(refreshToken);
 
-		//리프레시 토큰을 파싱하고 서버에 저장된 리프레시 토큰의 정보와 일치하는지 대조합니다.
-		DecodedJWT decodedRefreshToken = jwtService.verifyJwt(refreshToken);
-		RefreshTokenDto refreshTokenDto = jwtRedisService.getRefreshTokenInfo(refreshToken);
-
-		if (!decodedRefreshToken.getId().equals(refreshTokenDto.jid())) {
-			throw new ApiException(ErrorCode.UNAUTHORIZED);
-		}
-
-		Long userId = Long.valueOf(refreshTokenDto.subject());
-		JwtUserInfoDto jwtUserInfoDto = userService.getUserInfoById(userId);
-
-		jwtRedisService.deleteRefreshToken(refreshToken);
-
-		//액세스 토큰 재발급해서 쿠키에 담고 HttpServletResponse header에 추가합니다.
 		AuthTokenDto authTokenDto = jwtService.generateAccessTokenAndRefreshToken(jwtUserInfoDto.userId(),
 			jwtUserInfoDto.username(), jwtUserInfoDto.roleId());
 
+		addAuthCookiesToHeader(authTokenDto, response);
+
+		return authTokenDto.accessToken();
+	}
+
+	private void addAuthCookiesToHeader(AuthTokenDto authTokenDto, HttpServletResponse response) {
 		ResponseCookie accessTokenCookie = CookieUtil.createHttpOnlyCookie(ACCESS_TOKEN_COOKIE_NAME,
 			authTokenDto.accessToken(),
 			Duration.ofMinutes(60));
@@ -123,7 +105,20 @@ public class JwtResolverFilter extends OncePerRequestFilter {
 
 		response.addHeader("Set-Cookie", accessTokenCookie.toString());
 		response.addHeader("Set-Cookie", refreshTokenCookie.toString());
+	}
 
-		return authTokenDto.accessToken();
+	private JwtUserInfoDto parseAndVerifyRefreshToken(String refreshToken) {
+		DecodedJWT decodedRefreshToken = jwtService.verifyJwt(refreshToken);
+		RefreshTokenDto refreshTokenDto = jwtRedisService.getRefreshTokenInfo(refreshToken);
+
+		if (!decodedRefreshToken.getId().equals(refreshTokenDto.jid())) {
+			throw new ApiException(ErrorCode.UNAUTHORIZED);
+		}
+
+		Long userId = Long.valueOf(refreshTokenDto.subject());
+
+		jwtRedisService.deleteRefreshToken(refreshToken);
+
+		return userService.getUserInfoById(userId);
 	}
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtResolverFilter.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtResolverFilter.java
@@ -97,6 +97,8 @@ public class JwtResolverFilter extends OncePerRequestFilter {
 		Long userId = Long.valueOf(refreshTokenDto.subject());
 		JwtUserInfoDto jwtUserInfoDto = userService.getUserInfoById(userId);
 
+		jwtRedisService.deleteRefreshToken(refreshToken);
+
 		List<String> newTokens = jwtService.generateAccessTokenAndRefreshToken(jwtUserInfoDto.userId(),
 			jwtUserInfoDto.username(), jwtUserInfoDto.roleId());
 

--- a/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtResolverFilter.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtResolverFilter.java
@@ -1,22 +1,16 @@
-package com.trackery.trackerybackapiserver.config;
+package com.trackery.trackerybackapiserver.config.filter;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Optional;
 
 import org.springframework.lang.NonNull;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import com.auth0.jwt.exceptions.JWTVerificationException;
-import com.auth0.jwt.interfaces.DecodedJWT;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
-import com.trackery.trackerybackapiserver.domain.jwt.dto.JwtUserInfoDto;
+import com.trackery.trackerybackapiserver.domain.jwt.service.JwtRedisService;
 import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
-import com.trackery.trackerybackapiserver.domain.user.entity.CustomUserDetails;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -39,10 +33,12 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 @RequiredArgsConstructor
-public class JwtFilter extends OncePerRequestFilter {
+public class JwtResolverFilter extends OncePerRequestFilter {
 
 	private final JwtService jwtService;
+	private final JwtRedisService jwtRedisService;
 	private static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
+	private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
 
 	/**
 	 * JWT 인증/인가를 해주는 필터
@@ -59,13 +55,9 @@ public class JwtFilter extends OncePerRequestFilter {
 	@Override
 	protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response,
 		@NonNull FilterChain filterChain) throws ServletException, IOException {
-
 		String accessToken = getAccessTokenFromCookie(request);
 
-		JwtUserInfoDto userInfo = verifyAndParseJwt(accessToken);
-
-		setAuthentication(userInfo);
-
+		request.setAttribute(ACCESS_TOKEN_COOKIE_NAME, accessToken);
 		filterChain.doFilter(request, response);
 	}
 
@@ -75,33 +67,17 @@ public class JwtFilter extends OncePerRequestFilter {
 				.filter(cookie -> ACCESS_TOKEN_COOKIE_NAME.equals(cookie.getName()))
 				.findFirst()
 				.map(Cookie::getValue))
+			.orElseGet(() -> reissueAccessTokenViaRefreshToken(request));
+	}
+
+	private String reissueAccessTokenViaRefreshToken(HttpServletRequest request) {
+		String refreshToken = Optional.ofNullable(request.getCookies())
+			.flatMap(cookies -> Arrays.stream(cookies)
+				.filter(cookie -> REFRESH_TOKEN_COOKIE_NAME.equals(cookie.getName()))
+				.findFirst()
+				.map(Cookie::getValue))
 			.orElseThrow(() -> new ApiException(ErrorCode.UNAUTHORIZED));
-	}
 
-	private JwtUserInfoDto verifyAndParseJwt(String accessToken) {
-		try {
-			DecodedJWT jwt = jwtService.verifyJwt(accessToken);
-			Long userId = Long.valueOf(jwt.getSubject());
-			String userName = jwt.getClaim("username").asString();
-			Long roleId = jwt.getClaim("role").asLong();
-
-			return new JwtUserInfoDto(userId, userName, roleId);
-		} catch (JWTVerificationException e) {
-			log.error("JWT 검증 실패: {}", e.getMessage());
-			throw new ApiException(ErrorCode.UNAUTHORIZED_JWT_VERIFY_FAILED);
-		}
-	}
-
-	private void setAuthentication(JwtUserInfoDto userInfo) {
-		UserDetails userDetails = CustomUserDetails.builder()
-			.userId(userInfo.userId())
-			.userName(userInfo.username())
-			.roleId(userInfo.roleId())
-			.build();
-
-		UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(userDetails,
-			null, userDetails.getAuthorities());
-
-		SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+		return jwtService.reissueAccessTokenByRefreshToken(refreshToken);
 	}
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtResolverFilter.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtResolverFilter.java
@@ -14,6 +14,7 @@ import com.auth0.jwt.interfaces.DecodedJWT;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
 import com.trackery.trackerybackapiserver.domain.common.util.CookieUtil;
+import com.trackery.trackerybackapiserver.domain.jwt.dto.AuthTokenDto;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.JwtUserInfoDto;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.RefreshTokenDto;
 import com.trackery.trackerybackapiserver.domain.jwt.service.JwtRedisService;
@@ -33,7 +34,7 @@ import lombok.extern.slf4j.Slf4j;
  * fileName       : JwtFilter
  * author         : durururuk
  * date           : 25. 2. 19.
- * description    : JWT 인증/인가를 담당하는 필터
+ * description    : 액세스 토큰을 가져오는 필터입니다
  * ===========================================================
  * DATE              AUTHOR             NOTE
  * -----------------------------------------------------------
@@ -99,17 +100,17 @@ public class JwtResolverFilter extends OncePerRequestFilter {
 
 		jwtRedisService.deleteRefreshToken(refreshToken);
 
-		List<String> newTokens = jwtService.generateAccessTokenAndRefreshToken(jwtUserInfoDto.userId(),
+		AuthTokenDto authTokenDto = jwtService.generateAccessTokenAndRefreshToken(jwtUserInfoDto.userId(),
 			jwtUserInfoDto.username(), jwtUserInfoDto.roleId());
 
-		ResponseCookie accessTokenCookie = CookieUtil.createHttpOnlyCookie(ACCESS_TOKEN_COOKIE_NAME, newTokens.get(0),
+		ResponseCookie accessTokenCookie = CookieUtil.createHttpOnlyCookie(ACCESS_TOKEN_COOKIE_NAME, authTokenDto.accessToken(),
 			Duration.ofMinutes(60));
-		ResponseCookie refreshTokenCookie = CookieUtil.createHttpOnlyCookie(REFRESH_TOKEN_COOKIE_NAME, newTokens.get(1),
+		ResponseCookie refreshTokenCookie = CookieUtil.createHttpOnlyCookie(REFRESH_TOKEN_COOKIE_NAME, authTokenDto.refreshToken(),
 			Duration.ofDays(7));
 
 		response.addHeader("Set-Cookie", accessTokenCookie.toString());
 		response.addHeader("Set-Cookie", refreshTokenCookie.toString());
 
-		return newTokens.get(0);
+		return authTokenDto.accessToken();
 	}
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtResolverFilter.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtResolverFilter.java
@@ -2,28 +2,22 @@ package com.trackery.trackerybackapiserver.config.filter;
 
 import java.io.IOException;
 import java.time.Duration;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.function.Supplier;
 
 import org.springframework.http.ResponseCookie;
 import org.springframework.lang.NonNull;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import com.auth0.jwt.interfaces.DecodedJWT;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
 import com.trackery.trackerybackapiserver.domain.common.util.CookieUtil;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.AuthTokenDto;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.JwtUserInfoDto;
-import com.trackery.trackerybackapiserver.domain.jwt.dto.RefreshTokenDto;
 import com.trackery.trackerybackapiserver.domain.jwt.service.JwtRedisService;
 import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
 import com.trackery.trackerybackapiserver.domain.user.service.UserService;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -60,19 +54,11 @@ public class JwtResolverFilter extends OncePerRequestFilter {
 	@Override
 	protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response,
 		@NonNull FilterChain filterChain) throws ServletException, IOException {
-		String accessToken = extractToken(request, ACCESS_TOKEN_COOKIE_NAME, () -> reissueAccessTokenViaRefreshToken(request, response));
+		String accessToken = CookieUtil.extractCookieValue(request, ACCESS_TOKEN_COOKIE_NAME,
+			() -> reissueAccessTokenByRefreshToken(request, response));
 
 		request.setAttribute(ACCESS_TOKEN_COOKIE_NAME, accessToken);
 		filterChain.doFilter(request, response);
-	}
-
-	private String extractToken(HttpServletRequest request, String cookieName, Supplier<String> ifAbsent) {
-		return Optional.ofNullable(request.getCookies())
-			.flatMap(cookies -> Arrays.stream(cookies)
-				.filter(cookie -> cookieName.equals(cookie.getName()))
-				.findFirst()
-				.map(Cookie::getValue))
-			.orElseGet(ifAbsent);
 	}
 
 	/**
@@ -81,11 +67,13 @@ public class JwtResolverFilter extends OncePerRequestFilter {
 	 *
 	 * @return : 액세스 토큰
 	 */
-	private String reissueAccessTokenViaRefreshToken(HttpServletRequest request, HttpServletResponse response) {
-		String refreshToken =  extractToken(request, REFRESH_TOKEN_COOKIE_NAME,
-			() -> { throw new ApiException(ErrorCode.UNAUTHORIZED); });
+	private String reissueAccessTokenByRefreshToken(HttpServletRequest request, HttpServletResponse response) {
+		String refreshToken = CookieUtil.extractCookieValue(request, REFRESH_TOKEN_COOKIE_NAME,
+			() -> {
+				throw new ApiException(ErrorCode.UNAUTHORIZED);
+			});
 
-		JwtUserInfoDto jwtUserInfoDto = parseAndVerifyRefreshToken(refreshToken);
+		JwtUserInfoDto jwtUserInfoDto = jwtService.parseAndVerifyRefreshToken(refreshToken);
 
 		AuthTokenDto authTokenDto = jwtService.generateAccessTokenAndRefreshToken(jwtUserInfoDto.userId(),
 			jwtUserInfoDto.username(), jwtUserInfoDto.roleId());
@@ -95,6 +83,11 @@ public class JwtResolverFilter extends OncePerRequestFilter {
 		return authTokenDto.accessToken();
 	}
 
+	/**
+	 * 인증에 필요한 토큰을 쿠키로 만들고 응답 헤더에 추가합니다.
+	 * @param authTokenDto : 액세스 토큰과 리프레시 토큰이 담긴 DTO
+	 * @param response : 응답 정보가 담긴 HttpServletResponse 객체
+	 */
 	private void addAuthCookiesToHeader(AuthTokenDto authTokenDto, HttpServletResponse response) {
 		ResponseCookie accessTokenCookie = CookieUtil.createHttpOnlyCookie(ACCESS_TOKEN_COOKIE_NAME,
 			authTokenDto.accessToken(),
@@ -105,20 +98,5 @@ public class JwtResolverFilter extends OncePerRequestFilter {
 
 		response.addHeader("Set-Cookie", accessTokenCookie.toString());
 		response.addHeader("Set-Cookie", refreshTokenCookie.toString());
-	}
-
-	private JwtUserInfoDto parseAndVerifyRefreshToken(String refreshToken) {
-		DecodedJWT decodedRefreshToken = jwtService.verifyJwt(refreshToken);
-		RefreshTokenDto refreshTokenDto = jwtRedisService.getRefreshTokenInfo(refreshToken);
-
-		if (!decodedRefreshToken.getId().equals(refreshTokenDto.jid())) {
-			throw new ApiException(ErrorCode.UNAUTHORIZED);
-		}
-
-		Long userId = Long.valueOf(refreshTokenDto.subject());
-
-		jwtRedisService.deleteRefreshToken(refreshToken);
-
-		return userService.getUserInfoById(userId);
 	}
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtResolverFilter.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtResolverFilter.java
@@ -3,7 +3,6 @@ package com.trackery.trackerybackapiserver.config.filter;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.http.ResponseCookie;
@@ -103,9 +102,11 @@ public class JwtResolverFilter extends OncePerRequestFilter {
 		AuthTokenDto authTokenDto = jwtService.generateAccessTokenAndRefreshToken(jwtUserInfoDto.userId(),
 			jwtUserInfoDto.username(), jwtUserInfoDto.roleId());
 
-		ResponseCookie accessTokenCookie = CookieUtil.createHttpOnlyCookie(ACCESS_TOKEN_COOKIE_NAME, authTokenDto.accessToken(),
+		ResponseCookie accessTokenCookie = CookieUtil.createHttpOnlyCookie(ACCESS_TOKEN_COOKIE_NAME,
+			authTokenDto.accessToken(),
 			Duration.ofMinutes(60));
-		ResponseCookie refreshTokenCookie = CookieUtil.createHttpOnlyCookie(REFRESH_TOKEN_COOKIE_NAME, authTokenDto.refreshToken(),
+		ResponseCookie refreshTokenCookie = CookieUtil.createHttpOnlyCookie(REFRESH_TOKEN_COOKIE_NAME,
+			authTokenDto.refreshToken(),
 			Duration.ofDays(7));
 
 		response.addHeader("Set-Cookie", accessTokenCookie.toString());

--- a/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtResolverFilter.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtResolverFilter.java
@@ -4,13 +4,18 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Optional;
 
+import org.springframework.core.annotation.Order;
 import org.springframework.lang.NonNull;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import com.auth0.jwt.interfaces.DecodedJWT;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
+import com.trackery.trackerybackapiserver.domain.jwt.dto.JwtUserInfoDto;
+import com.trackery.trackerybackapiserver.domain.jwt.dto.RefreshTokenDto;
 import com.trackery.trackerybackapiserver.domain.jwt.service.JwtRedisService;
 import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
+import com.trackery.trackerybackapiserver.domain.user.service.UserService;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -37,6 +42,7 @@ public class JwtResolverFilter extends OncePerRequestFilter {
 
 	private final JwtService jwtService;
 	private final JwtRedisService jwtRedisService;
+	private final UserService userService;
 	private static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
 	private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
 
@@ -78,6 +84,16 @@ public class JwtResolverFilter extends OncePerRequestFilter {
 				.map(Cookie::getValue))
 			.orElseThrow(() -> new ApiException(ErrorCode.UNAUTHORIZED));
 
-		return jwtService.reissueAccessTokenByRefreshToken(refreshToken);
+		DecodedJWT decodedRefreshToken = jwtService.verifyJwt(refreshToken);
+		RefreshTokenDto refreshTokenDto = jwtRedisService.getRefreshTokenInfo(refreshToken);
+
+		if (!decodedRefreshToken.getId().equals(refreshTokenDto.jid())) {
+			throw new ApiException(ErrorCode.UNAUTHORIZED);
+		}
+
+		Long userId = Long.valueOf(refreshTokenDto.subject());
+		JwtUserInfoDto jwtUserInfoDto = userService.getUserInfoById(userId);
+
+		return jwtService.generateAccessToken(jwtUserInfoDto.userId(), jwtUserInfoDto.username(), jwtUserInfoDto.roleId());
 	}
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtResolverFilter.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtResolverFilter.java
@@ -1,16 +1,19 @@
 package com.trackery.trackerybackapiserver.config.filter;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
-import org.springframework.core.annotation.Order;
+import org.springframework.http.ResponseCookie;
 import org.springframework.lang.NonNull;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
+import com.trackery.trackerybackapiserver.domain.common.util.CookieUtil;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.JwtUserInfoDto;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.RefreshTokenDto;
 import com.trackery.trackerybackapiserver.domain.jwt.service.JwtRedisService;
@@ -61,22 +64,22 @@ public class JwtResolverFilter extends OncePerRequestFilter {
 	@Override
 	protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response,
 		@NonNull FilterChain filterChain) throws ServletException, IOException {
-		String accessToken = getAccessTokenFromCookie(request);
+		String accessToken = getAccessTokenFromCookie(request, response);
 
 		request.setAttribute(ACCESS_TOKEN_COOKIE_NAME, accessToken);
 		filterChain.doFilter(request, response);
 	}
 
-	private String getAccessTokenFromCookie(HttpServletRequest request) {
+	private String getAccessTokenFromCookie(HttpServletRequest request, HttpServletResponse response) {
 		return Optional.ofNullable(request.getCookies())
 			.flatMap(cookies -> Arrays.stream(cookies)
 				.filter(cookie -> ACCESS_TOKEN_COOKIE_NAME.equals(cookie.getName()))
 				.findFirst()
 				.map(Cookie::getValue))
-			.orElseGet(() -> reissueAccessTokenViaRefreshToken(request));
+			.orElseGet(() -> reissueAccessTokenViaRefreshToken(request, response));
 	}
 
-	private String reissueAccessTokenViaRefreshToken(HttpServletRequest request) {
+	private String reissueAccessTokenViaRefreshToken(HttpServletRequest request, HttpServletResponse response) {
 		String refreshToken = Optional.ofNullable(request.getCookies())
 			.flatMap(cookies -> Arrays.stream(cookies)
 				.filter(cookie -> REFRESH_TOKEN_COOKIE_NAME.equals(cookie.getName()))
@@ -94,6 +97,17 @@ public class JwtResolverFilter extends OncePerRequestFilter {
 		Long userId = Long.valueOf(refreshTokenDto.subject());
 		JwtUserInfoDto jwtUserInfoDto = userService.getUserInfoById(userId);
 
-		return jwtService.generateAccessToken(jwtUserInfoDto.userId(), jwtUserInfoDto.username(), jwtUserInfoDto.roleId());
+		List<String> newTokens = jwtService.generateAccessTokenAndRefreshToken(jwtUserInfoDto.userId(),
+			jwtUserInfoDto.username(), jwtUserInfoDto.roleId());
+
+		ResponseCookie accessTokenCookie = CookieUtil.createHttpOnlyCookie(ACCESS_TOKEN_COOKIE_NAME, newTokens.get(0),
+			Duration.ofMinutes(60));
+		ResponseCookie refreshTokenCookie = CookieUtil.createHttpOnlyCookie(REFRESH_TOKEN_COOKIE_NAME, newTokens.get(1),
+			Duration.ofDays(7));
+
+		response.addHeader("Set-Cookie", accessTokenCookie.toString());
+		response.addHeader("Set-Cookie", refreshTokenCookie.toString());
+
+		return newTokens.get(0);
 	}
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/common/response/enums/ErrorCode.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/common/response/enums/ErrorCode.java
@@ -120,7 +120,7 @@ public enum ErrorCode {
 	/**
 	 * 이미 데이터베이스에 존재하는 이메일임 (HttpStatus.CONFLICT, 409, "이미 가입된 이메일입니다.")
 	 */
-	Duplicate_EMAIL(HttpStatus.CONFLICT, 409, "이미 가입된 이메일입니다."),
+	DUPLICATE_EMAIL(HttpStatus.CONFLICT, 409, "이미 가입된 이메일입니다."),
 
 	/**
 	 * OAuth 인증에 실패 (HttpStatus.UNAUTHORIZED, 401, "OAuth 인증에 실패했습니다.")

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/common/util/CookieUtil.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/common/util/CookieUtil.java
@@ -1,11 +1,17 @@
 package com.trackery.trackerybackapiserver.domain.common.util;
 
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.Supplier;
 
 import org.springframework.http.ResponseCookie;
 
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * packageName    : com.trackery.trackerybackapiserver.domain.common.util
@@ -49,7 +55,8 @@ public class CookieUtil {
 	}
 
 	/**
-	 * 쿠키를 삭제합니다.
+	 * 쿠키를 삭제할 용도로 사용될 메서드입니다.
+	 * maxAge가 0인 쿠키를 만들어서 SET-COOKIE하여 바로 삭제되게 합니다.
 	 * @param key 삭제할 쿠키 key
 	 * @return 삭제될 쿠키 정보
 	 */
@@ -60,5 +67,23 @@ public class CookieUtil {
 			.maxAge(0)
 			.sameSite("Strict")
 			.build();
+	}
+
+	/**
+	 * 요청 객체에서 쿠키를 가져와서 원하는 쿠키 값을 반환합니다.
+	 * 찾지 못했을 경우 Supplier를 실행해서 대체 값을 반환합니다.
+	 *
+	 * @param request : HttpServletRequest 요청 객체, 여기서 쿠키를 가져옵니다.
+	 * @param cookieName : 가져오고자 하는 쿠키의 key값
+	 * @param ifAbsent : 쿠키를 가져오지 못했을 경우 실행될 람다 메서드
+	 * @return : 가져온 쿠키 값 혹은 Supplier에서 받아온 대체 값
+	 */
+	public static String extractCookieValue(HttpServletRequest request, String cookieName, Supplier<String> ifAbsent) {
+		return Optional.ofNullable(request.getCookies())
+			.flatMap(cookies -> Arrays.stream(cookies)
+				.filter(cookie -> cookieName.equals(cookie.getName()))
+				.findFirst()
+				.map(Cookie::getValue))
+			.orElseGet(ifAbsent);
 	}
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/common/util/CookieUtil.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/common/util/CookieUtil.java
@@ -35,14 +35,15 @@ public class CookieUtil {
 	 *
 	 * @param key : 쿠키 이름
 	 * @param value : 쿠키 값
+	 * @param duration : 쿠키의 유효시간
 	 * @return : 생성된 http-only 쿠키
 	 */
-	public static ResponseCookie createHttpOnlyCookie(String key, String value) {
+	public static ResponseCookie createHttpOnlyCookie(String key, String value, Duration duration) {
 		return ResponseCookie.from(key, value)
 			.httpOnly(true)
 			.path("/")
 			//TODO JWT 토큰 만료시간 일괄 관리되게 수정
-			.maxAge(Duration.ofSeconds(600))
+			.maxAge(duration)
 			.sameSite("Strict")
 			.build();
 	}

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/common/util/JwtUtil.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/common/util/JwtUtil.java
@@ -26,7 +26,8 @@ import lombok.extern.slf4j.Slf4j;
  * ===========================================================
  * DATE              AUTHOR             NOTE
  * -----------------------------------------------------------
- * 25. 2. 18.        durururuk       최초 생성
+ * 25. 2. 18.       durururuk       최초 생성
+ * 25. 3. 28.		durururuk		리프레시 토큰 생성 메서드 추가
  */
 @Slf4j
 @Component
@@ -34,7 +35,8 @@ public class JwtUtil {
 
 	//만료시간 10분(600초)
 	//TODO JWT 만료시간 일괄 설정되게 수정
-	private static final int EXPIRATION_TIME = 600;
+	private static final int ACCESS_TOKEN_EXPIRATION_TIME = 600;
+	private static final int REFRESH_TOKEN_EXPIRATION_TIME = 604800;
 
 	private final String projectDomain;
 	private final Algorithm algorithm;
@@ -45,7 +47,7 @@ public class JwtUtil {
 	}
 
 	/**
-	 * JWT 생성 메서드
+	 * 액세스 토큰 생성 메서드
 	 *
 	 * @param userId : 인증할 유저ID
 	 * @param userName : 인증할 유저명
@@ -60,8 +62,30 @@ public class JwtUtil {
 				.withClaim("role", roleId)
 				.withNotBefore(Instant.now())
 				.withIssuedAt(Instant.now())
-				.withExpiresAt(Instant.now().plusSeconds(EXPIRATION_TIME))
+				.withExpiresAt(Instant.now().plusSeconds(ACCESS_TOKEN_EXPIRATION_TIME))
 				.withJWTId(UUID.randomUUID().toString())
+				.sign(algorithm);
+		} catch (JWTCreationException e) {
+			log.error(e.getMessage());
+			throw new ApiException(ErrorCode.INTERNAL_SERVER_ERROR_FAILED_TO_GENERATE_JWT);
+		}
+	}
+
+	/**
+	 * 유저 ID로 리프레시 토큰 발급하는 메서드
+	 *
+	 * @param userId : 유저 ID
+	 * @return : 리프레시 토큰
+	 */
+	public String generateRefreshToken(Long userId) {
+		try {
+			return JWT.create()
+				.withIssuer(projectDomain)
+				.withJWTId(UUID.randomUUID().toString())
+				.withSubject(userId.toString())
+				.withNotBefore(Instant.now())
+				.withIssuedAt(Instant.now())
+				.withExpiresAt(Instant.now().plusSeconds(REFRESH_TOKEN_EXPIRATION_TIME))
 				.sign(algorithm);
 		} catch (JWTCreationException e) {
 			log.error(e.getMessage());
@@ -94,7 +118,7 @@ public class JwtUtil {
 				.withSubject(subject)
 				.withNotBefore(Instant.now())
 				.withIssuedAt(Instant.now())
-				.withExpiresAt(Instant.now().plusSeconds(EXPIRATION_TIME))
+				.withExpiresAt(Instant.now().plusSeconds(ACCESS_TOKEN_EXPIRATION_TIME))
 				.sign(algorithm);
 		} catch (JWTCreationException e) {
 			log.error(e.getMessage());

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/dto/AccessTokenDto.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/dto/AccessTokenDto.java
@@ -5,7 +5,7 @@ package com.trackery.trackerybackapiserver.domain.jwt.dto;
  * fileName       : AccessTokenDto
  * author         : durururuk
  * date           : 25. 3. 28.
- * description    :
+ * description    : 액세스 토큰의 정보를 가지고 있는 DTO
  * ===========================================================
  * DATE              AUTHOR             NOTE
  * -----------------------------------------------------------

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/dto/AccessTokenDto.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/dto/AccessTokenDto.java
@@ -1,0 +1,15 @@
+package com.trackery.trackerybackapiserver.domain.jwt.dto;
+
+/**
+ * packageName    : com.trackery.trackerybackapiserver.domain.jwt.dto
+ * fileName       : AccessTokenDto
+ * author         : durururuk
+ * date           : 25. 3. 28.
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 25. 3. 28.        durururuk      최초 생성
+ */
+public record AccessTokenDto(String accessToken, String subject) {
+}

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/dto/AuthTokenDto.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/dto/AuthTokenDto.java
@@ -1,0 +1,15 @@
+package com.trackery.trackerybackapiserver.domain.jwt.dto;
+
+/**
+ * packageName    : com.trackery.trackerybackapiserver.domain.jwt.dto
+ * fileName       : AuthTokenDto
+ * author         : durururuk
+ * date           : 25. 3. 29.
+ * description    : 인증에 필요한 토큰을 담는 DTO
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 25. 3. 29.        durururuk      최초 생성
+ */
+public record AuthTokenDto(String accessToken, String refreshToken) {
+}

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/dto/JwtUserInfoDto.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/dto/JwtUserInfoDto.java
@@ -5,7 +5,7 @@ package com.trackery.trackerybackapiserver.domain.jwt.dto;
  * fileName       : JwtUserInfo
  * author         : durururuk
  * date           : 25. 3. 28.
- * description    :
+ * description    : 액세스 토큰 발급을 위해 필요한 유저 정보를 가지는 DTO
  * ===========================================================
  * DATE              AUTHOR             NOTE
  * -----------------------------------------------------------

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/dto/JwtUserInfoDto.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/dto/JwtUserInfoDto.java
@@ -1,0 +1,15 @@
+package com.trackery.trackerybackapiserver.domain.jwt.dto;
+
+/**
+ * packageName    : com.trackery.trackerybackapiserver.domain.jwt.dto
+ * fileName       : JwtUserInfo
+ * author         : durururuk
+ * date           : 25. 3. 28.
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 25. 3. 28.        durururuk      최초 생성
+ */
+public record JwtUserInfoDto(Long userId, String username, Long roleId) {
+}

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/dto/RefreshTokenDto.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/dto/RefreshTokenDto.java
@@ -5,7 +5,7 @@ package com.trackery.trackerybackapiserver.domain.jwt.dto;
  * fileName       : RefreshTokenDto
  * author         : durururuk
  * date           : 25. 3. 28.
- * description    :
+ * description    : 리프레시 토큰 정보를 담고있는 DTO
  * ===========================================================
  * DATE              AUTHOR             NOTE
  * -----------------------------------------------------------

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/dto/RefreshTokenDto.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/dto/RefreshTokenDto.java
@@ -1,0 +1,15 @@
+package com.trackery.trackerybackapiserver.domain.jwt.dto;
+
+/**
+ * packageName    : com.trackery.trackerybackapiserver.domain.jwt.dto
+ * fileName       : RefreshTokenDto
+ * author         : durururuk
+ * date           : 25. 3. 28.
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 25. 3. 28.        durururuk      최초 생성
+ */
+public record RefreshTokenDto(String refreshToken, String jid, String subject) {
+}

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtRedisService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtRedisService.java
@@ -55,6 +55,7 @@ public class JwtRedisService {
 		}
 	}
 
+	//Todo 추후 unlink로 변경
 	public void deleteRefreshToken(String refreshToken) {
 		String redisKey = REFRESH_TOKEN_REDIS_KEY + refreshToken;
 		redisTemplate.delete(redisKey);

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtRedisService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtRedisService.java
@@ -3,11 +3,8 @@ package com.trackery.trackerybackapiserver.domain.jwt.service;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
-import com.auth0.jwt.interfaces.DecodedJWT;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.nimbusds.oauth2.sdk.token.RefreshToken;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.RefreshTokenDto;
@@ -33,9 +30,11 @@ public class JwtRedisService {
 	private final StringRedisTemplate redisTemplate;
 	private final ObjectMapper objectMapper;
 
+	private static final String REFRESH_TOKEN_REDIS_KEY = "jwtRefreshToken:";
+
 	public void saveRefreshToken(RefreshTokenDto refreshTokenDto) {
 		try {
-			String redisKey = "jwtRefreshToken:" + refreshTokenDto.refreshToken();
+			String redisKey = REFRESH_TOKEN_REDIS_KEY + refreshTokenDto.refreshToken();
 			String jsonRefreshTokenDto = objectMapper.writeValueAsString(refreshTokenDto);
 
 			redisTemplate.opsForValue().set(redisKey, jsonRefreshTokenDto);
@@ -46,7 +45,7 @@ public class JwtRedisService {
 	}
 
 	public RefreshTokenDto getRefreshTokenInfo(String refreshToken) {
-		String redisKey = "jwtRefreshToken:" + refreshToken;
+		String redisKey = REFRESH_TOKEN_REDIS_KEY + refreshToken;
 		String jsonRefreshTokenDto = redisTemplate.opsForValue().get(redisKey);
 		try {
 			return objectMapper.readValue(jsonRefreshTokenDto, RefreshTokenDto.class);
@@ -54,6 +53,11 @@ public class JwtRedisService {
 			log.error("Json 매핑 중 에러 발생 : ", e);
 			throw new ApiException(ErrorCode.INTERNAL_SERVER_ERROR);
 		}
+	}
+
+	public void deleteRefreshToken(String refreshToken) {
+		String redisKey = REFRESH_TOKEN_REDIS_KEY + refreshToken;
+		redisTemplate.delete(redisKey);
 	}
 
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtRedisService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtRedisService.java
@@ -1,0 +1,45 @@
+package com.trackery.trackerybackapiserver.domain.jwt.service;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
+import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
+import com.trackery.trackerybackapiserver.domain.jwt.dto.RefreshTokenDto;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * packageName    : com.trackery.trackerybackapiserver.domain.jwt.service
+ * fileName       : JwtRedisService
+ * author         : durururuk
+ * date           : 25. 3. 28.
+ * description    : Jwt 관련 Redis 작업을 하는 서비스 클래스
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 25. 3. 28.        durururuk      최초 생성
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class JwtRedisService {
+	private final StringRedisTemplate redisTemplate;
+	private final ObjectMapper objectMapper;
+
+	public void saveRefreshToken(RefreshTokenDto refreshTokenDto) {
+		try {
+			String redisKey = "jwtRefreshToken:" + refreshTokenDto.refreshToken();
+			String jsonRefreshTokenDto = objectMapper.writeValueAsString(refreshTokenDto);
+
+			redisTemplate.opsForValue().set(redisKey, jsonRefreshTokenDto);
+		} catch (JsonProcessingException e) {
+			log.error("Json 파싱 중 에러 발생 : ", e);
+			throw new ApiException(ErrorCode.INTERNAL_SERVER_ERROR);
+		}
+	}
+
+}

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtRedisService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtRedisService.java
@@ -3,8 +3,11 @@ package com.trackery.trackerybackapiserver.domain.jwt.service;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
+import com.auth0.jwt.interfaces.DecodedJWT;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.oauth2.sdk.token.RefreshToken;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.RefreshTokenDto;
@@ -38,6 +41,17 @@ public class JwtRedisService {
 			redisTemplate.opsForValue().set(redisKey, jsonRefreshTokenDto);
 		} catch (JsonProcessingException e) {
 			log.error("Json 파싱 중 에러 발생 : ", e);
+			throw new ApiException(ErrorCode.INTERNAL_SERVER_ERROR);
+		}
+	}
+
+	public RefreshTokenDto getRefreshTokenInfo(String refreshToken) {
+		String redisKey = "jwtRefreshToken:" + refreshToken;
+		String jsonRefreshTokenDto = redisTemplate.opsForValue().get(redisKey);
+		try {
+			return objectMapper.readValue(jsonRefreshTokenDto, RefreshTokenDto.class);
+		} catch (JsonProcessingException e) {
+			log.error("Json 매핑 중 에러 발생 : ", e);
 			throw new ApiException(ErrorCode.INTERNAL_SERVER_ERROR);
 		}
 	}

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtRedisService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtRedisService.java
@@ -21,7 +21,8 @@ import lombok.extern.slf4j.Slf4j;
  * ===========================================================
  * DATE              AUTHOR             NOTE
  * -----------------------------------------------------------
- * 25. 3. 28.        durururuk      최초 생성
+ * 25. 3. 28.       durururuk       최초 생성
+ * 25. 3. 28.		durururuk		리프레시 토큰 저장, 조회, 삭제 기능 구현
  */
 @Slf4j
 @Service
@@ -32,6 +33,12 @@ public class JwtRedisService {
 
 	private static final String REFRESH_TOKEN_REDIS_KEY = "jwtRefreshToken:";
 
+	/**
+	 * 리프레시 토큰 정보를 Redis에 저장합니다.
+	 * 토큰을 key, dto를 json 형식으로 변환하여 value 저장합니다.
+	 *
+	 * @param refreshTokenDto 리프레시 토큰, JwtId, 유저ID를 가지고 있는 DTO
+	 */
 	public void saveRefreshToken(RefreshTokenDto refreshTokenDto) {
 		try {
 			String redisKey = REFRESH_TOKEN_REDIS_KEY + refreshTokenDto.refreshToken();
@@ -44,6 +51,12 @@ public class JwtRedisService {
 		}
 	}
 
+	/**
+	 * Redis에 접근해서 리프레시 토큰을 가져오는 메서드입니다.
+	 *
+	 * @param refreshToken : 클라이언트한테 받아온 리프레시 토큰
+	 * @return : redis에 저장된 리프레시 토큰 정보 (리프레시 토큰 자체를 파싱한 것이 아닙니다.)
+	 */
 	public RefreshTokenDto getRefreshTokenInfo(String refreshToken) {
 		String redisKey = REFRESH_TOKEN_REDIS_KEY + refreshToken;
 		String jsonRefreshTokenDto = redisTemplate.opsForValue().get(redisKey);
@@ -55,6 +68,10 @@ public class JwtRedisService {
 		}
 	}
 
+	/**
+	 * 한 번 사용된 리프레시 토큰을 레디스에서 제거하는 메서드입니다.
+	 * @param refreshToken : 사용된 리프레시 토큰
+	 */
 	//Todo 추후 unlink로 변경
 	public void deleteRefreshToken(String refreshToken) {
 		String redisKey = REFRESH_TOKEN_REDIS_KEY + refreshToken;

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtService.java
@@ -103,12 +103,26 @@ public class JwtService {
 		return new RefreshTokenDto(refreshToken, jid, userId.toString());
 	}
 
-	public List<String> generateAccessTokenAndRefreshToken(Long userId, String userName, Long userRoleId) {
-		String accessToken = generateAccessToken(userId, userName, userRoleId);
+	/**
+	 * 유저 정보를 받아서 액세스 토큰과 리프레시 토큰을 리스트로 반환하는 메서드
+	 *
+	 * @param userId : 유저 ID
+	 * @param userName : 유저명
+	 * @param roleId : 역할 ID
+	 * @return : 액세스 토큰, 리프레시 토큰이 담긴 리스트
+	 */
+	public List<String> generateAccessTokenAndRefreshToken(Long userId, String userName, Long roleId) {
+		String accessToken = generateAccessToken(userId, userName, roleId);
 		String refreshToken = generateRefreshTokenAndSaveToRedis(userId);
 		return List.of(accessToken, refreshToken);
 	}
 
+	/**
+	 * 리프레시 토큰을 발급하고 정보를 redis에 저장하고 토큰을 반환하는 메서드
+	 *
+	 * @param userId : 유저 ID
+	 * @return 리프레시 토큰
+	 */
 	private String generateRefreshTokenAndSaveToRedis(Long userId) {
 		RefreshTokenDto refreshTokenDto = generateRefreshToken(userId);
 		jwtRedisService.saveRefreshToken(refreshTokenDto);

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtService.java
@@ -15,7 +15,9 @@ import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
+import com.trackery.trackerybackapiserver.domain.jwt.dto.JwtUserInfoDto;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.RefreshTokenDto;
+import com.trackery.trackerybackapiserver.domain.user.service.UserService;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -35,6 +37,7 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 public class JwtService {
 	private final JwtRedisService jwtRedisService;
+	private final UserService userService;
 
 	//만료시간 10분(600초)
 	//TODO JWT 만료시간 일괄 설정되게 수정
@@ -44,9 +47,11 @@ public class JwtService {
 	private final String projectDomain;
 	private final Algorithm algorithm;
 
-	public JwtService(JwtRedisService jwtRedisService, @Value("${JWT_SECRET_KEY}") String jwtSecretKey,
+	public JwtService(JwtRedisService jwtRedisService, UserService userService,
+		@Value("${JWT_SECRET_KEY}") String jwtSecretKey,
 		@Value("${PROJECT_DOMAIN}") String projectDomain) {
 		this.jwtRedisService = jwtRedisService;
+		this.userService = userService;
 		this.algorithm = Algorithm.HMAC256(jwtSecretKey);
 		this.projectDomain = projectDomain;
 	}
@@ -140,6 +145,20 @@ public class JwtService {
 			.build();
 
 		return verifier.verify(token);
+	}
+
+	public String reissueAccessTokenByRefreshToken(String refreshToken) {
+		DecodedJWT decodedRefreshToken = verifyJwt(refreshToken);
+		RefreshTokenDto refreshTokenDto = jwtRedisService.getRefreshTokenInfo(refreshToken);
+
+		if (!decodedRefreshToken.getId().equals(refreshTokenDto.jid())) {
+			throw new ApiException(ErrorCode.UNAUTHORIZED);
+		}
+
+		Long userId = Long.valueOf(refreshTokenDto.subject());
+		JwtUserInfoDto jwtUserInfoDto = userService.getUserInfoById(userId);
+
+		return generateAccessToken(jwtUserInfoDto.userId(), jwtUserInfoDto.username(), jwtUserInfoDto.roleId());
 	}
 
 	/**

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtService.java
@@ -15,6 +15,7 @@ import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
+import com.trackery.trackerybackapiserver.domain.jwt.dto.AuthTokenDto;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.RefreshTokenDto;
 
 import lombok.extern.slf4j.Slf4j;
@@ -112,10 +113,11 @@ public class JwtService {
 	 * @param roleId : 역할 ID
 	 * @return : 액세스 토큰, 리프레시 토큰이 담긴 리스트
 	 */
-	public List<String> generateAccessTokenAndRefreshToken(Long userId, String userName, Long roleId) {
+	public AuthTokenDto generateAccessTokenAndRefreshToken(Long userId, String userName, Long roleId) {
 		String accessToken = generateAccessToken(userId, userName, roleId);
 		String refreshToken = generateRefreshTokenAndSaveToRedis(userId);
-		return List.of(accessToken, refreshToken);
+
+		return new AuthTokenDto(accessToken, refreshToken);
 	}
 
 	/**

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtService.java
@@ -36,7 +36,7 @@ import lombok.extern.slf4j.Slf4j;
 public class JwtService {
 	private final JwtRedisService jwtRedisService;
 
-	//만료시간 10분(600초)
+	//액세스 토큰 만료시간 1시간, 리프레시 토큰 만료시간 7일, 단위 : 초(s)
 	//TODO JWT 만료시간 일괄 설정되게 수정
 	private static final int ACCESS_TOKEN_EXPIRATION_TIME = 600;
 	private static final int REFRESH_TOKEN_EXPIRATION_TIME = 604800;
@@ -105,12 +105,12 @@ public class JwtService {
 	}
 
 	/**
-	 * 유저 정보를 받아서 액세스 토큰과 리프레시 토큰을 리스트로 반환하는 메서드
+	 * 유저 정보를 받아서 액세스 토큰과 리프레시 토큰을 DTO로 반환하는 메서드
 	 *
 	 * @param userId : 유저 ID
 	 * @param userName : 유저명
 	 * @param roleId : 역할 ID
-	 * @return : 액세스 토큰, 리프레시 토큰이 담긴 리스트
+	 * @return : 액세스 토큰, 리프레시 토큰이 담긴 DTO
 	 */
 	public AuthTokenDto generateAccessTokenAndRefreshToken(Long userId, String userName, Long roleId) {
 		String accessToken = generateAccessToken(userId, userName, roleId);

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtService.java
@@ -15,9 +15,7 @@ import com.auth0.jwt.interfaces.DecodedJWT;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.AuthTokenDto;
-import com.trackery.trackerybackapiserver.domain.jwt.dto.JwtUserInfoDto;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.RefreshTokenDto;
-import com.trackery.trackerybackapiserver.domain.user.service.UserService;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -37,7 +35,6 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 public class JwtService {
 	private final JwtRedisService jwtRedisService;
-	private final UserService userService;
 
 	//액세스 토큰 만료시간 1시간, 리프레시 토큰 만료시간 7일, 단위 : 초(s)
 	//TODO JWT 만료시간 일괄 설정되게 수정
@@ -48,11 +45,9 @@ public class JwtService {
 	private final Algorithm algorithm;
 
 	public JwtService(JwtRedisService jwtRedisService,
-		UserService userService,
 		@Value("${JWT_SECRET_KEY}") String jwtSecretKey,
 		@Value("${PROJECT_DOMAIN}") String projectDomain) {
 		this.jwtRedisService = jwtRedisService;
-		this.userService = userService;
 		this.algorithm = Algorithm.HMAC256(jwtSecretKey);
 		this.projectDomain = projectDomain;
 	}
@@ -167,11 +162,11 @@ public class JwtService {
 	}
 
 	/**
-	 * 리프레시 토큰을 파싱하고 검증한 뒤 유저 정보를 반환합니다.
+	 * 리프레시 토큰을 파싱하고 검증한 뒤 유저 ID를 반환합니다.
 	 * @param refreshToken : 리프레시 토큰
-	 * @return : userId, userName, roleId가 담긴 DTO
+	 * @return : userId
 	 */
-	public JwtUserInfoDto parseAndVerifyRefreshToken(String refreshToken) {
+	public Long parseAndVerifyRefreshToken(String refreshToken) {
 		DecodedJWT decodedRefreshToken = verifyJwt(refreshToken);
 		RefreshTokenDto refreshTokenDto = jwtRedisService.getRefreshTokenInfo(refreshToken);
 
@@ -179,10 +174,8 @@ public class JwtService {
 			throw new ApiException(ErrorCode.UNAUTHORIZED);
 		}
 
-		Long userId = Long.valueOf(refreshTokenDto.subject());
-
 		jwtRedisService.deleteRefreshToken(refreshToken);
 
-		return userService.getUserInfoById(userId);
+		return Long.valueOf(refreshTokenDto.subject());
 	}
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtService.java
@@ -1,6 +1,7 @@
 package com.trackery.trackerybackapiserver.domain.jwt.service;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -33,6 +34,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Component
 public class JwtService {
+	private final JwtRedisService jwtRedisService;
 
 	//만료시간 10분(600초)
 	//TODO JWT 만료시간 일괄 설정되게 수정
@@ -42,8 +44,9 @@ public class JwtService {
 	private final String projectDomain;
 	private final Algorithm algorithm;
 
-	public JwtService(@Value("${JWT_SECRET_KEY}") String jwtSecretKey,
+	public JwtService(JwtRedisService jwtRedisService, @Value("${JWT_SECRET_KEY}") String jwtSecretKey,
 		@Value("${PROJECT_DOMAIN}") String projectDomain) {
+		this.jwtRedisService = jwtRedisService;
 		this.algorithm = Algorithm.HMAC256(jwtSecretKey);
 		this.projectDomain = projectDomain;
 	}
@@ -98,6 +101,18 @@ public class JwtService {
 		}
 
 		return new RefreshTokenDto(refreshToken, jid, userId.toString());
+	}
+
+	public List<String> generateAccessTokenAndRefreshToken(Long userId, String userName, Long userRoleId) {
+		String accessToken = generateAccessToken(userId, userName, userRoleId);
+		String refreshToken = generateRefreshTokenAndSaveToRedis(userId);
+		return List.of(accessToken, refreshToken);
+	}
+
+	private String generateRefreshTokenAndSaveToRedis(Long userId) {
+		RefreshTokenDto refreshTokenDto = generateRefreshToken(userId);
+		jwtRedisService.saveRefreshToken(refreshTokenDto);
+		return refreshTokenDto.refreshToken();
 	}
 
 	/**

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtService.java
@@ -171,7 +171,7 @@ public class JwtService {
 		RefreshTokenDto refreshTokenDto = jwtRedisService.getRefreshTokenInfo(refreshToken);
 
 		if (!decodedRefreshToken.getId().equals(refreshTokenDto.jid())) {
-			throw new ApiException(ErrorCode.UNAUTHORIZED);
+			throw new ApiException(ErrorCode.UNAUTHORIZED_JWT_VERIFY_FAILED);
 		}
 
 		jwtRedisService.deleteRefreshToken(refreshToken);

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtService.java
@@ -15,7 +15,9 @@ import com.auth0.jwt.interfaces.DecodedJWT;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.AuthTokenDto;
+import com.trackery.trackerybackapiserver.domain.jwt.dto.JwtUserInfoDto;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.RefreshTokenDto;
+import com.trackery.trackerybackapiserver.domain.user.service.UserService;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -35,6 +37,7 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 public class JwtService {
 	private final JwtRedisService jwtRedisService;
+	private final UserService userService;
 
 	//액세스 토큰 만료시간 1시간, 리프레시 토큰 만료시간 7일, 단위 : 초(s)
 	//TODO JWT 만료시간 일괄 설정되게 수정
@@ -45,9 +48,11 @@ public class JwtService {
 	private final Algorithm algorithm;
 
 	public JwtService(JwtRedisService jwtRedisService,
+		UserService userService,
 		@Value("${JWT_SECRET_KEY}") String jwtSecretKey,
 		@Value("${PROJECT_DOMAIN}") String projectDomain) {
 		this.jwtRedisService = jwtRedisService;
+		this.userService = userService;
 		this.algorithm = Algorithm.HMAC256(jwtSecretKey);
 		this.projectDomain = projectDomain;
 	}
@@ -159,5 +164,25 @@ public class JwtService {
 			log.error(e.getMessage());
 			throw new ApiException(ErrorCode.INTERNAL_SERVER_ERROR_FAILED_TO_GENERATE_JWT);
 		}
+	}
+
+	/**
+	 * 리프레시 토큰을 파싱하고 검증한 뒤 유저 정보를 반환합니다.
+	 * @param refreshToken : 리프레시 토큰
+	 * @return : userId, userName, roleId가 담긴 DTO
+	 */
+	public JwtUserInfoDto parseAndVerifyRefreshToken(String refreshToken) {
+		DecodedJWT decodedRefreshToken = verifyJwt(refreshToken);
+		RefreshTokenDto refreshTokenDto = jwtRedisService.getRefreshTokenInfo(refreshToken);
+
+		if (!decodedRefreshToken.getId().equals(refreshTokenDto.jid())) {
+			throw new ApiException(ErrorCode.UNAUTHORIZED);
+		}
+
+		Long userId = Long.valueOf(refreshTokenDto.subject());
+
+		jwtRedisService.deleteRefreshToken(refreshToken);
+
+		return userService.getUserInfoById(userId);
 	}
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtService.java
@@ -136,12 +136,17 @@ public class JwtService {
 	 * @param token : jwt 토큰
 	 * @return : jwt의 디코딩된 정보를 담고있는 DecodedJWT 객체
 	 */
-	public DecodedJWT verifyJwt(String token) throws JWTVerificationException {
-		JWTVerifier verifier = JWT.require(algorithm)
-			.withIssuer(projectDomain)
-			.build();
+	public DecodedJWT verifyJwt(String token) {
+		try {
+			JWTVerifier verifier = JWT.require(algorithm)
+				.withIssuer(projectDomain)
+				.build();
+			return verifier.verify(token);
 
-		return verifier.verify(token);
+		} catch (JWTVerificationException e) {
+			log.error(e.getMessage());
+			throw new ApiException(ErrorCode.BAD_REQUEST);
+		}
 	}
 
 	/**

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtService.java
@@ -101,7 +101,11 @@ public class JwtService {
 			throw new ApiException(ErrorCode.INTERNAL_SERVER_ERROR_FAILED_TO_GENERATE_JWT);
 		}
 
-		return new RefreshTokenDto(refreshToken, jid, userId.toString());
+		RefreshTokenDto refreshTokenDto = new RefreshTokenDto(refreshToken, jid, userId.toString());
+
+		jwtRedisService.saveRefreshToken(refreshTokenDto);
+
+		return refreshTokenDto;
 	}
 
 	/**
@@ -114,21 +118,9 @@ public class JwtService {
 	 */
 	public AuthTokenDto generateAccessTokenAndRefreshToken(Long userId, String userName, Long roleId) {
 		String accessToken = generateAccessToken(userId, userName, roleId);
-		String refreshToken = generateRefreshTokenAndSaveToRedis(userId);
+		String refreshToken = generateRefreshToken(userId).refreshToken();
 
 		return new AuthTokenDto(accessToken, refreshToken);
-	}
-
-	/**
-	 * 리프레시 토큰을 발급하고 정보를 redis에 저장하고 토큰을 반환하는 메서드
-	 *
-	 * @param userId : 유저 ID
-	 * @return 리프레시 토큰
-	 */
-	private String generateRefreshTokenAndSaveToRedis(Long userId) {
-		RefreshTokenDto refreshTokenDto = generateRefreshToken(userId);
-		jwtRedisService.saveRefreshToken(refreshTokenDto);
-		return refreshTokenDto.refreshToken();
 	}
 
 	/**

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtService.java
@@ -1,4 +1,4 @@
-package com.trackery.trackerybackapiserver.domain.common.util;
+package com.trackery.trackerybackapiserver.domain.jwt.service;
 
 import java.time.Instant;
 import java.util.UUID;
@@ -14,6 +14,7 @@ import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
+import com.trackery.trackerybackapiserver.domain.jwt.dto.RefreshTokenDto;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -31,7 +32,7 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 @Component
-public class JwtUtil {
+public class JwtService {
 
 	//만료시간 10분(600초)
 	//TODO JWT 만료시간 일괄 설정되게 수정
@@ -41,7 +42,8 @@ public class JwtUtil {
 	private final String projectDomain;
 	private final Algorithm algorithm;
 
-	public JwtUtil(@Value("${JWT_SECRET_KEY}") String jwtSecretKey, @Value("${PROJECT_DOMAIN}") String projectDomain) {
+	public JwtService(@Value("${JWT_SECRET_KEY}") String jwtSecretKey,
+		@Value("${PROJECT_DOMAIN}") String projectDomain) {
 		this.algorithm = Algorithm.HMAC256(jwtSecretKey);
 		this.projectDomain = projectDomain;
 	}
@@ -77,11 +79,14 @@ public class JwtUtil {
 	 * @param userId : 유저 ID
 	 * @return : 리프레시 토큰
 	 */
-	public String generateRefreshToken(Long userId) {
+	public RefreshTokenDto generateRefreshToken(Long userId) {
+		String jid = UUID.randomUUID().toString();
+		String refreshToken;
+
 		try {
-			return JWT.create()
+			refreshToken = JWT.create()
 				.withIssuer(projectDomain)
-				.withJWTId(UUID.randomUUID().toString())
+				.withJWTId(jid)
 				.withSubject(userId.toString())
 				.withNotBefore(Instant.now())
 				.withIssuedAt(Instant.now())
@@ -91,6 +96,8 @@ public class JwtUtil {
 			log.error(e.getMessage());
 			throw new ApiException(ErrorCode.INTERNAL_SERVER_ERROR_FAILED_TO_GENERATE_JWT);
 		}
+
+		return new RefreshTokenDto(refreshToken, jid, userId.toString());
 	}
 
 	/**

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtService.java
@@ -15,9 +15,7 @@ import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
-import com.trackery.trackerybackapiserver.domain.jwt.dto.JwtUserInfoDto;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.RefreshTokenDto;
-import com.trackery.trackerybackapiserver.domain.user.service.UserService;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -37,7 +35,6 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 public class JwtService {
 	private final JwtRedisService jwtRedisService;
-	private final UserService userService;
 
 	//만료시간 10분(600초)
 	//TODO JWT 만료시간 일괄 설정되게 수정
@@ -47,11 +44,10 @@ public class JwtService {
 	private final String projectDomain;
 	private final Algorithm algorithm;
 
-	public JwtService(JwtRedisService jwtRedisService, UserService userService,
+	public JwtService(JwtRedisService jwtRedisService,
 		@Value("${JWT_SECRET_KEY}") String jwtSecretKey,
 		@Value("${PROJECT_DOMAIN}") String projectDomain) {
 		this.jwtRedisService = jwtRedisService;
-		this.userService = userService;
 		this.algorithm = Algorithm.HMAC256(jwtSecretKey);
 		this.projectDomain = projectDomain;
 	}
@@ -145,20 +141,6 @@ public class JwtService {
 			.build();
 
 		return verifier.verify(token);
-	}
-
-	public String reissueAccessTokenByRefreshToken(String refreshToken) {
-		DecodedJWT decodedRefreshToken = verifyJwt(refreshToken);
-		RefreshTokenDto refreshTokenDto = jwtRedisService.getRefreshTokenInfo(refreshToken);
-
-		if (!decodedRefreshToken.getId().equals(refreshTokenDto.jid())) {
-			throw new ApiException(ErrorCode.UNAUTHORIZED);
-		}
-
-		Long userId = Long.valueOf(refreshTokenDto.subject());
-		JwtUserInfoDto jwtUserInfoDto = userService.getUserInfoById(userId);
-
-		return generateAccessToken(jwtUserInfoDto.userId(), jwtUserInfoDto.username(), jwtUserInfoDto.roleId());
 	}
 
 	/**

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtService.java
@@ -1,7 +1,6 @@
 package com.trackery.trackerybackapiserver.domain.jwt.service;
 
 import java.time.Instant;
-import java.util.List;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/mail/controller/MailController.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/mail/controller/MailController.java
@@ -1,5 +1,7 @@
 package com.trackery.trackerybackapiserver.domain.mail.controller;
 
+import java.time.Duration;
+
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
@@ -57,7 +59,7 @@ public class MailController {
 	public ResponseEntity<ApiResponse<String>> verifyMail(@Valid @RequestBody VerifyEmailDto dto) {
 		String emailToken = mailService.verifyEmail(dto.getEmail(), dto.getAuthNumber());
 
-		ResponseCookie cookie = CookieUtil.createHttpOnlyCookie("emailToken", emailToken);
+		ResponseCookie cookie = CookieUtil.createHttpOnlyCookie("emailToken", emailToken, Duration.ofMinutes(10));
 
 		return ResponseEntity.ok()
 			.header(HttpHeaders.SET_COOKIE, cookie.toString())

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/mail/service/MailService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/mail/service/MailService.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service;
 
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
-import com.trackery.trackerybackapiserver.domain.common.util.JwtUtil;
+import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
 import com.trackery.trackerybackapiserver.domain.user.entity.User;
 import com.trackery.trackerybackapiserver.domain.user.mapper.UserMapper;
 
@@ -37,7 +37,7 @@ import lombok.extern.slf4j.Slf4j;
 public class MailService {
 	private final StringRedisTemplate redisTemplate;
 	private final SecureRandom secureRandom = new SecureRandom();
-	private final JwtUtil jwtUtil;
+	private final JwtService jwtService;
 	private final MailSenderService mailSenderService;
 
 	private static final String EMAIL_VERIFICATION_REDIS_KEY = "email:verify:";
@@ -87,7 +87,7 @@ public class MailService {
 
 		redisTemplate.delete(EMAIL_VERIFICATION_REDIS_KEY + emailAddress);
 
-		return jwtUtil.generateTokenWithSubject(emailAddress);
+		return jwtService.generateTokenWithSubject(emailAddress);
 	}
 
 	/**

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/controller/OAuthController.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/controller/OAuthController.java
@@ -1,5 +1,7 @@
 package com.trackery.trackerybackapiserver.domain.user.controller;
 
+import java.time.Duration;
+
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
@@ -148,7 +150,8 @@ public class OAuthController {
 
 			// 로그인 성공 또는 계정 연동 성공한 경우
 			// JWT 토큰을 쿠키에 설정
-			ResponseCookie cookie = CookieUtil.createHttpOnlyCookie("accessToken", result.getJwtToken());
+			ResponseCookie cookie = CookieUtil.createHttpOnlyCookie("accessToken", result.getJwtToken(),
+				Duration.ofMinutes(60));
 
 			return ResponseEntity.ok()
 				.header(HttpHeaders.SET_COOKIE, cookie.toString())

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/controller/UserController.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.trackery.trackerybackapiserver.domain.user.controller;
 
+import java.time.Duration;
 import java.util.List;
 
 import org.springframework.http.HttpHeaders;
@@ -63,7 +64,7 @@ public class UserController {
 		@Valid @RequestBody UserRegisterDto userRegisterDto) {
 		String jwt = userService.registerUser(emailToken, userNameToken, userRegisterDto);
 
-		ResponseCookie accessTokenCookie = CookieUtil.createHttpOnlyCookie("accessToken", jwt);
+		ResponseCookie accessTokenCookie = CookieUtil.createHttpOnlyCookie("accessToken", jwt, Duration.ofMinutes(60));
 		ResponseCookie emailTokenCookie = CookieUtil.deleteCookie("emailToken");
 		ResponseCookie userNameTokenCookie = CookieUtil.deleteCookie("userNameToken");
 
@@ -86,8 +87,10 @@ public class UserController {
 	public ResponseEntity<ApiResponse<String>> login(@Valid @RequestBody UserLoginDto userLoginDto) {
 		List<String> tokens = userService.login(userLoginDto);
 
-		ResponseCookie accessTokenCookie = CookieUtil.createHttpOnlyCookie("accessToken", tokens.get(0));
-		ResponseCookie refreshTokenCookie = CookieUtil.createHttpOnlyCookie("refreshToken", tokens.get(1));
+		ResponseCookie accessTokenCookie = CookieUtil.createHttpOnlyCookie("accessToken", tokens.get(0),
+			Duration.ofMinutes(60));
+		ResponseCookie refreshTokenCookie = CookieUtil.createHttpOnlyCookie("refreshToken", tokens.get(1),
+			Duration.ofDays(7));
 
 		return ResponseEntity.ok()
 			.header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
@@ -106,7 +109,8 @@ public class UserController {
 		UserNameAvailabilityResponseDto result = userService.checkUsernameAvailability(value);
 
 		if (result.available()) {
-			ResponseCookie cookie = CookieUtil.createHttpOnlyCookie("userNameToken", result.token());
+			ResponseCookie cookie = CookieUtil.createHttpOnlyCookie("userNameToken", result.token(),
+				Duration.ofMinutes(10));
 
 			return ResponseEntity.ok()
 				.header(HttpHeaders.SET_COOKIE, cookie.toString())

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/controller/UserController.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/controller/UserController.java
@@ -62,15 +62,19 @@ public class UserController {
 	public ResponseEntity<ApiResponse<String>> register(@CookieValue(name = "emailToken") String emailToken,
 		@CookieValue(name = "userNameToken") String userNameToken,
 		@Valid @RequestBody UserRegisterDto userRegisterDto) {
-		String jwt = userService.registerUser(emailToken, userNameToken, userRegisterDto);
+		List<String> tokens = userService.registerUser(emailToken, userNameToken, userRegisterDto);
 
-		ResponseCookie accessTokenCookie = CookieUtil.createHttpOnlyCookie("accessToken", jwt, Duration.ofMinutes(60));
+		ResponseCookie accessTokenCookie = CookieUtil.createHttpOnlyCookie("accessToken", tokens.get(0),
+			Duration.ofMinutes(60));
+		ResponseCookie refreshTokenCookie = CookieUtil.createHttpOnlyCookie("refreshToken", tokens.get(1),
+			Duration.ofDays(7));
 		ResponseCookie emailTokenCookie = CookieUtil.deleteCookie("emailToken");
 		ResponseCookie userNameTokenCookie = CookieUtil.deleteCookie("userNameToken");
 
 		return ResponseEntity.status(HttpStatus.CREATED)
 			.headers(httpHeaders -> {
 				httpHeaders.add(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
+				httpHeaders.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
 				httpHeaders.add(HttpHeaders.SET_COOKIE, emailTokenCookie.toString());
 				httpHeaders.add(HttpHeaders.SET_COOKIE, userNameTokenCookie.toString());
 			})

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/controller/UserController.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/controller/UserController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.trackery.trackerybackapiserver.domain.common.response.ApiResponse;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.SuccessCode;
 import com.trackery.trackerybackapiserver.domain.common.util.CookieUtil;
+import com.trackery.trackerybackapiserver.domain.jwt.dto.AuthTokenDto;
 import com.trackery.trackerybackapiserver.domain.user.dto.ChangePasswordDto;
 import com.trackery.trackerybackapiserver.domain.user.dto.UserLoginDto;
 import com.trackery.trackerybackapiserver.domain.user.dto.UserNameAvailabilityResponseDto;
@@ -62,11 +63,11 @@ public class UserController {
 	public ResponseEntity<ApiResponse<String>> register(@CookieValue(name = "emailToken") String emailToken,
 		@CookieValue(name = "userNameToken") String userNameToken,
 		@Valid @RequestBody UserRegisterDto userRegisterDto) {
-		List<String> tokens = userService.registerUser(emailToken, userNameToken, userRegisterDto);
+		AuthTokenDto authTokenDto = userService.registerUser(emailToken, userNameToken, userRegisterDto);
 
-		ResponseCookie accessTokenCookie = CookieUtil.createHttpOnlyCookie("accessToken", tokens.get(0),
+		ResponseCookie accessTokenCookie = CookieUtil.createHttpOnlyCookie("accessToken", authTokenDto.accessToken(),
 			Duration.ofMinutes(60));
-		ResponseCookie refreshTokenCookie = CookieUtil.createHttpOnlyCookie("refreshToken", tokens.get(1),
+		ResponseCookie refreshTokenCookie = CookieUtil.createHttpOnlyCookie("refreshToken", authTokenDto.refreshToken(),
 			Duration.ofDays(7));
 		ResponseCookie emailTokenCookie = CookieUtil.deleteCookie("emailToken");
 		ResponseCookie userNameTokenCookie = CookieUtil.deleteCookie("userNameToken");
@@ -89,11 +90,11 @@ public class UserController {
 	 */
 	@PostMapping("/login")
 	public ResponseEntity<ApiResponse<String>> login(@Valid @RequestBody UserLoginDto userLoginDto) {
-		List<String> tokens = userService.login(userLoginDto);
+		AuthTokenDto authTokenDto = userService.login(userLoginDto);
 
-		ResponseCookie accessTokenCookie = CookieUtil.createHttpOnlyCookie("accessToken", tokens.get(0),
+		ResponseCookie accessTokenCookie = CookieUtil.createHttpOnlyCookie("accessToken", authTokenDto.accessToken(),
 			Duration.ofMinutes(60));
-		ResponseCookie refreshTokenCookie = CookieUtil.createHttpOnlyCookie("refreshToken", tokens.get(1),
+		ResponseCookie refreshTokenCookie = CookieUtil.createHttpOnlyCookie("refreshToken", authTokenDto.refreshToken(),
 			Duration.ofDays(7));
 
 		return ResponseEntity.ok()

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/controller/UserController.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/controller/UserController.java
@@ -1,5 +1,7 @@
 package com.trackery.trackerybackapiserver.domain.user.controller;
 
+import java.util.List;
+
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
@@ -82,12 +84,14 @@ public class UserController {
 	 */
 	@PostMapping("/login")
 	public ResponseEntity<ApiResponse<String>> login(@Valid @RequestBody UserLoginDto userLoginDto) {
-		String jwt = userService.login(userLoginDto);
+		List<String> tokens = userService.login(userLoginDto);
 
-		ResponseCookie cookie = CookieUtil.createHttpOnlyCookie("accessToken", jwt);
+		ResponseCookie accessTokenCookie = CookieUtil.createHttpOnlyCookie("accessToken", tokens.get(0));
+		ResponseCookie refreshTokenCookie = CookieUtil.createHttpOnlyCookie("refreshToken", tokens.get(1));
 
 		return ResponseEntity.ok()
-			.header(HttpHeaders.SET_COOKIE, cookie.toString())
+			.header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
+			.header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
 			.body(ApiResponse.success(SuccessCode.OK));
 	}
 

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/controller/UserController.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/controller/UserController.java
@@ -1,7 +1,6 @@
 package com.trackery.trackerybackapiserver.domain.user.controller;
 
 import java.time.Duration;
-import java.util.List;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/entity/User.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/entity/User.java
@@ -76,6 +76,7 @@ public class User {
 	private Long roleId;
 
 	@Builder
+	@SuppressWarnings("java:S107")
 	public User(String email, String userName, String nickname, String password, String salt, Timestamp startDate,
 		Integer status,
 		Timestamp lastLogin, String userProfile, Long roleId) {

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/entity/User.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/entity/User.java
@@ -73,10 +73,12 @@ public class User {
 	 */
 	private String userProfile;
 
+	private Long roleId;
+
 	@Builder
 	public User(String email, String userName, String nickname, String password, String salt, Timestamp startDate,
 		Integer status,
-		Timestamp lastLogin, String userProfile) {
+		Timestamp lastLogin, String userProfile, Long roleId) {
 		this.email = email;
 		this.userName = userName;
 		this.nickname = nickname;
@@ -86,5 +88,6 @@ public class User {
 		this.status = status;
 		this.lastLogin = lastLogin;
 		this.userProfile = userProfile;
+		this.roleId = roleId;
 	}
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/entity/User.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/entity/User.java
@@ -1,6 +1,6 @@
 package com.trackery.trackerybackapiserver.domain.user.entity;
 
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -26,6 +26,7 @@ public class User {
 	/**
 	 * 사용자의 고유 식별자
 	 */
+	@SuppressWarnings("unused")
 	private Long userId;
 
 	/**
@@ -56,7 +57,7 @@ public class User {
 	/**
 	 * 계정 가입일자
 	 */
-	private Timestamp startDate;
+	private LocalDateTime startDate;
 
 	/**
 	 * 회원 상태 (탈퇴 여부등)
@@ -66,7 +67,7 @@ public class User {
 	/**
 	 * 마지막 로그인 일자
 	 */
-	private Timestamp lastLogin;
+	private LocalDateTime lastLogin;
 
 	/**
 	 * 사용자의 프로필 사진
@@ -77,9 +78,9 @@ public class User {
 
 	@Builder
 	@SuppressWarnings("java:S107")
-	public User(String email, String userName, String nickname, String password, String salt, Timestamp startDate,
+	public User(String email, String userName, String nickname, String password, String salt, LocalDateTime startDate,
 		Integer status,
-		Timestamp lastLogin, String userProfile, Long roleId) {
+		LocalDateTime lastLogin, String userProfile, Long roleId) {
 		this.email = email;
 		this.userName = userName;
 		this.nickname = nickname;

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/OAuthService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/OAuthService.java
@@ -11,8 +11,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
-import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
 import com.trackery.trackerybackapiserver.domain.common.util.PasswordUtil;
+import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
 import com.trackery.trackerybackapiserver.domain.user.client.OAuthClient;
 import com.trackery.trackerybackapiserver.domain.user.dto.OAuthLoginDto;
 import com.trackery.trackerybackapiserver.domain.user.dto.OAuthResponseDto;
@@ -75,7 +75,8 @@ public class OAuthService {
 		OAuthUserInfoDto userInfo = oAuthClient.getUserInfo(accessToken, provider);
 
 		// OAuth 연동 정보 조회
-		Optional<OAuth> existingOAuth = oAuthMapper.findByProviderAndProviderId(provider.name(), userInfo.getProviderUserId());
+		Optional<OAuth> existingOAuth = oAuthMapper.findByProviderAndProviderId(provider.name(),
+			userInfo.getProviderUserId());
 
 		// 이미 OAuth 연동된 계정이 있으면 그대로 로그인
 		if (existingOAuth.isPresent()) {
@@ -144,7 +145,6 @@ public class OAuthService {
 		);
 	}
 
-
 	/**
 	 * 신규 사용자 회원가입 매서드입니다.
 	 *
@@ -202,7 +202,6 @@ public class OAuthService {
 
 		oAuthMapper.insertOAuth(oAuth);
 	}
-
 
 	/**
 	 * 사용자명 생성 매서드입니다.

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/OAuthService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/OAuthService.java
@@ -1,7 +1,6 @@
 package com.trackery.trackerybackapiserver.domain.user.service;
 
 import java.security.SecureRandom;
-import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
@@ -168,9 +167,9 @@ public class OAuthService {
 			.nickname(userInfo.getNickname() != null ? userInfo.getNickname() : userName)
 			.password(hashedPassword)
 			.salt(salt)
-			.startDate(Timestamp.valueOf(LocalDateTime.now()))
+			.startDate(LocalDateTime.now())
 			.status(1)
-			.lastLogin(Timestamp.valueOf(LocalDateTime.now()))
+			.lastLogin(LocalDateTime.now())
 			.userProfile(null)
 			.build();
 

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/OAuthService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/OAuthService.java
@@ -11,7 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
-import com.trackery.trackerybackapiserver.domain.common.util.JwtUtil;
+import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
 import com.trackery.trackerybackapiserver.domain.common.util.PasswordUtil;
 import com.trackery.trackerybackapiserver.domain.user.client.OAuthClient;
 import com.trackery.trackerybackapiserver.domain.user.dto.OAuthLoginDto;
@@ -52,7 +52,7 @@ public class OAuthService {
 
 	private final UserMapper userMapper;
 	private final OAuthMapper oAuthMapper;
-	private final JwtUtil jwtUtil;
+	private final JwtService jwtService;
 	private final UserRoleMapper userRoleMapper;
 	private final OAuthClient oAuthClient;
 	private final SecureRandom random = new SecureRandom();
@@ -86,7 +86,7 @@ public class OAuthService {
 			UserRole userRole = userRoleMapper.findByUserId(user.getUserId())
 				.orElseThrow(() -> new ApiException(ErrorCode.INTERNAL_SERVER_ERROR));
 
-			String jwt = jwtUtil.generateAccessToken(user.getUserId(), user.getUserName(), userRole.getRoleId());
+			String jwt = jwtService.generateAccessToken(user.getUserId(), user.getUserName(), userRole.getRoleId());
 
 			return new OAuthLoginResult(
 				OAuthResponseDto.builder().isExistingEmail(false).build(),
@@ -116,7 +116,7 @@ public class OAuthService {
 				UserRole userRole = userRoleMapper.findByUserId(existingUser.get().getUserId())
 					.orElseThrow(() -> new ApiException(ErrorCode.INTERNAL_SERVER_ERROR));
 
-				String jwt = jwtUtil.generateAccessToken(
+				String jwt = jwtService.generateAccessToken(
 					existingUser.get().getUserId(),
 					existingUser.get().getUserName(),
 					userRole.getRoleId()
@@ -136,7 +136,7 @@ public class OAuthService {
 		UserRole userRole = userRoleMapper.findByUserId(newUser.getUserId())
 			.orElseThrow(() -> new ApiException(ErrorCode.INTERNAL_SERVER_ERROR));
 
-		String jwt = jwtUtil.generateAccessToken(newUser.getUserId(), newUser.getUserName(), userRole.getRoleId());
+		String jwt = jwtService.generateAccessToken(newUser.getUserId(), newUser.getUserName(), userRole.getRoleId());
 
 		return new OAuthLoginResult(
 			OAuthResponseDto.builder().isExistingEmail(false).build(),

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/UserService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/UserService.java
@@ -56,7 +56,7 @@ public class UserService {
 	 *
 	 * @param userRegisterDto : 회원 가입 정보를 담은 DTO
 	 */
-	public String registerUser(String emailToken, String userNameToken, UserRegisterDto userRegisterDto) {
+	public List<String> registerUser(String emailToken, String userNameToken, UserRegisterDto userRegisterDto) {
 		DecodedJWT decodedEmailToken = jwtService.verifyJwt(emailToken);
 		DecodedJWT decodedUserNameToken = jwtService.verifyJwt(userNameToken);
 
@@ -87,21 +87,7 @@ public class UserService {
 
 		userRoleMapper.insertUserRole(userRole);
 
-		return jwtService.generateAccessToken(user.getUserId(), user.getUserName(), userRole.getRoleId());
-	}
-
-	/**
-	 * 유저명 중복체크를 하여 토큰 발급하는 메서드
-	 * @param userName : 중복체크할 유저명
-	 * @return : boolean, jwt 토큰을 담은 DTO
-	 */
-	public UserNameAvailabilityResponseDto checkUsernameAvailability(String userName) {
-		if (!userMapper.isExistsUserName(userName)) {
-			String jwt = jwtService.generateTokenWithSubject(userName);
-			return new UserNameAvailabilityResponseDto(true, jwt);
-		} else {
-			return new UserNameAvailabilityResponseDto(false, null);
-		}
+		return generateTokens(user.getUserId(), user.getUserName(), userRole.getRoleId());
 	}
 
 	/**
@@ -121,12 +107,34 @@ public class UserService {
 		UserRole userRole = userRoleMapper.findByUserId(user.getUserId())
 			.orElseThrow(() -> new ApiException(ErrorCode.INTERNAL_SERVER_ERROR));
 
-		String accessToken = jwtService.generateAccessToken(user.getUserId(), user.getUserName(), userRole.getRoleId());
+		return generateTokens(user.getUserId(), user.getUserName(), userRole.getRoleId());
+	}
 
-		RefreshTokenDto refreshTokenDto = jwtService.generateRefreshToken(user.getUserId());
+	private List<String> generateTokens(Long userId, String userName, Long userRoleId) {
+		String accessToken = jwtService.generateAccessToken(userId, userName, userRoleId);
+		String refreshToken = generateRefreshTokenAndSaveInRedis(userId);
+
+		return List.of(accessToken, refreshToken);
+	}
+
+	private String generateRefreshTokenAndSaveInRedis(Long userId) {
+		RefreshTokenDto refreshTokenDto = jwtService.generateRefreshToken(userId);
 		jwtRedisService.saveRefreshToken(refreshTokenDto);
+		return refreshTokenDto.refreshToken();
+	}
 
-		return List.of(accessToken, refreshTokenDto.refreshToken());
+	/**
+	 * 유저명 중복체크를 하여 토큰 발급하는 메서드
+	 * @param userName : 중복체크할 유저명
+	 * @return : boolean, jwt 토큰을 담은 DTO
+	 */
+	public UserNameAvailabilityResponseDto checkUsernameAvailability(String userName) {
+		if (!userMapper.isExistsUserName(userName)) {
+			String jwt = jwtService.generateTokenWithSubject(userName);
+			return new UserNameAvailabilityResponseDto(true, jwt);
+		} else {
+			return new UserNameAvailabilityResponseDto(false, null);
+		}
 	}
 
 	/**

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/UserService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/UserService.java
@@ -2,7 +2,6 @@ package com.trackery.trackerybackapiserver.domain.user.service;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
-import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/UserService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/UserService.java
@@ -1,6 +1,5 @@
 package com.trackery.trackerybackapiserver.domain.user.service;
 
-import java.sql.Timestamp;
 import java.time.LocalDateTime;
 
 import org.springframework.stereotype.Service;
@@ -69,9 +68,9 @@ public class UserService {
 			.nickname(userRegisterDto.getNickname())
 			.password(hashedPassword)
 			.salt(salt)
-			.startDate(Timestamp.valueOf(LocalDateTime.now()))
+			.startDate(LocalDateTime.now())
 			.status(1)
-			.lastLogin(Timestamp.valueOf(LocalDateTime.now()))
+			.lastLogin(LocalDateTime.now())
 			.userProfile(userRegisterDto.getUserProfile())
 			.build();
 

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/UserService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/UserService.java
@@ -12,6 +12,7 @@ import com.auth0.jwt.interfaces.DecodedJWT;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
 import com.trackery.trackerybackapiserver.domain.common.util.PasswordUtil;
+import com.trackery.trackerybackapiserver.domain.jwt.dto.AuthTokenDto;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.JwtUserInfoDto;
 import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
 import com.trackery.trackerybackapiserver.domain.user.dto.UserLoginDto;
@@ -54,7 +55,7 @@ public class UserService {
 	 *
 	 * @param userRegisterDto : 회원 가입 정보를 담은 DTO
 	 */
-	public List<String> registerUser(String emailToken, String userNameToken, UserRegisterDto userRegisterDto) {
+	public AuthTokenDto registerUser(String emailToken, String userNameToken, UserRegisterDto userRegisterDto) {
 		DecodedJWT decodedEmailToken = jwtService.verifyJwt(emailToken);
 		DecodedJWT decodedUserNameToken = jwtService.verifyJwt(userNameToken);
 
@@ -95,7 +96,7 @@ public class UserService {
 	 * @param userLoginDto : username, password 받는 DTO
 	 * @return : 인증된 유저의 정보를 담고있는 jwt
 	 */
-	public List<String> login(UserLoginDto userLoginDto) {
+	public AuthTokenDto login(UserLoginDto userLoginDto) {
 		User user = userMapper.findByUserName(userLoginDto.getUserName()).orElseThrow(() -> new ApiException(
 			ErrorCode.UNAUTHORIZED_INVALID_CREDENTIALS));
 

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/UserService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/UserService.java
@@ -154,4 +154,6 @@ public class UserService {
 		return new JwtUserInfoDto(userId, user.getUserName(), userRole.getRoleId());
 	}
 
+
+
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/UserService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/UserService.java
@@ -6,7 +6,6 @@ import java.time.LocalDateTime;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
@@ -130,14 +129,7 @@ public class UserService {
 	 * @param password : 새로 변경될 비밀번호
 	 */
 	public void changePassword(String emailToken, String password) {
-		DecodedJWT jwt;
-		try {
-			jwt = jwtService.verifyJwt(emailToken);
-		} catch (JWTVerificationException e) {
-			log.error(e.getMessage());
-			throw new ApiException(ErrorCode.BAD_REQUEST);
-		}
-
+		DecodedJWT jwt = jwtService.verifyJwt(emailToken);
 		String email = jwt.getSubject();
 
 		if (!userMapper.isExistsEmail(email)) {
@@ -150,6 +142,12 @@ public class UserService {
 		userMapper.updatePassword(email, hashedPassword, salt);
 	}
 
+	/**
+	 * 액세스 토큰 발급을 위한 유저 정보를 DB에서 조회 후 DTO로 반환하는 메서드입니다.
+	 *
+	 * @param userId : 유저 ID
+	 * @return : userId, userName, userRole이 담긴 DTO
+	 */
 	public JwtUserInfoDto getUserInfoById(Long userId) {
 		User user = userMapper.findByUserId(userId).orElseThrow(() -> new ApiException(ErrorCode.NOT_FOUND));
 		UserRole userRole = userRoleMapper.findByUserId(userId)

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/UserService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.trackery.trackerybackapiserver.domain.user.service;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,8 +11,10 @@ import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
-import com.trackery.trackerybackapiserver.domain.common.util.JwtUtil;
 import com.trackery.trackerybackapiserver.domain.common.util.PasswordUtil;
+import com.trackery.trackerybackapiserver.domain.jwt.dto.RefreshTokenDto;
+import com.trackery.trackerybackapiserver.domain.jwt.service.JwtRedisService;
+import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
 import com.trackery.trackerybackapiserver.domain.user.dto.UserLoginDto;
 import com.trackery.trackerybackapiserver.domain.user.dto.UserNameAvailabilityResponseDto;
 import com.trackery.trackerybackapiserver.domain.user.dto.UserRegisterDto;
@@ -43,7 +46,8 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class UserService {
 	private final UserMapper userMapper;
-	private final JwtUtil jwtUtil;
+	private final JwtService jwtService;
+	private final JwtRedisService jwtRedisService;
 	private final UserRoleMapper userRoleMapper;
 
 	/**
@@ -53,8 +57,8 @@ public class UserService {
 	 * @param userRegisterDto : 회원 가입 정보를 담은 DTO
 	 */
 	public String registerUser(String emailToken, String userNameToken, UserRegisterDto userRegisterDto) {
-		DecodedJWT decodedEmailToken = jwtUtil.verifyJwt(emailToken);
-		DecodedJWT decodedUserNameToken = jwtUtil.verifyJwt(userNameToken);
+		DecodedJWT decodedEmailToken = jwtService.verifyJwt(emailToken);
+		DecodedJWT decodedUserNameToken = jwtService.verifyJwt(userNameToken);
 
 		String email = decodedEmailToken.getSubject();
 		String userName = decodedUserNameToken.getSubject();
@@ -83,7 +87,7 @@ public class UserService {
 
 		userRoleMapper.insertUserRole(userRole);
 
-		return jwtUtil.generateAccessToken(user.getUserId(), user.getUserName(), userRole.getRoleId());
+		return jwtService.generateAccessToken(user.getUserId(), user.getUserName(), userRole.getRoleId());
 	}
 
 	/**
@@ -93,7 +97,7 @@ public class UserService {
 	 */
 	public UserNameAvailabilityResponseDto checkUsernameAvailability(String userName) {
 		if (!userMapper.isExistsUserName(userName)) {
-			String jwt = jwtUtil.generateTokenWithSubject(userName);
+			String jwt = jwtService.generateTokenWithSubject(userName);
 			return new UserNameAvailabilityResponseDto(true, jwt);
 		} else {
 			return new UserNameAvailabilityResponseDto(false, null);
@@ -106,13 +110,9 @@ public class UserService {
 	 * @param userLoginDto : username, password 받는 DTO
 	 * @return : 인증된 유저의 정보를 담고있는 jwt
 	 */
-	public String login(UserLoginDto userLoginDto) {
+	public List<String> login(UserLoginDto userLoginDto) {
 		User user = userMapper.findByUserName(userLoginDto.getUserName()).orElseThrow(() -> new ApiException(
 			ErrorCode.UNAUTHORIZED_INVALID_CREDENTIALS));
-
-		if (user.getStatus() == 0) {
-			throw new ApiException(ErrorCode.UNAUTHORIZED_INVALID_CREDENTIALS);
-		}
 
 		if (!PasswordUtil.hashPassword(userLoginDto.getPassword(), user.getSalt()).equals(user.getPassword())) {
 			throw new ApiException(ErrorCode.UNAUTHORIZED_INVALID_CREDENTIALS);
@@ -121,7 +121,12 @@ public class UserService {
 		UserRole userRole = userRoleMapper.findByUserId(user.getUserId())
 			.orElseThrow(() -> new ApiException(ErrorCode.INTERNAL_SERVER_ERROR));
 
-		return jwtUtil.generateAccessToken(user.getUserId(), user.getUserName(), userRole.getRoleId());
+		String accessToken = jwtService.generateAccessToken(user.getUserId(), user.getUserName(), userRole.getRoleId());
+
+		RefreshTokenDto refreshTokenDto = jwtService.generateRefreshToken(user.getUserId());
+		jwtRedisService.saveRefreshToken(refreshTokenDto);
+
+		return List.of(accessToken, refreshTokenDto.refreshToken());
 	}
 
 	/**
@@ -132,7 +137,7 @@ public class UserService {
 	public void changePassword(String emailToken, String password) {
 		DecodedJWT jwt;
 		try {
-			jwt = jwtUtil.verifyJwt(emailToken);
+			jwt = jwtService.verifyJwt(emailToken);
 		} catch (JWTVerificationException e) {
 			log.error(e.getMessage());
 			throw new ApiException(ErrorCode.BAD_REQUEST);

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/UserService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/UserService.java
@@ -12,8 +12,6 @@ import com.auth0.jwt.interfaces.DecodedJWT;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
 import com.trackery.trackerybackapiserver.domain.common.util.PasswordUtil;
-import com.trackery.trackerybackapiserver.domain.jwt.dto.RefreshTokenDto;
-import com.trackery.trackerybackapiserver.domain.jwt.service.JwtRedisService;
 import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
 import com.trackery.trackerybackapiserver.domain.user.dto.UserLoginDto;
 import com.trackery.trackerybackapiserver.domain.user.dto.UserNameAvailabilityResponseDto;
@@ -47,7 +45,6 @@ import lombok.extern.slf4j.Slf4j;
 public class UserService {
 	private final UserMapper userMapper;
 	private final JwtService jwtService;
-	private final JwtRedisService jwtRedisService;
 	private final UserRoleMapper userRoleMapper;
 
 	/**
@@ -87,7 +84,8 @@ public class UserService {
 
 		userRoleMapper.insertUserRole(userRole);
 
-		return generateTokens(user.getUserId(), user.getUserName(), userRole.getRoleId());
+		return jwtService.generateAccessTokenAndRefreshToken(user.getUserId(), user.getUserName(),
+			userRole.getRoleId());
 	}
 
 	/**
@@ -107,20 +105,8 @@ public class UserService {
 		UserRole userRole = userRoleMapper.findByUserId(user.getUserId())
 			.orElseThrow(() -> new ApiException(ErrorCode.INTERNAL_SERVER_ERROR));
 
-		return generateTokens(user.getUserId(), user.getUserName(), userRole.getRoleId());
-	}
-
-	private List<String> generateTokens(Long userId, String userName, Long userRoleId) {
-		String accessToken = jwtService.generateAccessToken(userId, userName, userRoleId);
-		String refreshToken = generateRefreshTokenAndSaveInRedis(userId);
-
-		return List.of(accessToken, refreshToken);
-	}
-
-	private String generateRefreshTokenAndSaveInRedis(Long userId) {
-		RefreshTokenDto refreshTokenDto = jwtService.generateRefreshToken(userId);
-		jwtRedisService.saveRefreshToken(refreshTokenDto);
-		return refreshTokenDto.refreshToken();
+		return jwtService.generateAccessTokenAndRefreshToken(user.getUserId(), user.getUserName(),
+			userRole.getRoleId());
 	}
 
 	/**

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/UserService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/UserService.java
@@ -12,6 +12,7 @@ import com.auth0.jwt.interfaces.DecodedJWT;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
 import com.trackery.trackerybackapiserver.domain.common.util.PasswordUtil;
+import com.trackery.trackerybackapiserver.domain.jwt.dto.JwtUserInfoDto;
 import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
 import com.trackery.trackerybackapiserver.domain.user.dto.UserLoginDto;
 import com.trackery.trackerybackapiserver.domain.user.dto.UserNameAvailabilityResponseDto;
@@ -147,6 +148,13 @@ public class UserService {
 		String hashedPassword = PasswordUtil.hashPassword(password, salt);
 
 		userMapper.updatePassword(email, hashedPassword, salt);
+	}
+
+	public JwtUserInfoDto getUserInfoById(Long userId) {
+		User user = userMapper.findByUserId(userId).orElseThrow(() -> new ApiException(ErrorCode.NOT_FOUND));
+		UserRole userRole = userRoleMapper.findByUserId(userId)
+			.orElseThrow(() -> new ApiException(ErrorCode.INTERNAL_SERVER_ERROR));
+		return new JwtUserInfoDto(userId, user.getUserName(), userRole.getRoleId());
 	}
 
 }

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/CommonMockMvcControllerTestSetUp.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/CommonMockMvcControllerTestSetUp.java
@@ -4,12 +4,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.trackery.trackerybackapiserver.config.SecurityConfig;
-import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
+import com.trackery.trackerybackapiserver.domain.config.MockMvcUnitTestSecurityConfig;
 
 /**
  *packageName    : com.trackery.trackerybackapiserver.domain
@@ -24,15 +22,12 @@ import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
  25. 2. 19.        durururuk       최초 생성
  */
 
-@Import(SecurityConfig.class)
+@Import(MockMvcUnitTestSecurityConfig.class)
 @AutoConfigureMockMvc
 @AutoConfigureRestDocs
 public abstract class CommonMockMvcControllerTestSetUp {
 	@Autowired
 	protected MockMvc mockMvc;
-
-	@MockitoBean
-	protected JwtService jwtService;
 
 	protected ObjectMapper objectMapper = new ObjectMapper();
 }

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/CommonMockMvcControllerTestSetUp.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/CommonMockMvcControllerTestSetUp.java
@@ -9,7 +9,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.trackery.trackerybackapiserver.config.SecurityConfig;
-import com.trackery.trackerybackapiserver.domain.common.util.JwtUtil;
+import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
 
 /**
  *packageName    : com.trackery.trackerybackapiserver.domain
@@ -32,7 +32,7 @@ public abstract class CommonMockMvcControllerTestSetUp {
 	protected MockMvc mockMvc;
 
 	@MockitoBean
-	protected JwtUtil jwtUtil;
+	protected JwtService jwtService;
 
 	protected ObjectMapper objectMapper = new ObjectMapper();
 }

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/auth/controller/AuthControllerTest.java
@@ -10,7 +10,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
 
-import com.trackery.trackerybackapiserver.domain.CommonMockMvcControllerTestSetUp;
+import com.trackery.trackerybackapiserver.domain.config.CommonMockMvcControllerTestSetUp;
 import com.trackery.trackerybackapiserver.domain.auth.dto.AuthUserDto;
 import com.trackery.trackerybackapiserver.domain.auth.service.AuthService;
 

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/auth/controller/AuthControllerTest.java
@@ -10,8 +10,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
 
-import com.auth0.jwt.interfaces.Claim;
-import com.auth0.jwt.interfaces.DecodedJWT;
 import com.trackery.trackerybackapiserver.domain.CommonMockMvcControllerTestSetUp;
 import com.trackery.trackerybackapiserver.domain.auth.dto.AuthUserDto;
 import com.trackery.trackerybackapiserver.domain.auth.service.AuthService;
@@ -38,20 +36,6 @@ class AuthControllerTest extends CommonMockMvcControllerTestSetUp {
 
 	@Test
 	void 인증_확인_성공() throws Exception {
-		//TODO 아래 9줄 어떻게 처리할지 수정 필요
-		DecodedJWT decodedJWT = mock(DecodedJWT.class);
-		when(jwtService.verifyJwt(anyString())).thenReturn(decodedJWT);
-		when(decodedJWT.getSubject()).thenReturn("1");
-
-		Claim userRoleClaim = mock(Claim.class);
-		when(decodedJWT.getClaim("role")).thenReturn(userRoleClaim);
-		when(userRoleClaim.asLong()).thenReturn(1L);
-
-		Claim userNameClaim = mock(Claim.class);
-		when(decodedJWT.getClaim("username")).thenReturn(userNameClaim);
-		when(userNameClaim.asString()).thenReturn("abcdefg");
-
-
 		AuthUserDto authUserDto = new AuthUserDto(1L, "abcdefg", 1L);
 		when(authService.toAuthUserDto(any())).thenReturn(authUserDto);
 

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/auth/controller/AuthControllerTest.java
@@ -40,7 +40,7 @@ class AuthControllerTest extends CommonMockMvcControllerTestSetUp {
 	void 인증_확인_성공() throws Exception {
 		//TODO 아래 9줄 어떻게 처리할지 수정 필요
 		DecodedJWT decodedJWT = mock(DecodedJWT.class);
-		when(jwtUtil.verifyJwt(anyString())).thenReturn(decodedJWT);
+		when(jwtService.verifyJwt(anyString())).thenReturn(decodedJWT);
 		when(decodedJWT.getSubject()).thenReturn("1");
 
 		Claim userRoleClaim = mock(Claim.class);

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/common/controller/ExceptionHandlerFilterTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/common/controller/ExceptionHandlerFilterTest.java
@@ -6,18 +6,23 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.trackery.trackerybackapiserver.config.SecurityConfig;
 import com.trackery.trackerybackapiserver.config.filter.JwtResolverFilter;
-import com.trackery.trackerybackapiserver.domain.CommonMockMvcControllerTestSetUp;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
+import com.trackery.trackerybackapiserver.domain.jwt.service.JwtRedisService;
+import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
+import com.trackery.trackerybackapiserver.domain.user.service.UserService;
 
 /**
  * packageName    : com.trackery.trackerybackapiserver.domain.common.controller
@@ -31,11 +36,23 @@ import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiEx
  * 25. 3. 14.        durururuk      최초 생성
  */
 
+@Import(SecurityConfig.class)
 @WebMvcTest(TestController.class)
-@AutoConfigureMockMvc
-class ExceptionHandlerFilterTest extends CommonMockMvcControllerTestSetUp {
+class ExceptionHandlerFilterTest {
+	@Autowired
+	private MockMvc mockMvc;
+
 	@MockitoBean
 	private JwtResolverFilter jwtResolverFilter;
+
+	@MockitoBean
+	private UserService userService;
+
+	@MockitoBean
+	private JwtRedisService jwtRedisService;
+
+	@MockitoBean
+	private JwtService jwtService;
 
 	@Test
 	void JWT_필터_예외_발생_시_처리_테스트() throws Exception {

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/common/controller/ExceptionHandlerFilterTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/common/controller/ExceptionHandlerFilterTest.java
@@ -14,7 +14,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.trackery.trackerybackapiserver.config.JwtFilter;
+import com.trackery.trackerybackapiserver.config.filter.JwtResolverFilter;
 import com.trackery.trackerybackapiserver.domain.CommonMockMvcControllerTestSetUp;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
@@ -35,11 +35,11 @@ import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiEx
 @AutoConfigureMockMvc
 class ExceptionHandlerFilterTest extends CommonMockMvcControllerTestSetUp {
 	@MockitoBean
-	private JwtFilter jwtFilter;
+	private JwtResolverFilter jwtResolverFilter;
 
 	@Test
 	void JWT_필터_예외_발생_시_처리_테스트() throws Exception {
-		doThrow(new ApiException(ErrorCode.UNAUTHORIZED_JWT_VERIFY_FAILED)).when(jwtFilter)
+		doThrow(new ApiException(ErrorCode.UNAUTHORIZED_JWT_VERIFY_FAILED)).when(jwtResolverFilter)
 			.doFilter(any(), any(), any());
 
 		ResultActions result = mockMvc.perform(get("/test"));

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/common/util/CookieUtilTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/common/util/CookieUtilTest.java
@@ -1,11 +1,18 @@
 package com.trackery.trackerybackapiserver.domain.common.util;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import java.time.Duration;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.ResponseCookie;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * packageName    : com.trackery.trackerybackapiserver.domain.common.util
@@ -16,8 +23,9 @@ import org.springframework.http.ResponseCookie;
  * ===========================================================
  * DATE              AUTHOR             NOTE
  * -----------------------------------------------------------
- * 25. 2. 26.        durururuk      최초 생성
- * 25. 2. 26.        durururuk      액세스토큰 쿠키 생성 성공 케이스 단위테스트 작성
+ * 25. 2. 26.       durururuk       최초 생성
+ * 25. 2. 26.       durururuk       액세스토큰 쿠키 생성 성공 케이스 단위테스트 작성
+ * 25. 4. 01.		durururuk		extractCookie 테스트 코드 작성
  */
 class CookieUtilTest {
 
@@ -33,5 +41,37 @@ class CookieUtilTest {
 		assertTrue(cookie.isHttpOnly());
 		assertEquals("Strict", cookie.getSameSite());
 		assertEquals("/", cookie.getPath());
+	}
+
+	@Nested
+	@DisplayName("쿠키 추출 테스트")
+	class extractCookieValueTest{
+		HttpServletRequest request;
+
+		@BeforeEach
+		void setUp() {
+			request = mock(HttpServletRequest.class);
+		}
+
+		@Test
+		@DisplayName("성공 - 쿠키 추출 성공")
+		void success() {
+			Cookie cookie = new Cookie("testCookie", "testValue");
+			when(request.getCookies()).thenReturn(new Cookie[] {cookie});
+
+			String result = CookieUtil.extractCookieValue(request, "testCookie", () -> "default");
+
+			assertEquals("testValue", result);
+		}
+
+		@Test
+		@DisplayName("성공 - 대체 값 반환 성공")
+		void success_missingCookie() {
+			when(request.getCookies()).thenReturn(null);
+
+			String result = CookieUtil.extractCookieValue(request, "missingCookie", () -> "default");
+
+			assertEquals("default", result);
+		}
 	}
 }

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/common/util/CookieUtilTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/common/util/CookieUtilTest.java
@@ -2,6 +2,8 @@ package com.trackery.trackerybackapiserver.domain.common.util;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.time.Duration;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.http.ResponseCookie;
 
@@ -23,7 +25,7 @@ class CookieUtilTest {
 	void 액세스_토큰_쿠키_생성_성공() {
 		String jwt = "jwt";
 
-		ResponseCookie cookie = CookieUtil.createHttpOnlyCookie("accessToken" ,jwt);
+		ResponseCookie cookie = CookieUtil.createHttpOnlyCookie("accessToken" ,jwt, Duration.ofMinutes(60));
 
 		assertNotNull(cookie);
 		assertEquals("accessToken", cookie.getName());

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/common/util/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/common/util/GlobalExceptionHandlerTest.java
@@ -18,7 +18,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
-import com.trackery.trackerybackapiserver.domain.CommonMockMvcControllerTestSetUp;
+import com.trackery.trackerybackapiserver.domain.config.CommonMockMvcControllerTestSetUp;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
 import com.trackery.trackerybackapiserver.domain.user.controller.UserController;

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/common/util/JwtServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/common/util/JwtServiceTest.java
@@ -4,8 +4,10 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 
 import com.auth0.jwt.interfaces.DecodedJWT;
+import com.trackery.trackerybackapiserver.domain.jwt.service.JwtRedisService;
 import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
 
 import lombok.extern.slf4j.Slf4j;
@@ -27,13 +29,16 @@ import lombok.extern.slf4j.Slf4j;
 class JwtServiceTest {
 	private JwtService jwtService;
 
+	@Mock
+	private JwtRedisService jwtRedisService;
+
 	//운영환경에서 쓰이지 않는 테스트용 시크릿키입니다.
 	final String jwtSecretKeyForTest = "and0c2VjcmV0a2V5Zm9ydGVzdA==";
 	final String fakeProjectDomain = "www.a.com";
 
 	@BeforeEach
 	void setUp() {
-		jwtService = new JwtService(jwtSecretKeyForTest, fakeProjectDomain);
+		jwtService = new JwtService(jwtRedisService, jwtSecretKeyForTest, fakeProjectDomain);
 	}
 
 	@Test

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/common/util/JwtServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/common/util/JwtServiceTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.auth0.jwt.interfaces.DecodedJWT;
+import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -23,8 +24,8 @@ import lombok.extern.slf4j.Slf4j;
  25. 2. 20.		   durururuk       jwt 생성 및 검증 테스트 코드 추가
  */
 @Slf4j
-class JwtUtilTest {
-	private JwtUtil jwtUtil;
+class JwtServiceTest {
+	private JwtService jwtService;
 
 	//운영환경에서 쓰이지 않는 테스트용 시크릿키입니다.
 	final String jwtSecretKeyForTest = "and0c2VjcmV0a2V5Zm9ydGVzdA==";
@@ -32,14 +33,14 @@ class JwtUtilTest {
 
 	@BeforeEach
 	void setUp() {
-		jwtUtil = new JwtUtil(jwtSecretKeyForTest, fakeProjectDomain);
+		jwtService = new JwtService(jwtSecretKeyForTest, fakeProjectDomain);
 	}
 
 	@Test
 	void JWT_액세스_토큰_생성_검증_테스트() {
-		String token = jwtUtil.generateAccessToken(1L, "abcdefg", 1L);
+		String token = jwtService.generateAccessToken(1L, "abcdefg", 1L);
 
-		DecodedJWT decodedJwt = jwtUtil.verifyJwt(token);
+		DecodedJWT decodedJwt = jwtService.verifyJwt(token);
 
 		assertEquals(1L, Long.valueOf(decodedJwt.getSubject()));
 		assertEquals("abcdefg", decodedJwt.getClaim("username").asString());
@@ -49,9 +50,9 @@ class JwtUtilTest {
 	@Test
 	void JWT_이메일_토큰_생성_테스트() {
 		String email = "a@a.com";
-		String token = jwtUtil.generateTokenWithSubject(email);
+		String token = jwtService.generateTokenWithSubject(email);
 
-		DecodedJWT decodedJWT = jwtUtil.verifyJwt(token);
+		DecodedJWT decodedJWT = jwtService.verifyJwt(token);
 
 		assertEquals(fakeProjectDomain, decodedJWT.getIssuer());
 		assertEquals(email, decodedJWT.getSubject());

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/config/CommonMockMvcControllerTestSetUp.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/config/CommonMockMvcControllerTestSetUp.java
@@ -1,4 +1,4 @@
-package com.trackery.trackerybackapiserver.domain;
+package com.trackery.trackerybackapiserver.domain.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
@@ -7,7 +7,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.trackery.trackerybackapiserver.domain.config.MockMvcUnitTestSecurityConfig;
 
 /**
  *packageName    : com.trackery.trackerybackapiserver.domain

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/config/MockMvcUnitTestSecurityConfig.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/config/MockMvcUnitTestSecurityConfig.java
@@ -1,0 +1,30 @@
+package com.trackery.trackerybackapiserver.domain.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * packageName    : com.trackery.trackerybackapiserver.domain
+ * fileName       : MockMvcUnitTestSecurityConfig
+ * author         : durururuk
+ * date           : 25. 3. 29.
+ * description    :
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 25. 3. 29.        durururuk      최초 생성
+ */
+@TestConfiguration
+public class MockMvcUnitTestSecurityConfig {
+
+	@Bean
+	public SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+		return http
+			.csrf(AbstractHttpConfigurer::disable)
+			.authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+			.build();
+	}
+}

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/config/MockMvcUnitTestSecurityConfig.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/config/MockMvcUnitTestSecurityConfig.java
@@ -11,7 +11,8 @@ import org.springframework.security.web.SecurityFilterChain;
  * fileName       : MockMvcUnitTestSecurityConfig
  * author         : durururuk
  * date           : 25. 3. 29.
- * description    :
+ * description    : MockMvc를 이용한 컨트롤러 단위 테스트를 하기위해
+ * 					따로 사용될 설정 클래스입니다.
  * ===========================================================
  * DATE              AUTHOR             NOTE
  * -----------------------------------------------------------
@@ -19,7 +20,6 @@ import org.springframework.security.web.SecurityFilterChain;
  */
 @TestConfiguration
 public class MockMvcUnitTestSecurityConfig {
-
 	@Bean
 	public SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
 		return http

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtRedisServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtRedisServiceTest.java
@@ -1,8 +1,12 @@
 
 package com.trackery.trackerybackapiserver.domain.jwt.service;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -13,6 +17,7 @@ import org.springframework.data.redis.core.ValueOperations;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.RefreshTokenDto;
 
 /**
@@ -24,7 +29,8 @@ import com.trackery.trackerybackapiserver.domain.jwt.dto.RefreshTokenDto;
  * ===========================================================
  * DATE              AUTHOR             NOTE
  * -----------------------------------------------------------
- * 25. 3. 28.        durururuk      최초 생성
+ * 25. 3. 28.       durururuk      최초 생성
+ * 25. 3. 29.		durururuk	   테스트 코드 작성
  */
 @ExtendWith(MockitoExtension.class)
 class JwtRedisServiceTest {
@@ -40,20 +46,83 @@ class JwtRedisServiceTest {
 	@Mock
 	private ObjectMapper objectMapper;
 
-	@Test
-	void 리프레시토큰_저장_테스트_성공() throws JsonProcessingException {
-		// given
-		RefreshTokenDto refreshTokenDto = new RefreshTokenDto("refreshToken", "jid", "subject");
-		String redisKey = "jwtRefreshToken:" + refreshTokenDto.refreshToken();
-		String expectedJson = "refreshTokenDtoJson";
+	@Nested
+	@DisplayName("리프레시 토큰 저장")
+	class SaveRefreshTokenTest {
+		private final RefreshTokenDto refreshTokenDto = new RefreshTokenDto("refreshToken", "jid", "subject");
+		private final String redisKey = "jwtRefreshToken:" + refreshTokenDto.refreshToken();
 
-		when(objectMapper.writeValueAsString(refreshTokenDto)).thenReturn(expectedJson);
-		when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-		doNothing().when(valueOperations).set(redisKey, expectedJson);
+		@Test
+		@DisplayName("성공")
+		void success() throws JsonProcessingException {
+			when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+			String expectedJson = "refreshTokenDtoJson";
+			when(objectMapper.writeValueAsString(refreshTokenDto)).thenReturn(expectedJson);
+			doNothing().when(valueOperations).set(redisKey, expectedJson);
 
-		jwtRedisService.saveRefreshToken(refreshTokenDto);
+			jwtRedisService.saveRefreshToken(refreshTokenDto);
 
-		verify(objectMapper, times(1)).writeValueAsString(refreshTokenDto);
-		verify(redisTemplate.opsForValue(), times(1)).set(redisKey, expectedJson);
+			verify(objectMapper, times(1)).writeValueAsString(refreshTokenDto);
+			verify(redisTemplate.opsForValue(), times(1)).set(redisKey, expectedJson);
+		}
+
+		@Test
+		@DisplayName("실패 - json 파싱 에러")
+		void failure_1() throws JsonProcessingException {
+			when(objectMapper.writeValueAsString(refreshTokenDto)).thenThrow(JsonProcessingException.class);
+
+			assertThrows(ApiException.class, () -> jwtRedisService.saveRefreshToken(refreshTokenDto));
+		}
+
+	}
+
+	@Nested
+	@DisplayName("리프레시 토큰 조회")
+	class GetRefreshTokenTest {
+		private final String refreshToken = "<PASSWORD>";
+		private final String expectedJson = "refreshTokenDtoJson";
+		private final RefreshTokenDto refreshTokenDto = new RefreshTokenDto(refreshToken, "jid", "subject");
+
+		@BeforeEach
+		void setUp() {
+			when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+			String redisKey = "jwtRefreshToken:" + refreshToken;
+			when(valueOperations.get(redisKey)).thenReturn(expectedJson);
+		}
+
+		@Test
+		@DisplayName("성공")
+		void success() throws JsonProcessingException {
+			when(objectMapper.readValue(expectedJson, RefreshTokenDto.class)).thenReturn(refreshTokenDto);
+
+			RefreshTokenDto result = jwtRedisService.getRefreshTokenInfo(refreshToken);
+
+			assertEquals(refreshTokenDto, result);
+		}
+
+		@Test
+		@DisplayName("실패 - Json 매핑 에러")
+		void failure_1() throws JsonProcessingException {
+			when(objectMapper.readValue(expectedJson, RefreshTokenDto.class)).thenThrow(JsonProcessingException.class);
+			assertThrows(ApiException.class, () -> jwtRedisService.getRefreshTokenInfo(refreshToken));
+		}
+	}
+
+	@Nested
+	@DisplayName("리프레시 토큰 삭제")
+	class DeleteRefreshTokenTest {
+
+		@Test
+		@DisplayName("성공")
+		void success() {
+			String refreshToken = "<PASSWORD>";
+			String redisKey = "jwtRefreshToken:" + refreshToken;
+			when(redisTemplate.delete(redisKey)).thenReturn(true);
+
+			jwtRedisService.deleteRefreshToken(refreshToken);
+
+			verify(redisTemplate, times(1)).delete(redisKey);
+		}
+
 	}
 }

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtRedisServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtRedisServiceTest.java
@@ -1,0 +1,59 @@
+
+package com.trackery.trackerybackapiserver.domain.jwt.service;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trackery.trackerybackapiserver.domain.jwt.dto.RefreshTokenDto;
+
+/**
+ * packageName    : com.trackery.trackerybackapiserver.domain.jwt.service
+ * fileName       : JwtRedisServiceTest
+ * author         : durururuk
+ * date           : 25. 3. 28.
+ * description    : JwtRedisService 단위테스트
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 25. 3. 28.        durururuk      최초 생성
+ */
+@ExtendWith(MockitoExtension.class)
+class JwtRedisServiceTest {
+	@InjectMocks
+	private JwtRedisService jwtRedisService;
+
+	@Mock
+	private StringRedisTemplate redisTemplate;
+
+	@Mock
+	private ValueOperations<String, String> valueOperations;
+
+	@Mock
+	private ObjectMapper objectMapper;
+
+	@Test
+	void 리프레시토큰_저장_테스트_성공() throws JsonProcessingException {
+		// given
+		RefreshTokenDto refreshTokenDto = new RefreshTokenDto("refreshToken", "jid", "subject");
+		String redisKey = "jwtRefreshToken:" + refreshTokenDto.refreshToken();
+		String expectedJson = "refreshTokenDtoJson";
+
+		when(objectMapper.writeValueAsString(refreshTokenDto)).thenReturn(expectedJson);
+		when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+		doNothing().when(valueOperations).set(redisKey, expectedJson);
+
+		jwtRedisService.saveRefreshToken(refreshTokenDto);
+
+		verify(objectMapper, times(1)).writeValueAsString(refreshTokenDto);
+		verify(redisTemplate.opsForValue(), times(1)).set(redisKey, expectedJson);
+	}
+}

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtServiceTest.java
@@ -50,7 +50,7 @@ class JwtServiceTest {
 
 	@BeforeEach
 	void setUp() {
-		jwtService = new JwtService(jwtRedisService, userService, jwtSecretKeyForTest, fakeProjectDomain);
+		jwtService = new JwtService(jwtRedisService, jwtSecretKeyForTest, fakeProjectDomain);
 	}
 
 	@Test

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtServiceTest.java
@@ -33,6 +33,7 @@ import lombok.extern.slf4j.Slf4j;
  25. 2. 18.        durururuk        최초 생성
  25. 2. 20.		   durururuk        jwt 생성 및 검증 테스트 코드 추가
  25. 4. 01.        durururuk		parseAndVerifyRefreshToken 테스트 코드 작성
+ 25. 4. 01.        durururuk		JWT 검증 실패 시 예외 에러 메시지 수정
  */
 @Slf4j
 @ExtendWith(MockitoExtension.class)
@@ -198,7 +199,7 @@ class JwtServiceTest {
 			ApiException exception = assertThrows(ApiException.class,
 				() -> jwtService.parseAndVerifyRefreshToken(VALID_TOKEN));
 
-			assertEquals(ErrorCode.UNAUTHORIZED, exception.getErrorCode());
+			assertEquals(ErrorCode.UNAUTHORIZED_JWT_VERIFY_FAILED, exception.getErrorCode());
 			verify(jwtRedisService, never()).deleteRefreshToken(VALID_TOKEN);
 		}
 	}

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtServiceTest.java
@@ -1,4 +1,4 @@
-package com.trackery.trackerybackapiserver.domain.common.util;
+package com.trackery.trackerybackapiserver.domain.jwt.service;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -7,8 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 import com.auth0.jwt.interfaces.DecodedJWT;
-import com.trackery.trackerybackapiserver.domain.jwt.service.JwtRedisService;
-import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
+import com.trackery.trackerybackapiserver.domain.jwt.dto.RefreshTokenDto;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -50,6 +49,17 @@ class JwtServiceTest {
 		assertEquals(1L, Long.valueOf(decodedJwt.getSubject()));
 		assertEquals("abcdefg", decodedJwt.getClaim("username").asString());
 		assertEquals(1L, decodedJwt.getClaim("role").asLong());
+	}
+
+	@Test
+	void JWT_리프레시_토큰_생성_검증_테스트_성공() {
+		RefreshTokenDto refreshTokenDto = jwtService.generateRefreshToken(1L);
+
+		DecodedJWT decodedJWT = jwtService.verifyJwt(refreshTokenDto.refreshToken());
+
+		assertEquals(fakeProjectDomain, decodedJWT.getIssuer());
+		assertNotNull(decodedJWT.getId());
+		assertEquals(1L, Long.valueOf(decodedJWT.getSubject()));
 	}
 
 	@Test

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtServiceTest.java
@@ -1,12 +1,20 @@
 package com.trackery.trackerybackapiserver.domain.jwt.service;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.auth0.jwt.interfaces.DecodedJWT;
+import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
+import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
+import com.trackery.trackerybackapiserver.domain.jwt.dto.AuthTokenDto;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.RefreshTokenDto;
 
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +33,7 @@ import lombok.extern.slf4j.Slf4j;
  25. 2. 20.		   durururuk       jwt 생성 및 검증 테스트 코드 추가
  */
 @Slf4j
+@ExtendWith(MockitoExtension.class)
 class JwtServiceTest {
 	private JwtService jwtService;
 
@@ -51,14 +60,44 @@ class JwtServiceTest {
 		assertEquals(1L, decodedJwt.getClaim("role").asLong());
 	}
 
+	@Nested
+	@DisplayName("JWT 검증")
+	class verifyJwtTest {
+		@Test
+		@DisplayName("성공")
+		void success() {
+			String token = jwtService.generateAccessToken(1L, "abcdefg", 1L);
+
+			DecodedJWT decodedJWT = jwtService.verifyJwt(token);
+
+			assertNotNull(decodedJWT);
+			assertEquals("1", decodedJWT.getSubject());
+			assertEquals("abcdefg", decodedJWT.getClaim("username").asString());
+			assertEquals(1L, decodedJWT.getClaim("role").asLong());
+		}
+
+		@Test
+		@DisplayName("실패 - 유효하지 않은 JWT")
+		void failure_1() {
+			String token = "ㅁㄴㅇㄹ";
+
+			ApiException exception = assertThrows(ApiException.class, () -> jwtService.verifyJwt(token));
+
+			assertNotNull(exception);
+			assertEquals(ErrorCode.BAD_REQUEST, exception.getErrorCode());
+		}
+	}
+
+
 	@Test
 	void JWT_리프레시_토큰_생성_검증_테스트_성공() {
+		doNothing().when(jwtRedisService).saveRefreshToken(any(RefreshTokenDto.class));
+
 		RefreshTokenDto refreshTokenDto = jwtService.generateRefreshToken(1L);
 
 		DecodedJWT decodedJWT = jwtService.verifyJwt(refreshTokenDto.refreshToken());
 
 		assertEquals(fakeProjectDomain, decodedJWT.getIssuer());
-		assertNotNull(decodedJWT.getId());
 		assertEquals(1L, Long.valueOf(decodedJWT.getSubject()));
 	}
 
@@ -72,4 +111,39 @@ class JwtServiceTest {
 		assertEquals(fakeProjectDomain, decodedJWT.getIssuer());
 		assertEquals(email, decodedJWT.getSubject());
 	}
+
+	@Nested
+	@DisplayName("인증 토큰 DTO 변환")
+	class generateAccessTokenAndRefreshTokenTest {
+		private Long userId;
+		private String userName;
+		private Long roleId;
+
+		@BeforeEach
+		void setUp() {
+			userId = 1L;
+			userName = "abcdefg";
+			roleId = 1L;
+		}
+
+		@Test
+		@DisplayName("성공")
+		void success() {
+			doNothing().when(jwtRedisService).saveRefreshToken(any(RefreshTokenDto.class));
+
+			AuthTokenDto authTokenDto = jwtService.generateAccessTokenAndRefreshToken(userId, userName, roleId);
+
+			DecodedJWT decodedAccessToken = jwtService.verifyJwt(authTokenDto.accessToken());
+			DecodedJWT decodedRefreshToken = jwtService.verifyJwt(authTokenDto.refreshToken());
+
+			assertNotNull(authTokenDto.accessToken());
+			assertNotNull(authTokenDto.refreshToken());
+			assertEquals("1", decodedAccessToken.getSubject());
+			assertEquals("abcdefg", decodedAccessToken.getClaim("username").asString());
+			assertEquals(1L, decodedAccessToken.getClaim("role").asLong());
+			assertEquals(fakeProjectDomain, decodedRefreshToken.getIssuer());
+		}
+	}
+
+
 }

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtServiceTest.java
@@ -16,6 +16,7 @@ import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.AuthTokenDto;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.RefreshTokenDto;
+import com.trackery.trackerybackapiserver.domain.user.service.UserService;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -40,13 +41,16 @@ class JwtServiceTest {
 	@Mock
 	private JwtRedisService jwtRedisService;
 
+	@Mock
+	private UserService userService;
+
 	//운영환경에서 쓰이지 않는 테스트용 시크릿키입니다.
 	final String jwtSecretKeyForTest = "and0c2VjcmV0a2V5Zm9ydGVzdA==";
 	final String fakeProjectDomain = "www.a.com";
 
 	@BeforeEach
 	void setUp() {
-		jwtService = new JwtService(jwtRedisService, jwtSecretKeyForTest, fakeProjectDomain);
+		jwtService = new JwtService(jwtRedisService, userService, jwtSecretKeyForTest, fakeProjectDomain);
 	}
 
 	@Test

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.auth0.jwt.interfaces.DecodedJWT;
@@ -16,12 +17,11 @@ import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.AuthTokenDto;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.RefreshTokenDto;
-import com.trackery.trackerybackapiserver.domain.user.service.UserService;
 
 import lombok.extern.slf4j.Slf4j;
 
 /**
- *packageName    : com.trackery.trackerybackapiserver.domain.common.util
+ packageName    : com.trackery.trackerybackapiserver.domain.common.util
 
  fileName       : JwtUtilTest
  author         : durururuk
@@ -30,8 +30,9 @@ import lombok.extern.slf4j.Slf4j;
  ===========================================================
  DATE              AUTHOR             NOTE
  -----------------------------------------------------------
- 25. 2. 18.        durururuk       최초 생성
- 25. 2. 20.		   durururuk       jwt 생성 및 검증 테스트 코드 추가
+ 25. 2. 18.        durururuk        최초 생성
+ 25. 2. 20.		   durururuk        jwt 생성 및 검증 테스트 코드 추가
+ 25. 4. 01.        durururuk		parseAndVerifyRefreshToken 테스트 코드 작성
  */
 @Slf4j
 @ExtendWith(MockitoExtension.class)
@@ -41,9 +42,6 @@ class JwtServiceTest {
 	@Mock
 	private JwtRedisService jwtRedisService;
 
-	@Mock
-	private UserService userService;
-
 	//운영환경에서 쓰이지 않는 테스트용 시크릿키입니다.
 	final String jwtSecretKeyForTest = "and0c2VjcmV0a2V5Zm9ydGVzdA==";
 	final String fakeProjectDomain = "www.a.com";
@@ -51,6 +49,7 @@ class JwtServiceTest {
 	@BeforeEach
 	void setUp() {
 		jwtService = new JwtService(jwtRedisService, jwtSecretKeyForTest, fakeProjectDomain);
+		jwtService = Mockito.spy(jwtService);
 	}
 
 	@Test
@@ -91,7 +90,6 @@ class JwtServiceTest {
 			assertEquals(ErrorCode.BAD_REQUEST, exception.getErrorCode());
 		}
 	}
-
 
 	@Test
 	void JWT_리프레시_토큰_생성_검증_테스트_성공() {
@@ -149,5 +147,60 @@ class JwtServiceTest {
 		}
 	}
 
+	@Nested
+	@DisplayName("리프레시 토큰 파싱 및 검증 테스트")
+	class parseAndVerifyRefreshTokenTests {
+		DecodedJWT decodedJWT = mock(DecodedJWT.class);
+
+		private final String VALID_TOKEN = "validRefreshToken";
+		private final String INVALID_TOKEN = "invalidRefreshToken";
+
+		private final String SUBJECT = "1";
+
+		@Test
+		@DisplayName("성공")
+		void success() {
+			String VALID_JID = "validJid";
+			RefreshTokenDto refreshTokenDto = new RefreshTokenDto(VALID_TOKEN, VALID_JID, SUBJECT);
+
+			doReturn(decodedJWT).when(jwtService).verifyJwt(VALID_TOKEN);
+			when(jwtRedisService.getRefreshTokenInfo(VALID_TOKEN)).thenReturn(refreshTokenDto);
+			when(decodedJWT.getId()).thenReturn(VALID_JID);
+
+			Long userId = jwtService.parseAndVerifyRefreshToken(VALID_TOKEN);
+
+			assertEquals(1L, userId);
+			verify(jwtRedisService).deleteRefreshToken(VALID_TOKEN);
+		}
+
+		@Test
+		@DisplayName("실패 - 유효하지 않은 리프레시 토큰")
+		void shouldThrowUnauthorizedExceptionForInvalidRefreshToken() {
+			doThrow(new ApiException(ErrorCode.BAD_REQUEST)).when(jwtService).verifyJwt(INVALID_TOKEN);
+
+			ApiException exception = assertThrows(ApiException.class,
+				() -> jwtService.parseAndVerifyRefreshToken(INVALID_TOKEN));
+
+			assertEquals(ErrorCode.BAD_REQUEST, exception.getErrorCode());
+			verify(jwtRedisService, never()).deleteRefreshToken(INVALID_TOKEN);
+		}
+
+		@Test
+		@DisplayName("실패 - 유효하지 않은 JID")
+		void shouldThrowUnauthorizedExceptionForInvalidJid() {
+			String INVALID_JID = "invalidJid";
+			RefreshTokenDto refreshTokenDto = new RefreshTokenDto(VALID_TOKEN, INVALID_JID, SUBJECT);
+
+			doReturn(decodedJWT).when(jwtService).verifyJwt(VALID_TOKEN);
+			when(jwtRedisService.getRefreshTokenInfo(VALID_TOKEN)).thenReturn(refreshTokenDto);
+			when(decodedJWT.getId()).thenReturn("differentJid");
+
+			ApiException exception = assertThrows(ApiException.class,
+				() -> jwtService.parseAndVerifyRefreshToken(VALID_TOKEN));
+
+			assertEquals(ErrorCode.UNAUTHORIZED, exception.getErrorCode());
+			verify(jwtRedisService, never()).deleteRefreshToken(VALID_TOKEN);
+		}
+	}
 
 }

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/mail/controller/MailControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/mail/controller/MailControllerTest.java
@@ -18,7 +18,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.ResultActions;
 
-import com.trackery.trackerybackapiserver.domain.CommonMockMvcControllerTestSetUp;
+import com.trackery.trackerybackapiserver.domain.config.CommonMockMvcControllerTestSetUp;
 import com.trackery.trackerybackapiserver.domain.common.dto.VerifyEmailDto;
 import com.trackery.trackerybackapiserver.domain.mail.service.MailService;
 

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/mail/service/MailServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/mail/service/MailServiceTest.java
@@ -16,7 +16,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
-import com.trackery.trackerybackapiserver.domain.common.util.JwtUtil;
+import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
 import com.trackery.trackerybackapiserver.domain.user.entity.User;
 import com.trackery.trackerybackapiserver.domain.user.mapper.UserMapper;
 
@@ -42,7 +42,7 @@ class MailServiceTest {
 	private StringRedisTemplate redisTemplate;
 
 	@Mock
-	private JwtUtil jwtUtil;
+	private JwtService jwtService;
 
 	@Mock
 	private ValueOperations<String, String> valueOperations;
@@ -82,7 +82,7 @@ class MailServiceTest {
 		String emailToken = "mockedEmailToken";
 
 		when(valueOperations.get(redisKey)).thenReturn(authNumber);
-		when(jwtUtil.generateTokenWithSubject(email)).thenReturn(emailToken);
+		when(jwtService.generateTokenWithSubject(email)).thenReturn(emailToken);
 		when(redisTemplate.delete(redisKey)).thenReturn(true);
 		when(redisTemplate.opsForValue()).thenReturn(valueOperations);
 
@@ -90,7 +90,7 @@ class MailServiceTest {
 
 		assertEquals(emailToken, resultToken);
 		verify(valueOperations, times(1)).get(redisKey);
-		verify(jwtUtil, times(1)).generateTokenWithSubject(email);
+		verify(jwtService, times(1)).generateTokenWithSubject(email);
 		verify(redisTemplate, times(1)).delete(redisKey);
 	}
 

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/user/controller/OAuthControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/user/controller/OAuthControllerTest.java
@@ -15,7 +15,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
 
-import com.trackery.trackerybackapiserver.domain.CommonMockMvcControllerTestSetUp;
+import com.trackery.trackerybackapiserver.domain.config.CommonMockMvcControllerTestSetUp;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
 import com.trackery.trackerybackapiserver.domain.user.dto.OAuthLinkRequestDto;

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/user/controller/UserControllerTest.java
@@ -5,6 +5,8 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import org.mockito.Spy;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -101,7 +103,12 @@ class UserControllerTest extends CommonMockMvcControllerTestSetUp {
 		ReflectionTestUtils.setField(loginDto, "userName", "abcdefg");
 		ReflectionTestUtils.setField(loginDto, "password", "Qwerasdf1234!");
 
-		when(userService.login(any())).thenReturn("jwt");
+		String accessToken = "accessToken";
+		String refreshToken = "refreshToken";
+
+		List<String> expectedResult = List.of(accessToken, refreshToken);
+
+		when(userService.login(any())).thenReturn(expectedResult);
 
 		ResultActions result = mockMvc
 			.perform(post("/api/users/login")
@@ -113,6 +120,9 @@ class UserControllerTest extends CommonMockMvcControllerTestSetUp {
 			.andExpect(status().isOk())
 			.andExpect(cookie().exists("accessToken"))
 			.andExpect(cookie().httpOnly("accessToken", true))
-			.andExpect(cookie().value("accessToken", "jwt"));
+			.andExpect(cookie().value("accessToken", accessToken))
+			.andExpect(cookie().exists("refreshToken"))
+			.andExpect(cookie().httpOnly("refreshToken", true))
+			.andExpect(cookie().value("refreshToken", refreshToken));
 	}
 }

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/user/controller/UserControllerTest.java
@@ -15,7 +15,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
-import com.trackery.trackerybackapiserver.domain.CommonMockMvcControllerTestSetUp;
+import com.trackery.trackerybackapiserver.domain.config.CommonMockMvcControllerTestSetUp;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.AuthTokenDto;
 import com.trackery.trackerybackapiserver.domain.user.dto.UserLoginDto;
 import com.trackery.trackerybackapiserver.domain.user.dto.UserNameAvailabilityResponseDto;

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/user/controller/UserControllerTest.java
@@ -62,10 +62,13 @@ class UserControllerTest extends CommonMockMvcControllerTestSetUp {
 		ReflectionTestUtils.setField(registerDto, "nickname", "김커피");
 		ReflectionTestUtils.setField(registerDto, "password", "Qwerasdf1234!!asdf");
 
+		String accessToken = "accessToken";
+		String refreshToken = "refreshToken";
+		List<String> tokens = List.of(accessToken, refreshToken);
 		String emailToken = "emailJwt";
 		String userNameToken = "userNameJwt";
 
-		when(userService.registerUser(eq(emailToken), eq(userNameToken), any(UserRegisterDto.class))).thenReturn("accessJwt");
+		when(userService.registerUser(eq(emailToken), eq(userNameToken), any(UserRegisterDto.class))).thenReturn(tokens);
 
 		ResultActions result = mockMvc
 			.perform(post("/api/users/register")
@@ -80,7 +83,10 @@ class UserControllerTest extends CommonMockMvcControllerTestSetUp {
 			.andExpect(status().isCreated())
 			.andExpect(cookie().exists("accessToken"))
 			.andExpect(cookie().httpOnly("accessToken", true))
-			.andExpect(cookie().value("accessToken", "accessJwt"));
+			.andExpect(cookie().value("accessToken", accessToken))
+			.andExpect(cookie().exists("refreshToken"))
+			.andExpect(cookie().httpOnly("refreshToken", true))
+			.andExpect(cookie().value("refreshToken", refreshToken));
 	}
 
 	@Test

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/user/controller/UserControllerTest.java
@@ -5,15 +5,11 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import java.util.List;
-
 import org.junit.jupiter.api.Test;
 import org.mockito.Spy;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
@@ -42,9 +38,7 @@ import jakarta.servlet.http.Cookie;
  25. 2. 14.        durururuk       로그인 컨트롤러 테스트 코드 작성
  */
 
-@WithMockUser
 @WebMvcTest(UserController.class)
-@AutoConfigureMockMvc(addFilters = false)
 class UserControllerTest extends CommonMockMvcControllerTestSetUp {
 	@Autowired
 	private MockMvc mockMvc;
@@ -69,7 +63,8 @@ class UserControllerTest extends CommonMockMvcControllerTestSetUp {
 		String emailToken = "emailJwt";
 		String userNameToken = "userNameJwt";
 
-		when(userService.registerUser(eq(emailToken), eq(userNameToken), any(UserRegisterDto.class))).thenReturn(authTokenDto);
+		when(userService.registerUser(eq(emailToken), eq(userNameToken), any(UserRegisterDto.class))).thenReturn(
+			authTokenDto);
 
 		ResultActions result = mockMvc
 			.perform(post("/api/users/register")

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/user/controller/UserControllerTest.java
@@ -20,6 +20,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 import com.trackery.trackerybackapiserver.domain.CommonMockMvcControllerTestSetUp;
+import com.trackery.trackerybackapiserver.domain.jwt.dto.AuthTokenDto;
 import com.trackery.trackerybackapiserver.domain.user.dto.UserLoginDto;
 import com.trackery.trackerybackapiserver.domain.user.dto.UserNameAvailabilityResponseDto;
 import com.trackery.trackerybackapiserver.domain.user.dto.UserRegisterDto;
@@ -64,11 +65,11 @@ class UserControllerTest extends CommonMockMvcControllerTestSetUp {
 
 		String accessToken = "accessToken";
 		String refreshToken = "refreshToken";
-		List<String> tokens = List.of(accessToken, refreshToken);
+		AuthTokenDto authTokenDto = new AuthTokenDto(accessToken, refreshToken);
 		String emailToken = "emailJwt";
 		String userNameToken = "userNameJwt";
 
-		when(userService.registerUser(eq(emailToken), eq(userNameToken), any(UserRegisterDto.class))).thenReturn(tokens);
+		when(userService.registerUser(eq(emailToken), eq(userNameToken), any(UserRegisterDto.class))).thenReturn(authTokenDto);
 
 		ResultActions result = mockMvc
 			.perform(post("/api/users/register")
@@ -111,10 +112,9 @@ class UserControllerTest extends CommonMockMvcControllerTestSetUp {
 
 		String accessToken = "accessToken";
 		String refreshToken = "refreshToken";
+		AuthTokenDto authTokenDto = new AuthTokenDto(accessToken, refreshToken);
 
-		List<String> expectedResult = List.of(accessToken, refreshToken);
-
-		when(userService.login(any())).thenReturn(expectedResult);
+		when(userService.login(any())).thenReturn(authTokenDto);
 
 		ResultActions result = mockMvc
 			.perform(post("/api/users/login")

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/user/service/OAuthServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/user/service/OAuthServiceTest.java
@@ -13,7 +13,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import com.trackery.trackerybackapiserver.domain.common.util.JwtUtil;
+import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
 import com.trackery.trackerybackapiserver.domain.user.client.OAuthClient;
 import com.trackery.trackerybackapiserver.domain.user.dto.OAuthLoginDto;
 import com.trackery.trackerybackapiserver.domain.user.dto.OAuthUserInfoDto;
@@ -52,7 +52,7 @@ class OAuthServiceTest {
 	private UserRoleMapper userRoleMapper;
 
 	@Mock
-	private JwtUtil jwtUtil;
+	private JwtService jwtService;
 
 	@Mock
 	private OAuthClient oAuthClient;
@@ -107,7 +107,7 @@ class OAuthServiceTest {
 		when(oAuthMapper.findByProviderAndProviderId(anyString(), anyString())).thenReturn(Optional.of(oAuth));
 		when(userMapper.findByUserId(anyLong())).thenReturn(Optional.of(user));
 		when(userRoleMapper.findByUserId(anyLong())).thenReturn(Optional.of(userRole));
-		when(jwtUtil.generateAccessToken(anyLong(), anyString(), anyLong())).thenReturn("jwt_token");
+		when(jwtService.generateAccessToken(anyLong(), anyString(), anyLong())).thenReturn("jwt_token");
 
 		// when
 		OAuthService.OAuthLoginResult result = oAuthService.processOAuthLogin(oAuthLoginDto);
@@ -121,7 +121,7 @@ class OAuthServiceTest {
 		verify(oAuthMapper).findByProviderAndProviderId(anyString(), anyString());
 		verify(userMapper).findByUserId(anyLong());
 		verify(userRoleMapper).findByUserId(anyLong());
-		verify(jwtUtil).generateAccessToken(anyLong(), anyString(), anyLong());
+		verify(jwtService).generateAccessToken(anyLong(), anyString(), anyLong());
 	}
 
 	@Test
@@ -160,7 +160,7 @@ class OAuthServiceTest {
 		when(oAuthMapper.findByProviderAndProviderId(anyString(), anyString())).thenReturn(Optional.empty());
 		when(userMapper.findByEmail(anyString())).thenReturn(Optional.of(user));
 		when(userRoleMapper.findByUserId(anyLong())).thenReturn(Optional.of(userRole));
-		when(jwtUtil.generateAccessToken(anyLong(), anyString(), anyLong())).thenReturn("jwt_token");
+		when(jwtService.generateAccessToken(anyLong(), anyString(), anyLong())).thenReturn("jwt_token");
 
 		// when
 		OAuthService.OAuthLoginResult result = oAuthService.processOAuthLogin(oAuthLoginDto);
@@ -175,7 +175,7 @@ class OAuthServiceTest {
 		verify(userMapper).findByEmail(anyString());
 		verify(oAuthMapper).insertOAuth(any(OAuth.class));
 		verify(userRoleMapper).findByUserId(anyLong());
-		verify(jwtUtil).generateAccessToken(anyLong(), anyString(), anyLong());
+		verify(jwtService).generateAccessToken(anyLong(), anyString(), anyLong());
 	}
 
 	@Test
@@ -194,7 +194,7 @@ class OAuthServiceTest {
 		}).when(userMapper).insertUser(any(User.class));
 
 		when(userRoleMapper.findByUserId(anyLong())).thenReturn(Optional.of(userRole));
-		when(jwtUtil.generateAccessToken(anyLong(), anyString(), anyLong())).thenReturn("jwt_token");
+		when(jwtService.generateAccessToken(anyLong(), anyString(), anyLong())).thenReturn("jwt_token");
 
 		// when
 		OAuthService.OAuthLoginResult result = oAuthService.processOAuthLogin(oAuthLoginDto);
@@ -211,6 +211,6 @@ class OAuthServiceTest {
 		verify(userRoleMapper).insertUserRole(any(UserRole.class));
 		verify(oAuthMapper).insertOAuth(any(OAuth.class));
 		verify(userRoleMapper).findByUserId(anyLong());
-		verify(jwtUtil).generateAccessToken(anyLong(), anyString(), anyLong());
+		verify(jwtService).generateAccessToken(anyLong(), anyString(), anyLong());
 	}
 }

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/user/service/UserServiceTest.java
@@ -3,6 +3,7 @@ package com.trackery.trackerybackapiserver.domain.user.service;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -15,8 +16,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.auth0.jwt.interfaces.DecodedJWT;
-import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
 import com.trackery.trackerybackapiserver.domain.common.util.PasswordUtil;
+import com.trackery.trackerybackapiserver.domain.jwt.dto.RefreshTokenDto;
+import com.trackery.trackerybackapiserver.domain.jwt.service.JwtRedisService;
+import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
 import com.trackery.trackerybackapiserver.domain.user.dto.UserLoginDto;
 import com.trackery.trackerybackapiserver.domain.user.dto.UserNameAvailabilityResponseDto;
 import com.trackery.trackerybackapiserver.domain.user.dto.UserRegisterDto;
@@ -56,6 +59,9 @@ class UserServiceTest {
 	@Mock
 	private JwtService jwtService;
 
+	@Mock
+	private JwtRedisService jwtRedisService;
+
 	@Test
 	void 회원가입_성공() {
 		try (MockedStatic<PasswordUtil> mockedStatic = mockStatic(PasswordUtil.class)) {
@@ -89,7 +95,7 @@ class UserServiceTest {
 
 			when(jwtService.generateAccessToken(anyLong(), anyString(), anyLong())).thenReturn("jwt token");
 
-			String result =  userService.registerUser(emailToken, userNameToken, registerDto);
+			String result = userService.registerUser(emailToken, userNameToken, registerDto);
 
 			assertEquals("jwt token", result);
 
@@ -136,14 +142,21 @@ class UserServiceTest {
 			.roleId(1L)
 			.build();
 
+		String accessToken = "access token";
+		String refreshToken = "refresh token";
+
 		when(userMapper.findByUserName(anyString())).thenReturn(Optional.of(user));
 		when(userRoleMapper.findByUserId(anyLong())).thenReturn(Optional.of(userRole));
 
-		when(jwtService.generateAccessToken(anyLong(), anyString(), anyLong())).thenReturn("jwt token");
+		when(jwtService.generateAccessToken(anyLong(), anyString(), anyLong())).thenReturn(accessToken);
+		when(jwtService.generateRefreshToken(anyLong())).thenReturn(
+			new RefreshTokenDto(refreshToken, "jid", "userId"));
 
-		String result = userService.login(loginDto);
+		doNothing().when(jwtRedisService).saveRefreshToken(any(RefreshTokenDto.class));
 
-		assertEquals("jwt token", result);
+		List<String> result = userService.login(loginDto);
+
+		assertEquals(List.of(accessToken, refreshToken), result);
 		verify(userMapper, times(1)).findByUserName(anyString());
 		verify(userRoleMapper, times(1)).findByUserId(anyLong());
 	}

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/user/service/UserServiceTest.java
@@ -17,6 +17,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.trackery.trackerybackapiserver.domain.common.util.PasswordUtil;
+import com.trackery.trackerybackapiserver.domain.jwt.dto.AuthTokenDto;
 import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
 import com.trackery.trackerybackapiserver.domain.user.dto.UserLoginDto;
 import com.trackery.trackerybackapiserver.domain.user.dto.UserNameAvailabilityResponseDto;
@@ -90,14 +91,14 @@ class UserServiceTest {
 
 			String accessToken = "accessToken";
 			String refreshToken = "refreshToken";
-			List<String> tokens = List.of(accessToken, refreshToken);
+			AuthTokenDto authTokenDto = new AuthTokenDto(accessToken, refreshToken);
 
-			when(jwtService.generateAccessTokenAndRefreshToken(anyLong(), anyString(), anyLong())).thenReturn(tokens);
+			when(jwtService.generateAccessTokenAndRefreshToken(anyLong(), anyString(), anyLong())).thenReturn(authTokenDto);
 
-			List<String> result = userService.registerUser(emailToken, userNameToken, registerDto);
+			AuthTokenDto result = userService.registerUser(emailToken, userNameToken, registerDto);
 
-			assertEquals(accessToken, result.get(0));
-			assertEquals(refreshToken, result.get(1));
+			assertEquals(accessToken, result.accessToken());
+			assertEquals(refreshToken, result.refreshToken());
 
 			verify(userMapper, times(1)).insertUser(any(User.class));
 			verify(userRoleMapper, times(1)).insertUserRole(any(UserRole.class));
@@ -144,16 +145,17 @@ class UserServiceTest {
 
 		String accessToken = "access token";
 		String refreshToken = "refresh token";
+		AuthTokenDto authTokenDto = new AuthTokenDto(accessToken, refreshToken);
 
 		when(userMapper.findByUserName(anyString())).thenReturn(Optional.of(user));
 		when(userRoleMapper.findByUserId(anyLong())).thenReturn(Optional.of(userRole));
 
 		when(jwtService.generateAccessTokenAndRefreshToken(anyLong(), anyString(), anyLong())).thenReturn(
-			List.of(accessToken, refreshToken));
+			authTokenDto);
 
-		List<String> result = userService.login(loginDto);
+		AuthTokenDto result = userService.login(loginDto);
 
-		assertEquals(List.of(accessToken, refreshToken), result);
+		assertEquals(authTokenDto, result);
 		verify(userMapper, times(1)).findByUserName(anyString());
 		verify(userRoleMapper, times(1)).findByUserId(anyLong());
 	}

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/user/service/UserServiceTest.java
@@ -17,8 +17,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.trackery.trackerybackapiserver.domain.common.util.PasswordUtil;
-import com.trackery.trackerybackapiserver.domain.jwt.dto.RefreshTokenDto;
-import com.trackery.trackerybackapiserver.domain.jwt.service.JwtRedisService;
 import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
 import com.trackery.trackerybackapiserver.domain.user.dto.UserLoginDto;
 import com.trackery.trackerybackapiserver.domain.user.dto.UserNameAvailabilityResponseDto;
@@ -150,7 +148,8 @@ class UserServiceTest {
 		when(userMapper.findByUserName(anyString())).thenReturn(Optional.of(user));
 		when(userRoleMapper.findByUserId(anyLong())).thenReturn(Optional.of(userRole));
 
-		when(jwtService.generateAccessTokenAndRefreshToken(anyLong(), anyString(), anyLong())).thenReturn(List.of(accessToken, refreshToken));
+		when(jwtService.generateAccessTokenAndRefreshToken(anyLong(), anyString(), anyLong())).thenReturn(
+			List.of(accessToken, refreshToken));
 
 		List<String> result = userService.login(loginDto);
 

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/user/service/UserServiceTest.java
@@ -15,7 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.auth0.jwt.interfaces.DecodedJWT;
-import com.trackery.trackerybackapiserver.domain.common.util.JwtUtil;
+import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
 import com.trackery.trackerybackapiserver.domain.common.util.PasswordUtil;
 import com.trackery.trackerybackapiserver.domain.user.dto.UserLoginDto;
 import com.trackery.trackerybackapiserver.domain.user.dto.UserNameAvailabilityResponseDto;
@@ -54,7 +54,7 @@ class UserServiceTest {
 	UserLoginDto loginDto;
 
 	@Mock
-	private JwtUtil jwtUtil;
+	private JwtService jwtService;
 
 	@Test
 	void 회원가입_성공() {
@@ -68,8 +68,8 @@ class UserServiceTest {
 			DecodedJWT decodedEmailToken = mock(DecodedJWT.class);
 			DecodedJWT decodedUserNameToken = mock(DecodedJWT.class);
 
-			when(jwtUtil.verifyJwt(emailToken)).thenReturn(decodedEmailToken);
-			when(jwtUtil.verifyJwt(userNameToken)).thenReturn(decodedUserNameToken);
+			when(jwtService.verifyJwt(emailToken)).thenReturn(decodedEmailToken);
+			when(jwtService.verifyJwt(userNameToken)).thenReturn(decodedUserNameToken);
 
 			when(decodedEmailToken.getSubject()).thenReturn("a@a.com");
 			when(decodedUserNameToken.getSubject()).thenReturn("abcdfg");
@@ -87,7 +87,7 @@ class UserServiceTest {
 				return null;
 			}).when(userRoleMapper).insertUserRole(any(UserRole.class));
 
-			when(jwtUtil.generateAccessToken(anyLong(), anyString(), anyLong())).thenReturn("jwt token");
+			when(jwtService.generateAccessToken(anyLong(), anyString(), anyLong())).thenReturn("jwt token");
 
 			String result =  userService.registerUser(emailToken, userNameToken, registerDto);
 
@@ -104,7 +104,7 @@ class UserServiceTest {
 	@Test
 	void 유저명_중복_확인_성공() {
 		when(userMapper.isExistsUserName(anyString())).thenReturn(false);
-		when(jwtUtil.generateTokenWithSubject("abcdefg")).thenReturn("jwt");
+		when(jwtService.generateTokenWithSubject("abcdefg")).thenReturn("jwt");
 
 		UserNameAvailabilityResponseDto result = userService.checkUsernameAvailability("abcdefg");
 
@@ -139,7 +139,7 @@ class UserServiceTest {
 		when(userMapper.findByUserName(anyString())).thenReturn(Optional.of(user));
 		when(userRoleMapper.findByUserId(anyLong())).thenReturn(Optional.of(userRole));
 
-		when(jwtUtil.generateAccessToken(anyLong(), anyString(), anyLong())).thenReturn("jwt token");
+		when(jwtService.generateAccessToken(anyLong(), anyString(), anyLong())).thenReturn("jwt token");
 
 		String result = userService.login(loginDto);
 

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/user/service/UserServiceTest.java
@@ -3,7 +3,6 @@ package com.trackery.trackerybackapiserver.domain.user.service;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -93,7 +92,8 @@ class UserServiceTest {
 			String refreshToken = "refreshToken";
 			AuthTokenDto authTokenDto = new AuthTokenDto(accessToken, refreshToken);
 
-			when(jwtService.generateAccessTokenAndRefreshToken(anyLong(), anyString(), anyLong())).thenReturn(authTokenDto);
+			when(jwtService.generateAccessTokenAndRefreshToken(anyLong(), anyString(), anyLong())).thenReturn(
+				authTokenDto);
 
 			AuthTokenDto result = userService.registerUser(emailToken, userNameToken, registerDto);
 

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/user/service/UserServiceTest.java
@@ -59,9 +59,6 @@ class UserServiceTest {
 	@Mock
 	private JwtService jwtService;
 
-	@Mock
-	private JwtRedisService jwtRedisService;
-
 	@Test
 	void 회원가입_성공() {
 		try (MockedStatic<PasswordUtil> mockedStatic = mockStatic(PasswordUtil.class)) {
@@ -93,11 +90,16 @@ class UserServiceTest {
 				return null;
 			}).when(userRoleMapper).insertUserRole(any(UserRole.class));
 
-			when(jwtService.generateAccessToken(anyLong(), anyString(), anyLong())).thenReturn("jwt token");
+			String accessToken = "accessToken";
+			String refreshToken = "refreshToken";
+			List<String> tokens = List.of(accessToken, refreshToken);
 
-			String result = userService.registerUser(emailToken, userNameToken, registerDto);
+			when(jwtService.generateAccessTokenAndRefreshToken(anyLong(), anyString(), anyLong())).thenReturn(tokens);
 
-			assertEquals("jwt token", result);
+			List<String> result = userService.registerUser(emailToken, userNameToken, registerDto);
+
+			assertEquals(accessToken, result.get(0));
+			assertEquals(refreshToken, result.get(1));
 
 			verify(userMapper, times(1)).insertUser(any(User.class));
 			verify(userRoleMapper, times(1)).insertUserRole(any(UserRole.class));
@@ -148,11 +150,7 @@ class UserServiceTest {
 		when(userMapper.findByUserName(anyString())).thenReturn(Optional.of(user));
 		when(userRoleMapper.findByUserId(anyLong())).thenReturn(Optional.of(userRole));
 
-		when(jwtService.generateAccessToken(anyLong(), anyString(), anyLong())).thenReturn(accessToken);
-		when(jwtService.generateRefreshToken(anyLong())).thenReturn(
-			new RefreshTokenDto(refreshToken, "jid", "userId"));
-
-		doNothing().when(jwtRedisService).saveRefreshToken(any(RefreshTokenDto.class));
+		when(jwtService.generateAccessTokenAndRefreshToken(anyLong(), anyString(), anyLong())).thenReturn(List.of(accessToken, refreshToken));
 
 		List<String> result = userService.login(loginDto);
 

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/user/service/UserServiceTest.java
@@ -5,6 +5,9 @@ import static org.mockito.Mockito.*;
 
 import java.util.Optional;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -15,8 +18,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.auth0.jwt.interfaces.DecodedJWT;
+import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
 import com.trackery.trackerybackapiserver.domain.common.util.PasswordUtil;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.AuthTokenDto;
+import com.trackery.trackerybackapiserver.domain.jwt.dto.JwtUserInfoDto;
 import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
 import com.trackery.trackerybackapiserver.domain.user.dto.UserLoginDto;
 import com.trackery.trackerybackapiserver.domain.user.dto.UserNameAvailabilityResponseDto;
@@ -158,5 +163,67 @@ class UserServiceTest {
 		assertEquals(authTokenDto, result);
 		verify(userMapper, times(1)).findByUserName(anyString());
 		verify(userRoleMapper, times(1)).findByUserId(anyLong());
+	}
+
+	@Nested
+	@DisplayName("비밀번호 변경 테스트")
+	class changePasswordTest {
+		private static final String EMAIL_TOKEN = "emailToken";
+		private static final String NEW_PASSWORD = "aaaaaaaa";
+		private static final String EMAIL = "a@a.com";
+		private static final DecodedJWT DECODED_EMAIL_TOKEN = mock(DecodedJWT.class);
+
+		@Test
+		@DisplayName("성공")
+		void success() {
+			when(jwtService.verifyJwt(EMAIL_TOKEN)).thenReturn(DECODED_EMAIL_TOKEN);
+			when(DECODED_EMAIL_TOKEN.getSubject()).thenReturn(EMAIL);
+			when(userMapper.isExistsEmail(EMAIL)).thenReturn(true);
+			doNothing().when(userMapper).updatePassword(eq(EMAIL), anyString(), anyString());
+
+			userService.changePassword(EMAIL_TOKEN, NEW_PASSWORD);
+
+			verify(userMapper, times(1)).isExistsEmail(EMAIL);
+			verify(userMapper, times(1)).updatePassword(eq(EMAIL), anyString(), anyString());
+		}
+
+		@Test
+		@DisplayName("실패 - 이메일이 DB에 존재하지 않음")
+		void failure_1() {
+			when(jwtService.verifyJwt(EMAIL_TOKEN)).thenReturn(DECODED_EMAIL_TOKEN);
+			when(DECODED_EMAIL_TOKEN.getSubject()).thenReturn(EMAIL);
+			when(userMapper.isExistsEmail(EMAIL)).thenReturn(false);
+
+			assertThrows(ApiException.class, () -> userService.changePassword(EMAIL_TOKEN, NEW_PASSWORD));
+
+			verify(userMapper, times(1)).isExistsEmail(EMAIL);
+		}
+	}
+
+	@Nested
+	@DisplayName("액세스 토큰 발급 필요 정보 조회 테스트")
+	class getUserInfoByIdTest {
+		User user = User.builder().userName("abcdefg").build();
+		UserRole userRole = UserRole.builder().userId(1L).roleId(1L).build();
+		JwtUserInfoDto expectedDto = new JwtUserInfoDto(1L, "abcdefg", 1L);
+
+		@BeforeEach
+		void setUp() {
+			ReflectionTestUtils.setField(user, "userId", 1L);
+		}
+
+		@Test
+		@DisplayName("성공")
+		void success() {
+			when(userMapper.findByUserId(1L)).thenReturn(Optional.of(user));
+			when(userRoleMapper.findByUserId(1L)).thenReturn(Optional.of(userRole));
+
+			JwtUserInfoDto result = userService.getUserInfoById(1L);
+
+			assertEquals(expectedDto, result);
+
+			verify(userMapper, times(1)).findByUserId(1L);
+			verify(userRoleMapper, times(1)).findByUserId(1L);
+		}
 	}
 }


### PR DESCRIPTION
인증을 할 때 사용될 리프레시 토큰을 추가했습니다.

리프레시 토큰 기능

 발급
  1. JWT ID, userId를 가지고 있고, 만료기한은 7일입니다. 발급 될 때 Redis에 저장됩니다.
 
 액세스 토큰 재발급
  1. 쿠키에서 리프레시 토큰을 가져와서 파싱한 다음, 유효성을 검증합니다.
  2. Redis에 저장된 리프레시 토큰 정보와 일치하는지 대조합니다.
  3. 유효한 리프레시 토큰이라면 액세스 토큰과 리프레시 토큰을 재발급하고 기존 리프레시 토큰은 폐기합니다. 

Resolves #24