### PR TITLE
앨범 도메인 API 문서 작성

### DIFF
--- a/src/docs/asciidoc/album-api.adoc
+++ b/src/docs/asciidoc/album-api.adoc
@@ -4,6 +4,9 @@
 === 앨범 생성 API
 ==== POST /api/albums
 
+앨범 제목, 앨범 설명, 공개 여부를 JSON으로 받아서 앨범을 생성할 수 있는 API입니다.
+응답으로는 생성된 앨범의 ID, 앨범 제목, 설명을 반환합니다.
+
 ===== 요청
 include::{snippets}/create-album/http-request.adoc[]
 include::{snippets}/create-album/request-fields.adoc[]
@@ -15,6 +18,8 @@ include::{snippets}/create-album/response-fields.adoc[]
 === 앨범 삭제 API
 ==== DELETE /api/albums?albumId={앨범 ID}
 
+앨범 ID로 앨범을 삭제할 수 있는 API입니다. 추가로 반환되는 데이터는 없습니다.
+
 ===== 요청
 include::{snippets}/delete-album/http-request.adoc[]
 
@@ -25,6 +30,8 @@ include::{snippets}/delete-album/response-fields.adoc[]
 
 === 앨범에 이미지 추가 API
 ==== POST /api/albums/images
+
+앨범 ID와 앨범에 추가할 이미지 ID 리스트를 받아서 앨범에 이미지를 추가하는 API입니다. 응답은 성공한 이미지 개수, 실패한 이미지 개수, 성공한 이미지는 성공한 이미지 ID 리스트, 실패한 이미지는 사유를 포함해서 데이터를 반환합니다.
 
 ===== 요청
 include::{snippets}/add-images-into-album/http-request.adoc[]
@@ -38,6 +45,9 @@ include::{snippets}/add-images-into-album/response-fields.adoc[]
 === 앨범에서 이미지 삭제 API
 ==== DELETE /api/albums/images
 
+앨범 ID와 이미지 ID 리스트로 앨범에 있는 이미지를 삭제하는 기능입니다.
+앨범에 해당 ID를 가진 이미지가 없을 경우 건너뛰어집니다. 응답은 성공한 이미지 개수, 실패한 이미지 개수, 성공한 이미지는 성공한 이미지 ID 리스트, 실패한 이미지는 사유를 포함해서 데이터를 반환합니다.
+
 ===== 요청
 include::{snippets}/delete-images-from-album/http-request.adoc[]
 include::{snippets}/delete-images-from-album/request-fields.adoc[]
@@ -50,6 +60,8 @@ include::{snippets}/delete-images-from-album/response-fields.adoc[]
 === 앨범 상세 정보 조회 API
 ==== GET /api/albums?albumId={앨범 ID}
 
+앨범의 정보와 앨범에 포함돼있는 이미지를 불러오는 API입니다. 이미지 응답 데이터 형식은 이미지 API 문서를 참고 바랍니다.
+
 ===== 요청
 include::{snippets}/get-album-detailed-info/http-request.adoc[]
 
@@ -60,6 +72,8 @@ include::{snippets}/get-album-detailed-info/response-fields.adoc[]
 
 === 앨범 정보 수정 API
 ==== PATCH /api/albums
+
+앨범 정보를 수정하는 API입니다. 각 필드 중 입력이 들어온 필드만 업데이트가 이뤄집니다.
 
 ===== 요청
 include::{snippets}/update-album-info/http-request.adoc[]

--- a/src/docs/asciidoc/album-api.adoc
+++ b/src/docs/asciidoc/album-api.adoc
@@ -1,0 +1,26 @@
+== 앨범 API
+'''
+
+=== *앨범 생성 API*
+==== POST /api/albums
+
+===== 요청
+include::{snippets}/create-album/http-request.adoc[]
+include::{snippets}/create-album/request-fields.adoc[]
+
+===== 응답
+include::{snippets}/create-album/http-response.adoc[]
+include::{snippets}/create-album/response-fields.adoc[]
+'''
+
+=== *앨범에 이미지 추가 API*
+==== POST /api/albums/images
+
+===== 요청
+include::{snippets}/add-images-into-album/http-request.adoc[]
+include::{snippets}/add-images-into-album/request-fields.adoc[]
+
+===== 응답
+include::{snippets}/add-images-into-album/http-response.adoc[]
+include::{snippets}/add-images-into-album/response-fields.adoc[]
+'''

--- a/src/docs/asciidoc/album-api.adoc
+++ b/src/docs/asciidoc/album-api.adoc
@@ -1,7 +1,7 @@
 == 앨범 API
 '''
 
