### PR TITLE
앨범 엔트포인트 수정

### DIFF
--- a/src/docs/asciidoc/album-api.adoc
+++ b/src/docs/asciidoc/album-api.adoc
@@ -16,7 +16,7 @@ include::{snippets}/create-album/http-response.adoc[]
 include::{snippets}/create-album/response-fields.adoc[]
 '''
 === 앨범 삭제 API
-==== DELETE /api/albums?albumId={앨범 ID}
+==== DELETE /api/albums/{앨범 ID}
 
 앨범 ID로 앨범을 삭제할 수 있는 API입니다. 추가로 반환되는 데이터는 없습니다.
 
@@ -29,7 +29,7 @@ include::{snippets}/delete-album/response-fields.adoc[]
 '''
 
 === 앨범에 이미지 추가 API
-==== POST /api/albums/images
+==== POST /api/albums/{앨범 ID}/images
 
 앨범 ID와 앨범에 추가할 이미지 ID 리스트를 받아서 앨범에 이미지를 추가하는 API입니다. 응답은 성공한 이미지 개수, 실패한 이미지 개수, 성공한 이미지는 성공한 이미지 ID 리스트, 실패한 이미지는 사유를 포함해서 데이터를 반환합니다.
 
@@ -43,7 +43,7 @@ include::{snippets}/add-images-into-album/response-fields.adoc[]
 '''
 
 === 앨범에서 이미지 삭제 API
-==== DELETE /api/albums/images
+==== DELETE /api/albums/{앨범 ID}/images
 
 앨범 ID와 이미지 ID 리스트로 앨범에 있는 이미지를 삭제하는 기능입니다.
 앨범에 해당 ID를 가진 이미지가 없을 경우 건너뛰어집니다. 응답은 성공한 이미지 개수, 실패한 이미지 개수, 성공한 이미지는 성공한 이미지 ID 리스트, 실패한 이미지는 사유를 포함해서 데이터를 반환합니다.
@@ -58,7 +58,7 @@ include::{snippets}/delete-images-from-album/response-fields.adoc[]
 '''
 
 === 앨범 상세 정보 조회 API
-==== GET /api/albums?albumId={앨범 ID}
+==== GET /api/albums/{앨범 ID}
 
 앨범의 정보와 앨범에 포함돼있는 이미지를 불러오는 API입니다. 이미지 응답 데이터 형식은 이미지 API 문서를 참고 바랍니다.
 
