### PR TITLE
feature/User-api-문서화

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -11,4 +11,5 @@ include::{snippets}/get-public-images/http-response.adoc[]
 include::{snippets}/get-public-images/response-fields.adoc[]
 
 include::album-api.adoc[]
-
+include::location-api.adoc[]
+include::user-api.adoc[]

--- a/src/docs/asciidoc/user-api.adoc
+++ b/src/docs/asciidoc/user-api.adoc
@@ -1,0 +1,146 @@
+== 사용자 API
+'''
+
+=== 사용자 회원가입 API
+==== POST /api/users/register
+
+사용자 이름, 이메일, 비밀번호를 받아서 회원가입을 처리하는 API입니다.
+이메일 중복 확인과 이메일 인증 메일 발송을 포함합니다.
+
+===== 요청
+include::{snippets}/register-user-success/http-request.adoc[]
+include::{snippets}/register-user-success/request-fields.adoc[]
+
+===== 응답
+include::{snippets}/register-user-success/http-response.adoc[]
+include::{snippets}/register-user-success/response-fields.adoc[]
+'''
+
+=== 사용자 로그인 API
+==== POST /api/users/login
+
+이메일과 비밀번호로 로그인하는 API입니다.
+성공 시 JWT 토큰을 HTTP-only 쿠키에 설정합니다.
+
+===== 요청
+include::{snippets}/login-user-success/http-request.adoc[]
+include::{snippets}/login-user-success/request-fields.adoc[]
+
+===== 응답
+include::{snippets}/login-user-success/http-response.adoc[]
+include::{snippets}/login-user-success/response-fields.adoc[]
+'''
+
+=== 사용자 상세 정보 조회 API
+==== GET /api/users/details
+
+인증된 사용자의 상세 정보를 조회하는 API입니다.
+JWT 토큰을 통해 사용자 정보를 확인합니다.
+
+===== 요청
+include::{snippets}/get-user-detailed-info-success/http-request.adoc[]
+
+===== 응답
+include::{snippets}/get-user-detailed-info-success/http-response.adoc[]
+include::{snippets}/get-user-detailed-info-success/response-fields.adoc[]
+'''
+
+=== 사용자명 중복 확인 API
+==== GET /api/users/exists/username
+
+사용자명의 사용 가능 여부를 확인하는 API입니다.
+
+===== 요청
+include::{snippets}/check-username-availability-success/http-request.adoc[]
+include::{snippets}/check-username-availability-success/query-parameters.adoc[]
+
+===== 응답
+include::{snippets}/check-username-availability-success/http-response.adoc[]
+include::{snippets}/check-username-availability-success/response-fields.adoc[]
+'''
+
+=== 비밀번호 변경 API
+==== PATCH /api/users/me/password
+
+인증된 사용자의 비밀번호를 변경하는 API입니다.
+기존 비밀번호 확인 후 새 비밀번호로 변경합니다.
+
+===== 요청
+include::{snippets}/update-user-password-success/http-request.adoc[]
+include::{snippets}/update-user-password-success/request-fields.adoc[]
+
+===== 응답
+include::{snippets}/update-user-password-success/http-response.adoc[]
+include::{snippets}/update-user-password-success/response-fields.adoc[]
+'''
+
+=== OAuth 로그인 API
+==== GET /api/users/oauth/login/{provider}
+
+OAuth 제공자(Naver, Kakao, Google, GitHub)를 통한 로그인 API입니다.
+인증 코드를 받아서 JWT 토큰을 발급합니다.
+
+===== 요청
+include::{snippets}/oauth-login-success/http-request.adoc[]
+include::{snippets}/oauth-login-success/path-parameters.adoc[]
+include::{snippets}/oauth-login-success/query-parameters.adoc[]
+
+===== 응답
+include::{snippets}/oauth-login-success/http-response.adoc[]
+include::{snippets}/oauth-login-success/response-fields.adoc[]
+'''
+
+=== OAuth 계정 연동 API
+==== POST /api/users/oauth/link-account
+
+기존 사용자 계정에 OAuth 계정을 연동하는 API입니다.
+인증된 사용자만 사용할 수 있습니다.
+
+===== 요청
+include::{snippets}/oauth-link-success/http-request.adoc[]
+include::{snippets}/oauth-link-success/request-fields.adoc[]
+
+===== 응답
+include::{snippets}/oauth-link-success/http-response.adoc[]
+include::{snippets}/oauth-link-success/response-fields.adoc[]
+'''
+
+=== 사용자 프로필 조회 API
+==== GET /api/users/profile/me
+
+인증된 사용자의 프로필 정보를 조회하는 API입니다.
+사용자 ID, 사용자명, 닉네임, 프로필 이미지 URL을 반환합니다.
+
+===== 요청
+include::{snippets}/get-user-profile-success/http-request.adoc[]
+
+===== 응답 (성공)
+include::{snippets}/get-user-profile-success/http-response.adoc[]
+include::{snippets}/get-user-profile-success/response-fields.adoc[]
+
+===== 예외 상황
+- 사용자를 찾을 수 없는 경우: `ApiException(ErrorCode.NOT_FOUND)` 발생
+- 인증되지 않은 사용자의 경우: `ApiException(ErrorCode.UNAUTHORIZED)` 발생
+- 프로필 이미지가 없는 경우: `userProfilePic` 필드에 `null` 값 반환
+
+===== 테스트 케이스
+- 정상적인 프로필 조회 (프로필 이미지 포함)
+- 프로필 이미지가 없는 경우의 조회
+- 존재하지 않는 사용자의 프로필 조회 시도
+- 인증되지 않은 사용자의 접근 시도
+'''
+
+=== 사용자 정보 수정 API
+==== PATCH /api/users/info
+
+사용자의 기본 정보(이름, 이메일 등)를 수정하는 API입니다.
+각 필드 중 입력이 들어온 필드만 업데이트가 이뤄집니다.
+
+===== 요청
+include::{snippets}/update-user-info-success/http-request.adoc[]
+include::{snippets}/update-user-info-success/request-fields.adoc[]
+
+===== 응답
+include::{snippets}/update-user-info-success/http-response.adoc[]
+include::{snippets}/update-user-info-success/response-fields.adoc[]
+'''

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/location/controller/LocationControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/location/controller/LocationControllerTest.java
@@ -44,7 +44,8 @@ import com.trackery.trackerybackapiserver.domain.user.entity.CustomUserDetails;
  * DATE              AUTHOR             NOTE
  * -----------------------------------------------------------
  * 25. 4. 23.		durururuk		최초 생성
