### PR TITLE
feature/Spring-REST-Docs 추가

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,14 @@
 						<configuration>
 							<backend>html</backend>
 							<doctype>book</doctype>
+							<sourceDirectory>src/docs/asciidoc</sourceDirectory>
+							<outputDirectory>${project.build.directory}/generated-docs</outputDirectory>
+							<attributes>
+								<snippets>${project.build.directory}/generated-snippets</snippets>
+								<source-highlighter>highlightjs</source-highlighter>
+								<toc>left</toc>
+								<toclevels>2</toclevels>
+							</attributes>
 						</configuration>
 					</execution>
 				</executions>

--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,9 @@
 								<source-highlighter>highlightjs</source-highlighter>
 								<toc>left</toc>
 								<toclevels>2</toclevels>
+								<sectanchors>true</sectanchors>
+								<sectlinks>true</sectlinks>
+								<encoding>UTF-8</encoding>
 							</attributes>
 						</configuration>
 					</execution>
@@ -208,6 +211,27 @@
 						</exclude>
 					</excludes>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-resources-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>copy-docs</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>copy-resources</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${project.build.outputDirectory}/static/docs</outputDirectory>
+							<resources>
+								<resource>
+									<directory>${project.build.directory}/generated-docs</directory>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<!--JaCoCo 설정-->
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,8 @@
 		<java.version>17</java.version>
 		<sonar.organization>regloss</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
+		<spring-restdocs.version>3.0.3</spring-restdocs.version>
+
 	</properties>
 	<dependencies>
 		<dependency>
@@ -144,6 +146,12 @@
 			<version>2.31.25</version>
 			<scope>compile</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.restdocs</groupId>