-=== *앨범 생성 API*
+=== 앨범 생성 API
 ==== POST /api/albums
 
 ===== 요청
@@ -12,8 +12,18 @@ include::{snippets}/create-album/request-fields.adoc[]
 include::{snippets}/create-album/http-response.adoc[]
 include::{snippets}/create-album/response-fields.adoc[]
 '''
+=== 앨범 삭제 API
+==== DELETE /api/albums?albumId={앨범 ID}
 
-=== *앨범에 이미지 추가 API*
+===== 요청
+include::{snippets}/delete-album/http-request.adoc[]
+
+===== 응답
+include::{snippets}/delete-album/http-response.adoc[]
+include::{snippets}/delete-album/response-fields.adoc[]
+'''
+
+=== 앨범에 이미지 추가 API
 ==== POST /api/albums/images
 
 ===== 요청
@@ -23,4 +33,39 @@ include::{snippets}/add-images-into-album/request-fields.adoc[]
 ===== 응답
 include::{snippets}/add-images-into-album/http-response.adoc[]
 include::{snippets}/add-images-into-album/response-fields.adoc[]
+'''
+
+=== 앨범에서 이미지 삭제 API
+==== DELETE /api/albums/images
+
+===== 요청
+include::{snippets}/delete-images-from-album/http-request.adoc[]
+include::{snippets}/delete-images-from-album/request-fields.adoc[]
+
+===== 응답
+include::{snippets}/delete-images-from-album/http-response.adoc[]
+include::{snippets}/delete-images-from-album/response-fields.adoc[]
+'''
+
+=== 앨범 상세 정보 조회 API
+==== GET /api/albums?albumId={앨범 ID}
+
+===== 요청
+include::{snippets}/get-album-detailed-info/http-request.adoc[]
+
+===== 응답
+include::{snippets}/get-album-detailed-info/http-response.adoc[]
+include::{snippets}/get-album-detailed-info/response-fields.adoc[]
+'''
+
+=== 앨범 정보 수정 API
+==== PATCH /api/albums
+
+===== 요청
+include::{snippets}/update-album-info/http-request.adoc[]
+include::{snippets}/update-album-info/request-fields.adoc[]
+
+===== 응답
+include::{snippets}/update-album-info/http-response.adoc[]
+include::{snippets}/update-album-info/response-fields.adoc[]
 '''

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,4 +1,5 @@
-= API 문서
+= Trackery API 문서
+:sectnums
 :toc: left
 :toclevels: 2
 
@@ -9,3 +10,6 @@
 include::{snippets}/get-public-images/http-request.adoc[]
 include::{snippets}/get-public-images/http-response.adoc[]
 include::{snippets}/get-public-images/response-fields.adoc[]
+
+include::album-api.adoc[]
+

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/album/service/AlbumService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/album/service/AlbumService.java
@@ -26,9 +26,7 @@ import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiEx
 import com.trackery.trackerybackapiserver.domain.image.dto.ImageDto;
 import com.trackery.trackerybackapiserver.domain.image.entity.Image;
 import com.trackery.trackerybackapiserver.domain.image.mapper.ImageMapper;