@@ -71,7 +71,7 @@ include::{snippets}/get-album-detailed-info/response-fields.adoc[]
 '''
 
 === 앨범 정보 수정 API
-==== PATCH /api/albums
+==== PATCH /api/albums/{앨범 ID}
 
 앨범 정보를 수정하는 API입니다. 각 필드 중 입력이 들어온 필드만 업데이트가 이뤄집니다.
 

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,5 +1,4 @@
 = Trackery API 문서
-:sectnums
 :toc: left
 :toclevels: 2
 

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/album/controller/AlbumController.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/album/controller/AlbumController.java
@@ -6,10 +6,10 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.trackery.trackerybackapiserver.domain.album.dto.request.AlbumCreateRequestDto;
@@ -66,13 +66,14 @@ public class AlbumController {
 	 * @param requestDto 앨범 ID, 이미지 ID 리스트를 담은 DTO
 	 * @return 결과 정보를 담은 DTO
 	 */
-	@PostMapping("/images")
+	@PostMapping("/{albumId}/images")
 	public ResponseEntity<ApiResponse<AlbumImageEditResponseDto>> addImagesIntoAlbum(
 		@AuthenticationPrincipal CustomUserDetails userDetails,
+		@PathVariable("albumId") Long albumId,
 		@RequestBody @Valid AlbumImageEditRequestDto requestDto) {
 
 		AlbumImageEditResponseDto result = albumService.addImageIntoAlbum(userDetails.getUserId(),
-			requestDto.getAlbumId(), requestDto.getImageIdList());
+			albumId, requestDto.getImageIdList());
 
 		return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, result));
 	}
@@ -83,13 +84,14 @@ public class AlbumController {
 	 * @param requestDto 앨범 ID와 삭제할 이미지 리스트를 담은 DTO
 	 * @return 삭제된 이미지 정보, 실패한 이미지 정보를 담은 DTO
 	 */
-	@DeleteMapping("/images")
+	@DeleteMapping("/{albumId}/images")
 	public ResponseEntity<ApiResponse<AlbumImageEditResponseDto>> deleteImagesFromAlbum(
 		@AuthenticationPrincipal CustomUserDetails userDetails,
+		@PathVariable("albumId") Long albumId,
 		@RequestBody @Valid AlbumImageEditRequestDto requestDto
 	) {
 		AlbumImageEditResponseDto result = albumService.deleteImageFromAlbum(userDetails.getUserId(),
-			requestDto.getAlbumId(), requestDto.getImageIdList());
+			albumId, requestDto.getImageIdList());
 		return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, result));
 	}
 
@@ -99,8 +101,8 @@ public class AlbumController {
 	 * @param userDetails 인증된 유저 정보
 	 * @return 앨범 정보, 앨범에 있는 이미지를 담은 상세 정보 DTO
 	 */
-	@GetMapping
-	public ResponseEntity<ApiResponse<AlbumDetailedResponseDto>> getAlbumDetailedInfo(@RequestParam Long albumId,
+	@GetMapping("/{albumId}")
+	public ResponseEntity<ApiResponse<AlbumDetailedResponseDto>> getAlbumDetailedInfo(@PathVariable Long albumId,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		AlbumDetailedResponseDto result = albumService.getAlbumDetailedInfo(userDetails.getUserId(), albumId);
 		return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, result));
@@ -112,10 +114,12 @@ public class AlbumController {
 	 * @param userDetails 인증된 사용자 정보
 	 * @return 성공 시 200, 그 외 상황에 맞는 에러코드
 	 */
-	@PatchMapping
-	public ResponseEntity<ApiResponse<String>> updateAlbumInfo(@RequestBody AlbumUpdateRequestDto requestDto,
+	@PatchMapping("/{albumId}")
+	public ResponseEntity<ApiResponse<String>> updateAlbumInfo(
+		@PathVariable Long albumId,
+		@RequestBody AlbumUpdateRequestDto requestDto,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
-		albumService.updateAlbumInfo(userDetails.getUserId(), requestDto);
+		albumService.updateAlbumInfo(userDetails.getUserId(), albumId, requestDto);
 
 		return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK));
 	}
@@ -138,9 +142,9 @@ public class AlbumController {
 	 * @param albumId 앨범 ID
 	 * @return 추가로 반환되는 데이터는 없습니다.
 	 */
-	@DeleteMapping
+	@DeleteMapping("/{albumId}")
 	public ResponseEntity<ApiResponse<String>> deleteAlbum(@AuthenticationPrincipal CustomUserDetails userDetails,
-		@RequestParam Long albumId) {
+		@PathVariable Long albumId) {
 		albumService.deleteAlbum(userDetails.getUserId(), albumId);
 		return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK));
 	}

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/album/dto/request/AlbumImageEditRequestDto.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/album/dto/request/AlbumImageEditRequestDto.java
@@ -2,7 +2,6 @@ package com.trackery.trackerybackapiserver.domain.album.dto.request;
 
 import java.util.List;
 
-import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -21,10 +20,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class AlbumImageEditRequestDto {
 	/**
-	 * albumId 앨범 ID
-	 * imageIdList 이미지 ID 리스트
+	 * 이미지 ID 리스트
 	 */
-	@NotNull
-	private Long albumId;
 	private List<Long> imageIdList;
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/album/dto/request/AlbumUpdateRequestDto.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/album/dto/request/AlbumUpdateRequestDto.java
@@ -1,6 +1,5 @@
 package com.trackery.trackerybackapiserver.domain.album.dto.request;
 
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,13 +22,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class AlbumUpdateRequestDto {
 	/*
-	albumId 앨범 ID(필수)
 	albumTitle 앨범 제목
 	albumDescription 앨범 설명
 	isPublic 공개 여부
 	 */
-	@NotNull
-	private Long albumId;
 	private String albumTitle;
 	private String albumDescription;
 	private Integer isPublic;

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/album/mapper/AlbumMapper.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/album/mapper/AlbumMapper.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import com.trackery.trackerybackapiserver.domain.album.dto.request.AlbumUpdateRequestDto;
 import com.trackery.trackerybackapiserver.domain.album.entity.Album;
@@ -43,7 +44,7 @@ public interface AlbumMapper {
 
 	List<AlbumImage> findAlbumImagesByAlbumId(Long albumId);
 
-	void updateAlbumInfo(AlbumUpdateRequestDto albumUpdateRequestDto);
+	void updateAlbumInfo(@Param("albumId") Long albumId, @Param("dto") AlbumUpdateRequestDto albumUpdateRequestDto);
 
 	List<Album> findAlbumsByUserId(Long userId);
 

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/album/service/AlbumService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/album/service/AlbumService.java
@@ -210,12 +210,10 @@ public class AlbumService {
 	 * @param userId 유저 ID
 	 * @param albumUpdateRequestDto 앨범 정보 수정 Request DTO
 	 */
-	public void updateAlbumInfo(Long userId, AlbumUpdateRequestDto albumUpdateRequestDto) {
-		Long albumId = albumUpdateRequestDto.getAlbumId();
-
+	public void updateAlbumInfo(Long userId, Long albumId, AlbumUpdateRequestDto albumUpdateRequestDto) {
 		findAlbumAndCheckPermission(userId, albumId);
 
-		albumMapper.updateAlbumInfo(albumUpdateRequestDto);
+		albumMapper.updateAlbumInfo(albumId, albumUpdateRequestDto);
 	}
 
 	/**

--- a/src/main/resources/mapper/AlbumMapper.xml
+++ b/src/main/resources/mapper/AlbumMapper.xml
@@ -67,19 +67,19 @@
         SELECT * FROM album_image WHERE album_id = #{albumId}
     </select>
 
-    <update id="updateAlbumInfo" parameterType="com.trackery.trackerybackapiserver.domain.album.dto.request.AlbumUpdateRequestDto">
+    <update id="updateAlbumInfo">
         UPDATE album
         <set>
             album_mod_date = CONVERT_TZ(NOW(), 'UTC', 'Asia/Seoul'),
 
-            <if test="albumTitle != null and albumTitle != ''">
-                album_title = #{albumTitle},
+            <if test="dto.albumTitle != null and dto.albumTitle != ''">
+                album_title = #{dto.albumTitle},
             </if>
-            <if test="albumDescription != null">
-                album_description = #{albumDescription},
+            <if test="dto.albumDescription != null">
+                album_description = #{dto.albumDescription},
             </if>
-            <if test="isPublic != null">
-                is_public = #{isPublic},
+            <if test="dto.isPublic != null">
+                is_public = #{dto.isPublic},
             </if>
         </set>
         WHERE album_id = #{albumId}

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/album/controller/AlbumControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/album/controller/AlbumControllerTest.java
@@ -101,7 +101,6 @@ class AlbumControllerTest extends CommonMockMvcControllerTestSetUp {
 	@Test
 	void addImagesIntoAlbumSuccess() throws Exception {
 		AlbumImageEditRequestDto requestDto = new AlbumImageEditRequestDto();
-		ReflectionTestUtils.setField(requestDto, "albumId", 1L);
 		ReflectionTestUtils.setField(requestDto, "imageIdList", List.of(10L, 20L));
 
 		HashMap<Long, String> failedImageMap = new HashMap<>();
@@ -117,7 +116,7 @@ class AlbumControllerTest extends CommonMockMvcControllerTestSetUp {
 
 		when(albumService.addImageIntoAlbum(any(), any(), any())).thenReturn(responseDto);
 
-		ResultActions result = mockMvc.perform(post("/api/albums/images")
+		ResultActions result = mockMvc.perform(post("/api/albums/{albumId}/images", 1L)
 			.with(user(customUserDetails))
 			.with(csrf())
 			.contentType(MediaType.APPLICATION_JSON)
@@ -136,8 +135,10 @@ class AlbumControllerTest extends CommonMockMvcControllerTestSetUp {
 
 		result
 			.andDo(document("add-images-into-album",
+					pathParameters(
+						parameterWithName("albumId").description("앨범 ID")
+					),
 					requestFields(
-						fieldWithPath("albumId").description("이미지를 추가할 앨범 ID"),
 						fieldWithPath("imageIdList").description("앨범에 추가할 이미지 ID 리스트")
 					),
 
@@ -171,9 +172,8 @@ class AlbumControllerTest extends CommonMockMvcControllerTestSetUp {
 
 		when(albumService.getAlbumDetailedInfo(any(), eq(albumId))).thenReturn(responseDto);
 
-		ResultActions result = mockMvc.perform(get("/api/albums")
-			.with(user(customUserDetails))
-			.param("albumId", String.valueOf(1L)));
+		ResultActions result = mockMvc.perform(get("/api/albums/{albumId}", albumId)
+			.with(user(customUserDetails)));
 
 		result
 			.andExpect(status().isOk())
@@ -187,10 +187,9 @@ class AlbumControllerTest extends CommonMockMvcControllerTestSetUp {
 
 		result
 			.andDo(document("get-album-detailed-info",
-					queryParameters(
+					pathParameters(
 						parameterWithName("albumId").description("앨범 ID")
 					),
-
 					responseFields(
 						fieldWithPath("code").description("응답 코드"),
 						fieldWithPath("message").description("응답 메시지"),
@@ -209,15 +208,14 @@ class AlbumControllerTest extends CommonMockMvcControllerTestSetUp {
 	@Test
 	void updateAlbumInfoSuccess() throws Exception {
 		AlbumUpdateRequestDto requestDto = AlbumUpdateRequestDto.builder()
-			.albumId(1L)
 			.albumTitle("앨범 제목 수정")
 			.albumDescription("앨범 설명 수정")
 			.isPublic(1)
 			.build();
 
-		doNothing().when(albumService).updateAlbumInfo(any(), any());
+		doNothing().when(albumService).updateAlbumInfo(any(), any(), any());
 
-		ResultActions result = mockMvc.perform(patch("/api/albums")
+		ResultActions result = mockMvc.perform(patch("/api/albums/{albumId}", 1L)
 			.with(user(customUserDetails))
 			.with(csrf())
 			.contentType(MediaType.APPLICATION_JSON)
@@ -227,8 +225,10 @@ class AlbumControllerTest extends CommonMockMvcControllerTestSetUp {
 			.andExpect(status().isOk());
 
 		result.andDo(document("update-album-info",
+			pathParameters(
+				parameterWithName("albumId").description("앨범 ID")
+			),
 			requestFields(
-				fieldWithPath("albumId").description("앨범 ID").type(JsonFieldType.NUMBER),
 				fieldWithPath("albumTitle").description("앨범 제목").type(JsonFieldType.STRING),
 				fieldWithPath("albumDescription").description("앨범 설명").type(JsonFieldType.STRING),
 				fieldWithPath("isPublic").description("공개 여부").type(JsonFieldType.NUMBER)
@@ -244,7 +244,6 @@ class AlbumControllerTest extends CommonMockMvcControllerTestSetUp {
 	@Test
 	void deleteImagesFromAlbumSuccess() throws Exception {
 		AlbumImageEditRequestDto requestDto = new AlbumImageEditRequestDto();
-		ReflectionTestUtils.setField(requestDto, "albumId", 1L);
 		ReflectionTestUtils.setField(requestDto, "imageIdList", List.of(10L, 20L));
 
 		HashMap<Long, String> failedImageMap = new HashMap<>();
@@ -260,7 +259,7 @@ class AlbumControllerTest extends CommonMockMvcControllerTestSetUp {
 
 		when(albumService.deleteImageFromAlbum(any(), any(), any())).thenReturn(responseDto);
 
-		ResultActions result = mockMvc.perform(delete("/api/albums/images")
+		ResultActions result = mockMvc.perform(delete("/api/albums/{albumId}/images", 1L)
 			.with(user(customUserDetails))
 			.with(csrf())
 			.contentType(MediaType.APPLICATION_JSON)
@@ -278,8 +277,10 @@ class AlbumControllerTest extends CommonMockMvcControllerTestSetUp {
 			.andExpect(jsonPath("$.data.failedImageIds").isNotEmpty());
 
 		result.andDo(document("delete-images-from-album",
+				pathParameters(
+					parameterWithName("albumId").description("앨범 ID")
+				),
 				requestFields(
-					fieldWithPath("albumId").description("앨범 ID"),
 					fieldWithPath("imageIdList").description("앨범 ID 리스트")
 				),
 
@@ -350,10 +351,9 @@ class AlbumControllerTest extends CommonMockMvcControllerTestSetUp {
 
 		doNothing().when(albumService).deleteAlbum(any(), eq(albumId));
 
-		ResultActions result = mockMvc.perform(delete("/api/albums")
+		ResultActions result = mockMvc.perform(delete("/api/albums/{albumId}", albumId)
 			.with(user(customUserDetails))
-			.with(csrf())
-			.queryParam("albumId", String.valueOf(albumId)));
+			.with(csrf()));
 
 		result
 			.andExpect(status().isOk())
@@ -361,10 +361,9 @@ class AlbumControllerTest extends CommonMockMvcControllerTestSetUp {
 
 		result
 			.andDo(document("delete-album",
-					queryParameters(
+					pathParameters(
 						parameterWithName("albumId").description("앨범 ID")
 					),
-
 					responseFields(
 						fieldWithPath("code").description("응답 코드"),
 						fieldWithPath("message").description("응답 메시지")

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/album/service/AlbumServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/album/service/AlbumServiceTest.java
@@ -151,8 +151,10 @@ class AlbumServiceTest {
 			void testDeleteImageFromAlbum_AlbumNotFound() {
 				when(albumMapper.findByAlbumId(ALBUM_ID)).thenReturn(Optional.empty());
 
+				List<Long> imageIds = List.of(1L);
+
 				ApiException exception = assertThrows(ApiException.class,
-					() -> albumService.deleteImageFromAlbum(USER_ID, ALBUM_ID, List.of(1L)));
+					() -> albumService.deleteImageFromAlbum(USER_ID, ALBUM_ID, imageIds));
 
 				assertEquals(ErrorCode.NOT_FOUND_ALBUM, exception.getErrorCode());
 				verify(albumMapper, never()).deleteAlbumImageByAlbumImageId(anyLong());
@@ -164,8 +166,10 @@ class AlbumServiceTest {
 				Album forbiddenAlbum = Album.builder().userId(2L).build();
 				when(albumMapper.findByAlbumId(ALBUM_ID)).thenReturn(Optional.of(forbiddenAlbum));
 
+				List<Long> imageIds = List.of(1L);
+
 				ApiException exception = assertThrows(ApiException.class,
-					() -> albumService.deleteImageFromAlbum(USER_ID, ALBUM_ID, List.of(1L)));
+					() -> albumService.deleteImageFromAlbum(USER_ID, ALBUM_ID, imageIds));
 
 				assertEquals(ErrorCode.FORBIDDEN, exception.getErrorCode());
 				verify(albumMapper, never()).deleteAlbumImageByAlbumImageId(anyLong());
@@ -315,6 +319,7 @@ class AlbumServiceTest {
 				verify(albumMapper).findByAlbumId(ALBUM_ID);
 				verify(albumMapper).findAlbumImagesByAlbumId(ALBUM_ID);
 				verify(imageMapper, times(2)).findImageByImageId(anyLong());
+				verify(imageService, times(2)).convertImageToImageDto(any(Image.class));
 			}
 		}
 

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/album/service/AlbumServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/album/service/AlbumServiceTest.java
@@ -353,40 +353,37 @@ class AlbumServiceTest {
 		@DisplayName("성공")
 		void testUpdateAlbumInfo_Success() {
 			AlbumUpdateRequestDto requestDto = AlbumUpdateRequestDto.builder()
-				.albumId(ALBUM_ID)
 				.build();
 
 			when(albumMapper.findByAlbumId(ALBUM_ID)).thenReturn(Optional.of(album));
 
-			doNothing().when(albumMapper).updateAlbumInfo(requestDto);
+			doNothing().when(albumMapper).updateAlbumInfo(ALBUM_ID, requestDto);
 
-			assertDoesNotThrow(() -> albumService.updateAlbumInfo(USER_ID, requestDto));
+			assertDoesNotThrow(() -> albumService.updateAlbumInfo(USER_ID, ALBUM_ID, requestDto));
 
-			verify(albumMapper).updateAlbumInfo(requestDto);
+			verify(albumMapper).updateAlbumInfo(ALBUM_ID, requestDto);
 		}
 
 		@Test
 		@DisplayName("실패 - 앨범을 찾을 수 없음")
 		void testUpdateAlbumInfo_AlbumNotFound() {
 			AlbumUpdateRequestDto requestDto = AlbumUpdateRequestDto.builder()
-				.albumId(ALBUM_ID)
 				.build();
 
 			when(albumMapper.findByAlbumId(ALBUM_ID)).thenReturn(Optional.empty());
 
 			ApiException exception = assertThrows(ApiException.class,
-				() -> albumService.updateAlbumInfo(USER_ID, requestDto));
+				() -> albumService.updateAlbumInfo(USER_ID, ALBUM_ID, requestDto));
 
 			assertEquals(ErrorCode.NOT_FOUND_ALBUM, exception.getErrorCode());
 
-			verify(albumMapper, never()).updateAlbumInfo(any());
+			verify(albumMapper, never()).updateAlbumInfo(any(), any());
 		}
 
 		@Test
 		@DisplayName("실패 - 유저가 앨범에 접근 권한이 없음")
 		void testUpdateAlbumInfo_ForbiddenAccess() {
 			AlbumUpdateRequestDto requestDto = AlbumUpdateRequestDto.builder()
-				.albumId(5L)
 				.build();
 
 			Album forbiddenAlbum = Album.builder()
@@ -397,11 +394,11 @@ class AlbumServiceTest {
 			when(albumMapper.findByAlbumId(5L)).thenReturn(Optional.of(forbiddenAlbum));
 
 			ApiException exception = assertThrows(ApiException.class,
-				() -> albumService.updateAlbumInfo(USER_ID, requestDto));
+				() -> albumService.updateAlbumInfo(USER_ID, 5L, requestDto));
 
 			assertEquals(ErrorCode.FORBIDDEN, exception.getErrorCode());
 
-			verify(albumMapper, never()).updateAlbumInfo(any());
+			verify(albumMapper, never()).updateAlbumInfo(any(), any());
 		}
 	}
 


### PR DESCRIPTION
리소스에 접근할 때 쿼리스트링으로 자원에 접근하는 대신 
URL에 직접 포함되도록 앨범 도메인 엔드포인트를 수정했습니다.