- * 25. 6. 13.		Narilee			테스트 추가
+ * 25. 6. 13.		inari			테스트 추가
+ * 25. 6. 15.		inari			Spring-Rest-Docs api문서 추가
  */
 @WebMvcTest(LocationController.class)
 public class LocationControllerTest extends CommonMockMvcControllerTestSetUp {

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/user/controller/OAuthControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/user/controller/OAuthControllerTest.java
@@ -2,6 +2,9 @@ package com.trackery.trackerybackapiserver.domain.user.controller;
 
 import static org.mockito.Mockito.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import org.junit.jupiter.api.DisplayName;
@@ -36,6 +39,7 @@ import com.trackery.trackerybackapiserver.domain.user.service.OAuthService;
  * -----------------------------------------------------------
  * 25. 3. 3.        inari       최초 생성
  * 25. 3. 26.       inari       계정 연동 토큰 테스트 추가
+ * 25. 6. 17.		inari		Spring-Rest-Docs api문서 추가
  */
 @WithMockUser
 @WebMvcTest({OAuthController.class, GlobalExceptionHandler.class})
@@ -101,7 +105,7 @@ class OAuthControllerTest extends CommonMockMvcControllerTestSetUp {
 
 		// when
 		ResultActions resultActions = mockMvc
-			.perform(get("/api/users/oauth/login/naver")
+			.perform(get("/api/users/oauth/login/{provider}", "naver")
 				.queryParam("code", "auth_code")
 				.queryParam("state", "state")
 				.contentType(MediaType.APPLICATION_JSON));
@@ -112,7 +116,22 @@ class OAuthControllerTest extends CommonMockMvcControllerTestSetUp {
 			.andExpect(cookie().exists("accessToken"))
 			.andExpect(cookie().httpOnly("accessToken", true))
 			.andExpect(cookie().value("accessToken", "jwt"))
-			.andExpect(jsonPath("$.data.existingEmail").value(false));
+			.andExpect(jsonPath("$.data.existingEmail").value(false))
+			.andDo(document("oauth-login-success",
+				pathParameters(
+					parameterWithName("provider").description("OAuth 제공자 (naver, kakao, google, github)")
+				),
+				queryParameters(
+					parameterWithName("code").description("인증 코드"),
+					parameterWithName("state").description("상태 값").optional()
+				),
+				responseFields(
+					fieldWithPath("code").description("상태 코드"),
+					fieldWithPath("message").description("응답 메시지"),
+					fieldWithPath("data.email").description("사용자 이메일").optional(),
+					fieldWithPath("data.existingEmail").description("기존 이메일 존재 여부")
+				)
+			));
 	}
 
 	@Test
@@ -209,7 +228,20 @@ class OAuthControllerTest extends CommonMockMvcControllerTestSetUp {
 		resultActions
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.token").value(TOKEN))
-			.andExpect(jsonPath("$.data.provider").value(PROVIDER));
+			.andExpect(jsonPath("$.data.provider").value(PROVIDER))
+			.andDo(document("oauth-link-success",
+				requestFields(
+					fieldWithPath("provider").description("OAuth 제공자"),
+					fieldWithPath("email").description("연결할 이메일"),
+					fieldWithPath("linkAccount").description("계정 연동 여부").optional()
+				),
+				responseFields(
+					fieldWithPath("code").description("상태 코드"),
+					fieldWithPath("message").description("응답 메시지"),
+					fieldWithPath("data.token").description("연결 토큰"),
+					fieldWithPath("data.provider").description("OAuth 제공자")
+				)
+			));
 
 		verify(oAuthLinkService).createLinkToken(PROVIDER, EMAIL);
 	}

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/user/controller/UpdateUserInfoControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/user/controller/UpdateUserInfoControllerTest.java
@@ -3,6 +3,8 @@ package com.trackery.trackerybackapiserver.domain.user.controller;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -26,6 +28,18 @@ import com.trackery.trackerybackapiserver.domain.user.service.UpdateUserInfoServ
 
 import jakarta.servlet.http.Cookie;
 
+/**
+ * packageName    : com.trackery.trackerybackapiserver.domain.user.controller
+ * fileName       : UpdateUserInfoControllerTest
+ * author         : inari
+ * date           : 25. 4. 14.
+ * description    : 유저 정보 수정 컨트롤러의 테스트 클래스입니다.
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 25. 2. 14.       durururuk       최초 생성
+ * 25. 6. 17.		inari		Spring-Rest-Docs api문서 추가
+ */
 @WebMvcTest(UpdateUserInfoController.class)
 class UpdateUserInfoControllerTest extends CommonMockMvcControllerTestSetUp {
 
@@ -137,7 +151,18 @@ class UpdateUserInfoControllerTest extends CommonMockMvcControllerTestSetUp {
 					.content(objectMapper.writeValueAsString(dto))
 					.with(user(customUserDetails)))
 				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.message").value("Ok"));
+				.andExpect(jsonPath("$.message").value("Ok"))
+				.andDo(document("update-user-password-success",
+					requestFields(
+						fieldWithPath("oldPassword").description("기존 비밀번호"),
+						fieldWithPath("newPassword").description("새 비밀번호")
+					),
+					responseFields(
+						fieldWithPath("code").description("상태 코드"),
+						fieldWithPath("message").description("응답 메시지"),
+						fieldWithPath("data").type(Object.class).description("응답 데이터").optional()
+					)
+				));
 
 			verify(updateUserInfoService, times(1))
 				.updatePasswordByAuthentication(eq(1L), any(UpdatePasswordDto.class));
@@ -162,6 +187,38 @@ class UpdateUserInfoControllerTest extends CommonMockMvcControllerTestSetUp {
 
 			verify(updateUserInfoService, times(1))
 				.updateEmail(1L, "test-email-token");
+		}
+	}
+	
+	@Nested
+	@DisplayName("사용자 정보 수정 API MockMvc 테스트")
+	class UpdateUserInfoTest {
+		@Test
+		@DisplayName("성공")
+		void success() throws Exception {
+			UpdateNicknameDto updateNicknameDto = new UpdateNicknameDto();
+			ReflectionTestUtils.setField(updateNicknameDto, "nickname", "김커피");
+
+			doNothing().when(updateUserInfoService).updateUserNickname(1L, "김커피");
+
+			mockMvc.perform(patch("/api/users/me/nickname")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(updateNicknameDto))
+					.with(user(customUserDetails)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.message").value("Ok"))
+				.andDo(document("update-user-info-success",
+					requestFields(
+						fieldWithPath("nickname").description("수정할 닉네임").optional()
+					),
+					responseFields(
+						fieldWithPath("code").description("상태 코드"),
+						fieldWithPath("message").description("응답 메시지"),
+						fieldWithPath("data").type(Object.class).description("응답 데이터").optional()
+					)
+				));
+
+			verify(updateUserInfoService, times(1)).updateUserNickname(anyLong(), any());
 		}
 	}
 }

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/user/controller/UserControllerTest.java
@@ -2,6 +2,10 @@ package com.trackery.trackerybackapiserver.domain.user.controller;
 
 import static org.mockito.Mockito.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.relaxedResponseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -33,21 +37,20 @@ import com.trackery.trackerybackapiserver.domain.user.service.UserService;
 import jakarta.servlet.http.Cookie;
 
 /**
- *packageName    : com.trackery.trackerybackapiserver.domain.user.controller
-
- fileName       : UserControllerTest
- author         : durururuk
- date           : 25. 2. 14.
- description    : UserController 테스트코드
- ===========================================================
- DATE              AUTHOR             NOTE
- -----------------------------------------------------------
- 25. 2. 14.        durururuk       최초 생성
- 25. 2. 14.        durururuk       로그인 컨트롤러 테스트 코드 작성
- 25. 4. 09.		   durururuk	   유저 상세정보 조회 API 단위테스트 코드 작성
- 25. 4. 10.		   durururuk	   인증 기반 비밀번호 변경 컨트롤러 mockMvc 테스트 작성
+ * packageName    : com.trackery.trackerybackapiserver.domain.user.controller
+ * fileName       : UserControllerTest
+ * author         : durururuk
+ * date           : 25. 2. 14.
+ * description    : 유저 컨트롤러의 테스트 클래스입니다.
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 25. 2. 14.        durururuk      최초 생성
+ * 25. 2. 14.        durururuk      로그인 컨트롤러 테스트 코드 작성
+ * 25. 4. 09.		 durururuk	   	유저 상세정보 조회 API 단위테스트 코드 작성
+ * 25. 4. 10.		 durururuk	    인증 기반 비밀번호 변경 컨트롤러 mockMvc 테스트 작성
+ * 25. 6. 17.		 inari		    Spring-Rest-Docs api문서 추가
  */
-
 @WebMvcTest(UserController.class)
 class UserControllerTest extends CommonMockMvcControllerTestSetUp {
 	@Autowired
@@ -92,7 +95,18 @@ class UserControllerTest extends CommonMockMvcControllerTestSetUp {
 			.andExpect(cookie().value("accessToken", accessToken))
 			.andExpect(cookie().exists("refreshToken"))
 			.andExpect(cookie().httpOnly("refreshToken", true))
-			.andExpect(cookie().value("refreshToken", refreshToken));
+			.andExpect(cookie().value("refreshToken", refreshToken))
+			.andDo(document("register-user-success",
+				requestFields(
+					fieldWithPath("nickname").description("사용자 닉네임"),
+					fieldWithPath("password").description("사용자 비밀번호"),
+					fieldWithPath("userProfile").description("사용자 프로필 이미지").optional()
+				),
+				relaxedResponseFields(
+					fieldWithPath("code").description("상태 코드"),
+					fieldWithPath("message").description("응답 메시지")
+				)
+			));
 	}
 
 	@Test
@@ -107,7 +121,17 @@ class UserControllerTest extends CommonMockMvcControllerTestSetUp {
 		result.andExpect(status().isOk())
 			.andExpect(cookie().exists("userNameToken"))
 			.andExpect(cookie().value("userNameToken", "jwt"))
-			.andExpect(jsonPath("$.data").value(true));
+			.andExpect(jsonPath("$.data").value(true))
+			.andDo(document("check-username-availability-success",
+				queryParameters(
+					parameterWithName("value").description("확인할 사용자명")
+				),
+				responseFields(
+					fieldWithPath("code").description("상태 코드"),
+					fieldWithPath("message").description("응답 메시지"),
+					fieldWithPath("data").description("사용자명 사용 가능 여부")
+				)
+			));
 	}
 
 	@Test
@@ -134,7 +158,17 @@ class UserControllerTest extends CommonMockMvcControllerTestSetUp {
 			.andExpect(cookie().value("accessToken", accessToken))
 			.andExpect(cookie().exists("refreshToken"))
 			.andExpect(cookie().httpOnly("refreshToken", true))
-			.andExpect(cookie().value("refreshToken", refreshToken));
+			.andExpect(cookie().value("refreshToken", refreshToken))
+			.andDo(document("login-user-success",
+				requestFields(
+					fieldWithPath("userName").description("사용자명"),
+					fieldWithPath("password").description("비밀번호")
+				),
+				relaxedResponseFields(
+					fieldWithPath("code").description("상태 코드"),
+					fieldWithPath("message").description("응답 메시지")
+				)
+			));
 	}
 
 	@Nested
@@ -177,7 +211,22 @@ class UserControllerTest extends CommonMockMvcControllerTestSetUp {
 				.andExpect(jsonPath("$.data.OAuthList[0].oauthId").value(1))
 				.andExpect(jsonPath("$.data.OAuthList[0].userId").value(1))
 				.andExpect(jsonPath("$.data.OAuthList[0].provider").value("KAKAO"))
-				.andExpect(jsonPath("$.data.OAuthList[0].providerUserId").value("155788848"));
+				.andExpect(jsonPath("$.data.OAuthList[0].providerUserId").value("155788848"))
+				.andDo(document("get-user-detailed-info-success",
+					responseFields(
+						fieldWithPath("code").description("상태 코드"),
+						fieldWithPath("message").description("응답 메시지"),
+						fieldWithPath("data.userId").description("사용자 ID"),
+						fieldWithPath("data.userRoleId").description("사용자 역할 ID"),
+						fieldWithPath("data.userName").description("사용자명"),
+						fieldWithPath("data.nickname").description("닉네임"),
+						fieldWithPath("data.email").description("이메일"),
+						fieldWithPath("data.OAuthList[].oauthId").description("OAuth ID"),
+						fieldWithPath("data.OAuthList[].userId").description("연결된 사용자 ID"),
+						fieldWithPath("data.OAuthList[].provider").description("OAuth 제공자"),
+						fieldWithPath("data.OAuthList[].providerUserId").description("제공자 사용자 ID")
+					)
+				));
 		}
 	}
 }

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/user/controller/UserProfileControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/user/controller/UserProfileControllerTest.java
@@ -2,24 +2,28 @@ package com.trackery.trackerybackapiserver.domain.user.controller;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
-import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
+import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
+import com.trackery.trackerybackapiserver.domain.config.CommonMockMvcControllerTestSetUp;
 import com.trackery.trackerybackapiserver.domain.user.dto.UserProfileDto;
 import com.trackery.trackerybackapiserver.domain.user.entity.CustomUserDetails;
 import com.trackery.trackerybackapiserver.domain.user.service.UserService;
@@ -33,60 +37,54 @@ import com.trackery.trackerybackapiserver.domain.user.service.UserService;
  * ===========================================================
  * DATE              AUTHOR             NOTE
  * -----------------------------------------------------------
- * 25. 4. 28.        inari       최초 생성
+ * 25. 4. 28.        inari      	 최초 생성
+ * 25. 6. 17.		 inari		   Spring-Rest-Docs api문서 추가
  */
-@ExtendWith(MockitoExtension.class)
-class UserProfileControllerTest {
+@WebMvcTest(UserProfileController.class)
+class UserProfileControllerTest extends CommonMockMvcControllerTestSetUp {
 
-	private MockMvc mockMvc;
-
-	@Mock
+	@MockitoBean
 	private UserService userService;
-	private UserProfileDto userProfileDto;
+
 	private CustomUserDetails customUserDetails;
-	private TestUserProfileController testController;
+	private UserProfileDto userProfileDto;
 
 	@BeforeEach
 	void setUp() {
-		// CustomUserDetails 모의 객체 생성
-		customUserDetails = mock(CustomUserDetails.class);
-		lenient().when(customUserDetails.getUserId()).thenReturn(1L); // 명시적으로 ID 설정
-
-		// 불필요한 스터빙 제거 또는 lenient 모드로 변경
-		// username은 실제 테스트에서 사용되지 않지만 테스트 가독성을 위해 유지하고 lenient 설정
-		lenient().when(customUserDetails.getUsername()).thenReturn("testuser");
-
-		// 테스트용 컨트롤러 생성
-		testController = new TestUserProfileController(userService, customUserDetails);
-
-		// MockMvc 설정
-		mockMvc = MockMvcBuilders
-			.standaloneSetup(testController)
-			.addFilter(new CharacterEncodingFilter("UTF-8", true))
+		customUserDetails = CustomUserDetails.builder()
+			.userId(1L)
+			.roleId(1L)
+			.userName("testuser")
 			.build();
 
-		// 테스트 데이터 설정
 		userProfileDto = new UserProfileDto(1L, "testuser", "테스트유저", "profile-image-url");
 	}
 
 	@Test
 	@DisplayName("내 프로필 조회 성공")
 	void getMyProfile_success() throws Exception {
-		// given
 		when(userService.getUserProfile(1L)).thenReturn(userProfileDto);
 
-		// when & then
-		mockMvc.perform(MockMvcRequestBuilders.get("/api/users/profile/me")
-				.contentType(MediaType.APPLICATION_JSON)
-				.with(user(customUserDetails)))
-			.andDo(MockMvcResultHandlers.print())
+		ResultActions result = mockMvc.perform(get("/api/users/profile/me")
+			.with(user(customUserDetails)));
+
+		result
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.code").value("200"))
 			.andExpect(jsonPath("$.message").value("Ok"))
 			.andExpect(jsonPath("$.data.userId").value(1L))
 			.andExpect(jsonPath("$.data.userName").value("testuser"))
 			.andExpect(jsonPath("$.data.nickname").value("테스트유저"))
-			.andExpect(jsonPath("$.data.userProfilePic").value("profile-image-url"));
+			.andExpect(jsonPath("$.data.userProfilePic").value("profile-image-url"))
+			.andDo(document("get-user-profile-success",
+				responseFields(
+					fieldWithPath("code").description("상태 코드"),
+					fieldWithPath("message").description("응답 메시지"),
+					fieldWithPath("data.userId").description("사용자 ID"),
+					fieldWithPath("data.userName").description("사용자명"),
+					fieldWithPath("data.nickname").description("닉네임"),
+					fieldWithPath("data.userProfilePic").description("프로필 이미지 URL")
+				)
+			));
 
 		verify(userService, times(1)).getUserProfile(1L);
 	}
@@ -97,19 +95,10 @@ class UserProfileControllerTest {
 		// given
 		when(userService.getUserProfile(1L)).thenThrow(new ApiException(ErrorCode.NOT_FOUND));
 
-		// Controller.getMyProfile은 예외를 던지도록 되어 있음
-		// 예외는 일반적으로 전역 예외 핸들러에 의해 처리되지만 테스트에서는 제대로 설정되지 않았음
-		// 따라서 예외가 발생하는지 직접 테스트
-		try {
-			mockMvc.perform(MockMvcRequestBuilders.get("/api/users/profile/me")
-				.contentType(MediaType.APPLICATION_JSON));
-			fail("예외가 발생해야 합니다");
-		} catch (Exception e) {
-			// 근본 원인인 ApiException을 확인
-			Throwable rootCause = getRootCause(e);
-			assertTrue(rootCause instanceof ApiException);
-			assertEquals(ErrorCode.NOT_FOUND, ((ApiException) rootCause).getErrorCode());
-		}
+		// when & then - 전역 예외 핸들러가 있으므로 404 상태 코드 반환
+		mockMvc.perform(get("/api/users/profile/me")
+			.with(user(customUserDetails)))
+			.andExpect(status().isNotFound());
 
 		verify(userService, times(1)).getUserProfile(1L);
 	}
@@ -131,8 +120,8 @@ class UserProfileControllerTest {
 		when(userService.getUserProfile(1L)).thenReturn(profileWithoutImage);
 
 		// when & then
-		mockMvc.perform(MockMvcRequestBuilders.get("/api/users/profile/me")
-				.contentType(MediaType.APPLICATION_JSON))
+		mockMvc.perform(get("/api/users/profile/me")
+				.with(user(customUserDetails)))
 			.andDo(MockMvcResultHandlers.print())
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value("200"))


### PR DESCRIPTION
1. User API 문서화: Spring REST Docs를 활용해 User 도메인의 전체 API 문서를 생성
2. 테스트 리팩터링: 기존 User 도메인 테스트를 변경된 도메인에 맞춰 수정 및 Spring REST Docs에 맞게 전면 리팩터링
3. API 문서 추가: 회원가입, 로그인, OAuth, 프로필 관리 등 User 관련 모든 엔드포인트 문서화