-import com.trackery.trackerybackapiserver.domain.image.service.ImageS3Service;
-import com.trackery.trackerybackapiserver.domain.location.dto.LocationInfoDto;
-import com.trackery.trackerybackapiserver.domain.location.service.LocationUtil;
+import com.trackery.trackerybackapiserver.domain.image.service.ImageService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -51,7 +49,7 @@ import lombok.extern.slf4j.Slf4j;
 public class AlbumService {
 	private final AlbumMapper albumMapper;
 	private final ImageMapper imageMapper;
-	private final ImageS3Service imageS3Service;
+	private final ImageService imageService;
 
 	/**
 	 * 앨범 생성 기능
@@ -202,26 +200,7 @@ public class AlbumService {
 				.orElseThrow(() -> new ApiException(ErrorCode.NOT_FOUND_IMAGE)))
 			.toList();
 
-		List<ImageDto> imageDtoList = imageList.stream().map(image -> {
-			String imagePresignedUrl = imageS3Service.generatePreSignedGetUrl(image.getImageFile());
-
-			LocationInfoDto locationInfoDto = LocationUtil.getLocationInfoByCoordinatePoint(image.getCoordPoint());
-
-			return ImageDto.builder()
-				.imageId(image.getImageId())
-				.userId(image.getUserId())
-				.imageRegDate(image.getImageRegDate())
-				.sdName(locationInfoDto.sidoName())
-				.sggName(locationInfoDto.sigunguName())
-				.latitude(locationInfoDto.latitude())
-				.longitude(locationInfoDto.longitude())
-				.imageName(image.getImageName())
-				.imageContent(image.getImageContent())
-				.imageDate(image.getImageDate())
-				.isPublic(image.getIsPublic())
-				.imageUrl(imagePresignedUrl)
-				.build();
-		}).toList();
+		List<ImageDto> imageDtoList = imageList.stream().map(imageService::convertImageToImageDto).toList();
 
 		return AlbumDetailedResponseDto.of(album, imageDtoList);
 	}

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageService.java
@@ -96,7 +96,7 @@ public class ImageService {
 	 * @param image 이미지 객체
 	 * @return 이미지 정보를 담고있는 DTO
 	 */
-	private ImageDto convertImageToImageDto(Image image) {
+	public ImageDto convertImageToImageDto(Image image) {
 		String imagePresignedUrl = imageS3Service.generatePreSignedGetUrl(image.getImageFile());
 
 		CoordinatePoint coordPoint = image.getCoordPoint();

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/album/controller/AlbumControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/album/controller/AlbumControllerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.Mockito.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -169,7 +170,6 @@ class AlbumControllerTest extends CommonMockMvcControllerTestSetUp {
 
 		ResultActions result = mockMvc.perform(get("/api/albums")
 			.with(user(customUserDetails))
-			.with(csrf())
 			.param("albumId", String.valueOf(1L)));
 
 		result
@@ -181,6 +181,26 @@ class AlbumControllerTest extends CommonMockMvcControllerTestSetUp {
 			.andExpect(jsonPath("$.data.albumDescription").value("강릉 여행 기록"))
 			.andExpect(jsonPath("$.data.imageList").isArray())
 			.andExpect(jsonPath("$.data.imageList").exists());
+
+		result
+			.andDo(document("get-album-detailed-info",
+					queryParameters(
+						parameterWithName("albumId").description("앨범 ID")
+					),
+
+					responseFields(
+						fieldWithPath("code").description("응답 코드"),
+						fieldWithPath("message").description("응답 메시지"),
+						fieldWithPath("data.albumId").description("앨범 ID"),
+						fieldWithPath("data.createdUserId").description("앨벙을 생성한 유저 ID"),
+						fieldWithPath("data.albumTitle").description("앨범 제목"),
+						fieldWithPath("data.albumDescription").description("앨범 설명"),
+						fieldWithPath("data.isPublic").description("공개 여부"),
+						fieldWithPath("data.imageCount").description("이미지 개수"),
+						fieldWithPath("data.imageList").description("앨범 이미지 리스트")
+					)
+				)
+			);
 	}
 
 	@Test
@@ -198,6 +218,20 @@ class AlbumControllerTest extends CommonMockMvcControllerTestSetUp {
 
 		result
 			.andExpect(status().isOk());
+
+		result.andDo(document("update-album-info",
+			requestFields(
+				fieldWithPath("albumId").description("앨범 ID"),
+				fieldWithPath("albumTitle").description("앨범 제목"),
+				fieldWithPath("albumDescription").description("앨범 설명"),
+				fieldWithPath("isPublic").description("공개 여부")
+			),
+
+			responseFields(
+				fieldWithPath("code").description("응답 코드"),
+				fieldWithPath("message").description("응답 메시지")
+			)
+		));
 	}
 
 	@Test
@@ -235,6 +269,25 @@ class AlbumControllerTest extends CommonMockMvcControllerTestSetUp {
 			.andExpect(jsonPath("$.data.succeededImageIds").isNotEmpty())
 			.andExpect(jsonPath("$.data.failedImageIds").exists())
 			.andExpect(jsonPath("$.data.failedImageIds").isNotEmpty());
+
+		result.andDo(document("delete-images-from-album",
+				requestFields(
+					fieldWithPath("albumId").description("앨범 ID"),
+					fieldWithPath("imageIdList").description("앨범 ID 리스트")
+				),
+
+				responseFields(
+					fieldWithPath("code").description("응답 코드"),
+					fieldWithPath("message").description("응답 메시지"),
+					fieldWithPath("data.albumId").description("앨범 ID"),
+					fieldWithPath("data.succeededImageCount").description("성공한 이미지 개수"),
+					fieldWithPath("data.failedImageCount").description("실패한 이미지 개수"),
+					fieldWithPath("data.succeededImageIds").description("성공한 이미지 ID 리스트"),
+					fieldWithPath("data.failedImageIds").description("실패한 이미지 ID 맵"),
+					fieldWithPath("data.failedImageIds.*").description("실패한 이미지 ID별 오류 메시지")
+				)
+			)
+		);
 	}
 
 	@Test
@@ -267,6 +320,21 @@ class AlbumControllerTest extends CommonMockMvcControllerTestSetUp {
 			.andExpect(jsonPath("$.data.albumList[0].albumId").value(1))
 			.andExpect(jsonPath("$.data.albumList[0].albumImageCount").value(3))
 			.andExpect(jsonPath("$.data.albumList[0].isPublic").value(1));
+
+		result.andDo(document("get-my-album-simple-info",
+				responseFields(
+					fieldWithPath("code").description("응답 코드"),
+					fieldWithPath("message").description("응답 메시지"),
+					fieldWithPath("data.userId").description("요청 유저 ID"),
+					fieldWithPath("data.albumCount").description("앨범 개수"),
+					fieldWithPath("data.albumList").description("앨범 리스트"),
+					fieldWithPath("data.albumList[].albumId").description("앨범 ID"),
+					fieldWithPath("data.albumList[].albumTitle").description("앨범 제목"),
+					fieldWithPath("data.albumList[].albumImageCount").description("앨범 이미지 개수"),
+					fieldWithPath("data.albumList[].isPublic").description("공개 여부")
+				)
+			)
+		);
 	}
 
 	@Test
@@ -278,10 +346,23 @@ class AlbumControllerTest extends CommonMockMvcControllerTestSetUp {
 		ResultActions result = mockMvc.perform(delete("/api/albums")
 			.with(user(customUserDetails))
 			.with(csrf())
-			.param("albumId", String.valueOf(albumId)));
+			.queryParam("albumId", String.valueOf(albumId)));
 
 		result
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data").doesNotExist());
+
+		result
+			.andDo(document("delete-album",
+					queryParameters(
+						parameterWithName("albumId").description("앨범 ID")
+					),
+
+					responseFields(
+						fieldWithPath("code").description("응답 코드"),
+						fieldWithPath("message").description("응답 메시지")
+					)
+				)
+			);
 	}
 }

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/album/controller/AlbumControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/album/controller/AlbumControllerTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.ResultActions;
@@ -83,9 +84,9 @@ class AlbumControllerTest extends CommonMockMvcControllerTestSetUp {
 
 		result.andDo(document("create-album",
 			requestFields(
-				fieldWithPath("albumTitle").description("앨범 제목(필수)"),
-				fieldWithPath("albumDescription").description("앨범 설명").optional(),
-				fieldWithPath("isPublic").description("공개 여부(필수)")
+				fieldWithPath("albumTitle").description("앨범 제목(필수)").type(JsonFieldType.STRING),
+				fieldWithPath("albumDescription").description("앨범 설명").type(JsonFieldType.STRING).optional(),
+				fieldWithPath("isPublic").description("공개 여부(필수)").type(JsonFieldType.NUMBER)
 			),
 
 			responseFields(
@@ -164,6 +165,8 @@ class AlbumControllerTest extends CommonMockMvcControllerTestSetUp {
 			.albumTitle("강릉 여행")
 			.albumDescription("강릉 여행 기록")
 			.imageList(List.of())
+			.isPublic(0)
+			.imageCount(0)
 			.build();
 
 		when(albumService.getAlbumDetailedInfo(any(), eq(albumId))).thenReturn(responseDto);
@@ -195,8 +198,8 @@ class AlbumControllerTest extends CommonMockMvcControllerTestSetUp {
 						fieldWithPath("data.createdUserId").description("앨벙을 생성한 유저 ID"),
 						fieldWithPath("data.albumTitle").description("앨범 제목"),
 						fieldWithPath("data.albumDescription").description("앨범 설명"),
-						fieldWithPath("data.isPublic").description("공개 여부"),
-						fieldWithPath("data.imageCount").description("이미지 개수"),
+						fieldWithPath("data.isPublic").description("공개 여부").type(JsonFieldType.NUMBER),
+						fieldWithPath("data.imageCount").description("이미지 개수").type(JsonFieldType.NUMBER),
 						fieldWithPath("data.imageList").description("앨범 이미지 리스트")
 					)
 				)
@@ -205,8 +208,12 @@ class AlbumControllerTest extends CommonMockMvcControllerTestSetUp {
 
 	@Test
 	void updateAlbumInfoSuccess() throws Exception {
-		AlbumUpdateRequestDto requestDto = new AlbumUpdateRequestDto();
-		ReflectionTestUtils.setField(requestDto, "albumId", 1L);
+		AlbumUpdateRequestDto requestDto = AlbumUpdateRequestDto.builder()
+			.albumId(1L)
+			.albumTitle("앨범 제목 수정")
+			.albumDescription("앨범 설명 수정")
+			.isPublic(1)
+			.build();
 
 		doNothing().when(albumService).updateAlbumInfo(any(), any());
 
@@ -221,10 +228,10 @@ class AlbumControllerTest extends CommonMockMvcControllerTestSetUp {
 
 		result.andDo(document("update-album-info",
 			requestFields(
-				fieldWithPath("albumId").description("앨범 ID"),
-				fieldWithPath("albumTitle").description("앨범 제목"),
-				fieldWithPath("albumDescription").description("앨범 설명"),
-				fieldWithPath("isPublic").description("공개 여부")
+				fieldWithPath("albumId").description("앨범 ID").type(JsonFieldType.NUMBER),
+				fieldWithPath("albumTitle").description("앨범 제목").type(JsonFieldType.STRING),
+				fieldWithPath("albumDescription").description("앨범 설명").type(JsonFieldType.STRING),
+				fieldWithPath("isPublic").description("공개 여부").type(JsonFieldType.NUMBER)
 			),
 
 			responseFields(

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/album/controller/AlbumControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/album/controller/AlbumControllerTest.java
@@ -1,7 +1,9 @@
 package com.trackery.trackerybackapiserver.domain.album.controller;
 
 import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -77,6 +79,21 @@ class AlbumControllerTest extends CommonMockMvcControllerTestSetUp {
 			.andExpect(jsonPath("$.data.albumId").value(1))
 			.andExpect(jsonPath("$.data.albumTitle").value("강릉 여행"))
 			.andExpect(jsonPath("$.data.albumDescription").value("강릉 여행 기록"));
+
+		result.andDo(document("create-album",
+			requestFields(
+				fieldWithPath("albumTitle").description("앨범 제목(필수)"),
+				fieldWithPath("albumDescription").description("앨범 설명").optional(),
+				fieldWithPath("isPublic").description("공개 여부(필수)")
+			),
+
+			responseFields(
+				fieldWithPath("code").description("응답 코드"),
+				fieldWithPath("message").description("응답 메시지"),
+				fieldWithPath("data.albumId").description("생성된 앨범 ID"),
+				fieldWithPath("data.albumTitle").description("앨범 제목"),
+				fieldWithPath("data.albumDescription").description("앨범 설명")
+			)));
 	}
 
 	@Test
@@ -114,6 +131,26 @@ class AlbumControllerTest extends CommonMockMvcControllerTestSetUp {
 			.andExpect(jsonPath("$.data.succeededImageIds").isNotEmpty())
 			.andExpect(jsonPath("$.data.failedImageIds").exists())
 			.andExpect(jsonPath("$.data.failedImageIds").isNotEmpty());
+
+		result
+			.andDo(document("add-images-into-album",
+					requestFields(
+						fieldWithPath("albumId").description("이미지를 추가할 앨범 ID"),
+						fieldWithPath("imageIdList").description("앨범에 추가할 이미지 ID 리스트")
+					),
+
+					responseFields(
+						fieldWithPath("code").description("응답 코드"),
+						fieldWithPath("message").description("응답 메시지"),
+						fieldWithPath("data.albumId").description("앨범 ID"),
+						fieldWithPath("data.succeededImageCount").description("성공한 이미지 개수"),
+						fieldWithPath("data.failedImageCount").description("실패한 이미지 개수"),
+						fieldWithPath("data.succeededImageIds").description("성공한 이미지 ID 리스트"),
+						fieldWithPath("data.failedImageIds").description("실패한 이미지 ID 맵"),
+						fieldWithPath("data.failedImageIds.*").description("실패한 이미지 ID별 오류 메시지")
+					)
+				)
+			);
 	}
 
 	@Test

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/album/service/AlbumServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/album/service/AlbumServiceTest.java
@@ -33,7 +33,7 @@ import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
 import com.trackery.trackerybackapiserver.domain.image.entity.Image;
 import com.trackery.trackerybackapiserver.domain.image.mapper.ImageMapper;
-import com.trackery.trackerybackapiserver.domain.image.service.ImageS3Service;
+import com.trackery.trackerybackapiserver.domain.image.service.ImageService;
 import com.trackery.trackerybackapiserver.domain.location.dto.LocationInfoDto;
 import com.trackery.trackerybackapiserver.domain.location.entity.CoordinatePoint;
 import com.trackery.trackerybackapiserver.domain.location.service.LocationUtil;
@@ -47,7 +47,7 @@ class AlbumServiceTest {
 	private ImageMapper imageMapper;
 
 	@Mock
-	private ImageS3Service imageS3Service;
+	private ImageService imageService;
 
 	@InjectMocks
 	private AlbumService albumService;
@@ -302,8 +302,6 @@ class AlbumServiceTest {
 			when(imageMapper.findImageByImageId(1L)).thenReturn(Optional.of(image1));
 			when(imageMapper.findImageByImageId(2L)).thenReturn(Optional.of(image2));
 
-			when(imageS3Service.generatePreSignedGetUrl(anyString())).thenReturn("http://image-url.com/presigned");
-
 			try (MockedStatic<LocationUtil> mockedLocationUtil = mockStatic(LocationUtil.class)) {
 				mockedLocationUtil.when(() -> LocationUtil.getLocationInfoByCoordinatePoint(any(CoordinatePoint.class)))
 					.thenReturn(new LocationInfoDto(37.497942, 127.027621, "서울특별시", "강남구"));
@@ -317,7 +315,6 @@ class AlbumServiceTest {
 				verify(albumMapper).findByAlbumId(ALBUM_ID);
 				verify(albumMapper).findAlbumImagesByAlbumId(ALBUM_ID);
 				verify(imageMapper, times(2)).findImageByImageId(anyLong());
-				verify(imageS3Service, times(2)).generatePreSignedGetUrl(anyString());
 			}
 		}
 

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/config/CommonMockMvcControllerTestSetUp.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/config/CommonMockMvcControllerTestSetUp.java
@@ -1,9 +1,11 @@
 package com.trackery.trackerybackapiserver.domain.config;
 
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -21,9 +23,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  25. 2. 19.        durururuk       최초 생성
  */
 
-@Import(MockMvcUnitTestSecurityConfig.class)
 @AutoConfigureMockMvc
 @AutoConfigureRestDocs
+@Import({MockMvcUnitTestSecurityConfig.class, RestDocsConfiguration.class})
+@ExtendWith(RestDocumentationExtension.class)
 public abstract class CommonMockMvcControllerTestSetUp {
 	@Autowired
 	protected MockMvc mockMvc;

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/config/RestDocsConfiguration.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/config/RestDocsConfiguration.java
@@ -1,0 +1,29 @@
+package com.trackery.trackerybackapiserver.domain.config;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+
+import org.springframework.boot.test.autoconfigure.restdocs.RestDocsMockMvcConfigurationCustomizer;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * packageName    : com.trackery.trackerybackapiserver.domain.config
+ * fileName       : RestDocsConfiguration
+ * author         : durururuk
+ * date           : 25. 6. 13.
+ * description    : Spring Rest Docs 관련 설정 클래스입니다.
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 25. 6. 13.		durururuk		최초 생성
+ */
+@TestConfiguration
+public class RestDocsConfiguration {
+	@Bean
+	public RestDocsMockMvcConfigurationCustomizer restDocsMockMvcConfigurationCustomizer() {
+		return configurer -> configurer
+			.operationPreprocessors()
+			.withRequestDefaults(prettyPrint())
+			.withResponseDefaults(prettyPrint());
+	}
+}


### PR DESCRIPTION
앨범 도메인에 있는 API들에 대한 API 문서를 작성했습니다.

API 문서를 작성하다보니 리소스를 접근하는 방식이 RESTful 하지 않은 것 같아서 엔드포인트 수정을 해야 될 것 같습니다.


예시)
현재 ```/api/albums?albumId=1```
수정 방향 ```/api/albums/1```