+			<artifactId>spring-restdocs-asciidoctor</artifactId>
+			<version>${spring-restdocs.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -179,11 +187,6 @@
 					</execution>
 				</executions>
 				<dependencies>
-					<dependency>
-						<groupId>org.springframework.restdocs</groupId>
-						<artifactId>spring-restdocs-asciidoctor</artifactId>
-						<version>${spring-restdocs.version}</version>
-					</dependency>
 				</dependencies>
 			</plugin>
 			<plugin>

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,11 @@
+= API 문서
+:toc: left
+:toclevels: 2
+
+== 공개 이미지 목록 API
+
+=== GET /api/home/images
+
+include::{snippets}/get-public-images/http-request.adoc[]
+include::{snippets}/get-public-images/http-response.adoc[]
+include::{snippets}/get-public-images/response-fields.adoc[]

--- a/src/main/java/com/trackery/trackerybackapiserver/config/SecurityConfig.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/config/SecurityConfig.java
@@ -39,6 +39,7 @@ import lombok.RequiredArgsConstructor;
  * 25. 2. 21.        durururuk   JWT 추가
  * 25. 2. 21.        inari       상세 주석 추가
  * 25. 2. 27.        inari       간편 로그인 경로 추가
+ * 25. 6. 12.        inari       docs 경로 추가
  */
 @Configuration
 @EnableWebSecurity
@@ -62,7 +63,8 @@ public class SecurityConfig {
 		"/api/users/oauth/**",
 		"/api/users/me/password/email-token",
 		"/favicon.ico",
-		"/api/mail/**"
+		"/api/mail/**",
+		"/api/docs/**"
 	};
 
 	/**

--- a/src/main/java/com/trackery/trackerybackapiserver/config/WebConfig.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/config/WebConfig.java
@@ -3,7 +3,6 @@ package com.trackery.trackerybackapiserver.config;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.format.FormatterRegistry;
-import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import com.trackery.trackerybackapiserver.domain.user.enums.OAuthProvider;
@@ -19,7 +18,6 @@ import com.trackery.trackerybackapiserver.domain.user.enums.OAuthProvider;
  * DATE              AUTHOR             NOTE
  * -----------------------------------------------------------
  * 25. 3. 26.        inari       최초 생성
- * 25. 6. 12.        inari       spring rest docs로 접근 가능한 api 추가
  */
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
@@ -32,16 +30,6 @@ public class WebConfig implements WebMvcConfigurer {
 	@Override
 	public void addFormatters(FormatterRegistry registry) {
 		registry.addConverter(new StringToOAthProviderConverter());
-	}
-
-	/**
-	 * classpath:/static/docs/에 존재하는 파일을 /api/docs/**로 접근가능하게 해주는 핸들러입니다.
-	 * @param registry 패스 주소
-	 */
-	@Override
-	public void addResourceHandlers(ResourceHandlerRegistry registry) {
-		registry.addResourceHandler("/api/docs/**")
-			.addResourceLocations("classpath:/static/docs/");
 	}
 
 	/**

--- a/src/main/java/com/trackery/trackerybackapiserver/config/WebConfig.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/config/WebConfig.java
@@ -3,6 +3,7 @@ package com.trackery.trackerybackapiserver.config;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import com.trackery.trackerybackapiserver.domain.user.enums.OAuthProvider;
@@ -18,6 +19,7 @@ import com.trackery.trackerybackapiserver.domain.user.enums.OAuthProvider;
  * DATE              AUTHOR             NOTE
  * -----------------------------------------------------------
  * 25. 3. 26.        inari       최초 생성
+ * 25. 6. 12.        inari       spring rest docs로 접근 가능한 api 추가
  */
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
@@ -30,6 +32,16 @@ public class WebConfig implements WebMvcConfigurer {
 	@Override
 	public void addFormatters(FormatterRegistry registry) {
 		registry.addConverter(new StringToOAthProviderConverter());
+	}
+
+	/**
+	 * classpath:/static/docs/에 존재하는 파일을 /api/docs/**로 접근가능하게 해주는 핸들러입니다.
+	 * @param registry 패스 주소
+	 */
+	@Override
+	public void addResourceHandlers(ResourceHandlerRegistry registry) {
+		registry.addResourceHandler("/api/docs/**")
+			.addResourceLocations("classpath:/static/docs/");
 	}
 
 	/**

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/docs/controller/DocsController.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/docs/controller/DocsController.java
@@ -1,0 +1,51 @@
+package com.trackery.trackerybackapiserver.domain.docs.controller;
+
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
+import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
+
+import java.io.IOException;
+import java.nio.file.Files;
+
+/**
+ * packageName    : com.trackery.trackerybackapiserver.domain.docs.controller
+ * fileName       : DocsController
+ * author         : inari
+ * date           : 25. 6. 12.
+ * description    : Spring REST Docs 문서를 제공하는 컨트롤러입니다.
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 25. 6. 12.        inari       최초 생성
+ */
+@RestController
+@RequestMapping("/api/docs")
+public class DocsController {
+
+	/**
+	 * API 문서를 제공하는 REST 컨트롤러
+	 * 클래스패스의 REST DOCS의 정적 HTML 파일을 읽어서 프론트엔드로 전달
+	 */
+	@GetMapping({"/index.html", ""})
+	public ResponseEntity<String> getDocs() {
+		try {
+			Resource resource = new ClassPathResource("static/docs/index.html");
+			if (resource.exists()) {
+				String content = Files.readString(resource.getFile().toPath());
+				return ResponseEntity.ok()
+					.contentType(MediaType.TEXT_HTML)
+					.body(content);
+			}
+			throw new ApiException(ErrorCode.NOT_FOUND);
+		} catch (IOException e) {
+			throw new ApiException(ErrorCode.INTERNAL_SERVER_ERROR);
+		}
+	}
+}

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/image/controller/LandingImagesControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/image/controller/LandingImagesControllerTest.java
@@ -1,7 +1,9 @@
 package com.trackery.trackerybackapiserver.domain.image.controller;
 
 import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.util.Arrays;
@@ -10,6 +12,9 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -25,7 +30,9 @@ import com.trackery.trackerybackapiserver.domain.image.service.ImageService;
  * DATE              AUTHOR             NOTE
  * -----------------------------------------------------------
  * 25. 2. 14.        inari       최초 생성
+ * 25. 6. 11.        inari       adoc 문서 추가
  */
+@ExtendWith(RestDocumentationExtension.class)
 class LandingImagesControllerTest {
 
 	private MockMvc mockMvc;
@@ -33,11 +40,12 @@ class LandingImagesControllerTest {
 	private LandingImagesController landingImagesController;
 
 	@BeforeEach
-	void setUp() {
+	void setUp(RestDocumentationContextProvider restDocumentation) {
 		imageService = mock(ImageService.class);
 		landingImagesController = new LandingImagesController(imageService);
 		mockMvc = MockMvcBuilders
 			.standaloneSetup(landingImagesController)
+			.apply(documentationConfiguration(restDocumentation))
 			.build();
 	}
 
@@ -58,6 +66,13 @@ class LandingImagesControllerTest {
 			.andExpect(jsonPath("$.message").value("Ok"))
 			.andExpect(jsonPath("$.data.imageUrls").isArray())
 			.andExpect(jsonPath("$.data.imageUrls[0]").value("http://example.com/image1.jpg"))
-			.andExpect(jsonPath("$.data.imageUrls[1]").value("http://example.com/image2.jpg"));
+			.andExpect(jsonPath("$.data.imageUrls[1]").value("http://example.com/image2.jpg"))
+			.andDo(document("get-public-images",
+				responseFields(
+					fieldWithPath("code").description("응답 코드"),
+					fieldWithPath("message").description("응답 메시지"),
+					fieldWithPath("data.imageUrls[]").description("공개 이미지 URL 목록")
+				)
+			));
 	}
 }


### PR DESCRIPTION
Spring REST Docs 이용을 위해 restdocs의 html을 작성하기위한 pom.xml을 수정 및 샘플을 추가하였습니다.
빌드시 작성된 index.html을 static으로 자동으로 복사하도록 설정하였습니다.
프론트에서 요청시 컨트롤러를 통하여 문서 확인이 가능합니다.