### PR TITLE
페이지네이션 종속성 추가, 내 이미지 목록 조회 API V2버전 추가

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>3.4.1</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<relativePath/>
 	</parent>
 	<groupId>com.trackery</groupId>
 	<artifactId>Trackery-BackAPIServer</artifactId>
@@ -151,6 +151,11 @@
 			<artifactId>spring-restdocs-asciidoctor</artifactId>
 			<version>${spring-restdocs.version}</version>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.github.pagehelper</groupId>
+			<artifactId>pagehelper-spring-boot-starter</artifactId>
+			<version>2.1.0</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/controller/ImageController.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/controller/ImageController.java
@@ -62,6 +62,13 @@ public class ImageController {
 		return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, imageDtoList));
 	}
 
+	/**
+	 * 현재 인증된 유저가 업로드한 이미지 조회 API 페이지네이션 버전
+	 * @param userDetails 인증 유저 정보
+	 * @param pageNum 페이지 번호 (기본값 : 1)
+	 * @param pageSize 페이지 크기 (기본값 : 10)
+	 * @return 페이지네이션된 이미지 DTO 리스트
+	 */
 	@GetMapping("/v2/me")
 	public ResponseEntity<ApiResponse<PageInfo<ImageDto>>> getMyImagesV2(
 		@AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/controller/ImageController.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/controller/ImageController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.github.pagehelper.PageInfo;
 import com.trackery.trackerybackapiserver.domain.common.response.ApiResponse;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.SuccessCode;
 import com.trackery.trackerybackapiserver.domain.image.dto.ImageDto;
@@ -56,6 +57,17 @@ public class ImageController {
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		List<ImageDto> imageDtoList = imageService.getImageListByUserId(userDetails.getUserId());
 
+		return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, imageDtoList));
+	}
+
+	@GetMapping("/v2/me")
+	public ResponseEntity<ApiResponse<PageInfo<ImageDto>>> getMyImagesV2(
+		@AuthenticationPrincipal CustomUserDetails userDetails,
+			@RequestParam(defaultValue = "1") int pageNum,
+			@RequestParam(defaultValue = "10") int pageSize
+	) {
+		PageInfo<ImageDto> imageDtoList = imageService.getImageListByUserIdV2(userDetails.getUserId(), pageNum,
+			pageSize);
 		return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, imageDtoList));
 	}
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/controller/ImageController.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/controller/ImageController.java
@@ -49,9 +49,11 @@ public class ImageController {
 
 	/**
 	 * 현재 인증된 유저가 업로드한 이미지 다건 조회 API
+	 * @deprecated 페이지네이션 사용 버전으로 프론트 수정 후 삭제 예정 {@link #getMyImagesV2(CustomUserDetails, int, int)}
 	 * @param userDetails 인증 유저 정보
 	 * @return 이미지 정보 DTO
 	 */
+	@Deprecated(forRemoval = true)
 	@GetMapping("/me")
 	public ResponseEntity<ApiResponse<List<ImageDto>>> getMyImages(
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
@@ -63,8 +65,8 @@ public class ImageController {
 	@GetMapping("/v2/me")
 	public ResponseEntity<ApiResponse<PageInfo<ImageDto>>> getMyImagesV2(
 		@AuthenticationPrincipal CustomUserDetails userDetails,
-			@RequestParam(defaultValue = "1") int pageNum,
-			@RequestParam(defaultValue = "10") int pageSize
+		@RequestParam(defaultValue = "1") int pageNum,
+		@RequestParam(defaultValue = "10") int pageSize
 	) {
 		PageInfo<ImageDto> imageDtoList = imageService.getImageListByUserIdV2(userDetails.getUserId(), pageNum,
 			pageSize);

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageService.java
@@ -87,9 +87,11 @@ public class ImageService {
 
 	/**
 	 * 유저 ID로 이미지 다건 조회
+	 * @deprecated 페이지네이션 버전으로 변경 후 삭제 예정
 	 * @param userId 조회할 유저 ID
 	 * @return 이미지 정보를 담은 DTO
 	 */
+	@Deprecated(forRemoval = true)
 	public List<ImageDto> getImageListByUserId(Long userId) {
 		return imageMapper.findImagesByUserId(userId).stream()
 			.map(this::convertImageToImageDto)

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageService.java
@@ -7,6 +7,8 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
+import com.github.pagehelper.PageHelper;
+import com.github.pagehelper.PageInfo;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
 import com.trackery.trackerybackapiserver.domain.image.dto.ImageDto;
@@ -14,8 +16,6 @@ import com.trackery.trackerybackapiserver.domain.image.entity.Image;
 import com.trackery.trackerybackapiserver.domain.image.mapper.ImageMapper;
 import com.trackery.trackerybackapiserver.domain.location.dto.LocationInfoDto;
 import com.trackery.trackerybackapiserver.domain.location.entity.CoordinatePoint;
-import com.trackery.trackerybackapiserver.domain.location.entity.JusoSido;
-import com.trackery.trackerybackapiserver.domain.location.entity.JusoSigungu;
 import com.trackery.trackerybackapiserver.domain.location.service.LocationService;
 import com.trackery.trackerybackapiserver.domain.location.service.LocationUtil;
 
@@ -94,6 +94,23 @@ public class ImageService {
 		return imageMapper.findImagesByUserId(userId).stream()
 			.map(this::convertImageToImageDto)
 			.toList();
+	}
+
+	/**
+	 * 유저 ID로 이미지 다건 조회 페이지네이션 버전
+	 * @param userId 유저 ID
+	 * @param pageNum 페이지 번호
+	 * @param pageSize 페이지 사이즈
+	 * @return 페이지네이션된 이미지 DTO 리스트
+	 */
+	public PageInfo<ImageDto> getImageListByUserIdV2(Long userId, int pageNum, int pageSize) {
+		PageHelper.startPage(pageNum, pageSize);
+
+		List<ImageDto> imageDtoList = imageMapper.findImagesByUserId(userId).stream()
+			.map(this::convertImageToImageDto)
+			.toList();
+
+		return new PageInfo<>(imageDtoList);
 	}
 
 	/**

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -57,3 +57,11 @@ aws.region=${AWS_REGION}
 aws.accessKey=${AWS_ACCESS_KEY}
 aws.secretKey=${AWS_SECRET_KEY}
 aws.bucketName=${AWS_BUCKET_NAME}
+
+# PageHelper
+pagehelper.helper-dialect=mysql
+pagehelper.reasonable=true
+pagehelper.support-methods-arguments=true
+pagehelper.params=count=countSql
+pagehelper.default-count=true
+pagehelper.page-size-zero=false

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/image/controller/ImageControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/image/controller/ImageControllerTest.java
@@ -3,7 +3,11 @@ package com.trackery.trackerybackapiserver.domain.image.controller;
 import static org.mockito.Mockito.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -16,6 +20,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
 
+import com.github.pagehelper.PageInfo;
 import com.trackery.trackerybackapiserver.domain.config.CommonMockMvcControllerTestSetUp;
 import com.trackery.trackerybackapiserver.domain.image.dto.ImageDto;
 import com.trackery.trackerybackapiserver.domain.image.service.ImageService;
@@ -66,6 +71,7 @@ class ImageControllerTest extends CommonMockMvcControllerTestSetUp {
 			.imageContent(IMAGE_CONTENT)
 			.imageDate(IMAGE_DATE)
 			.imageUrl(IMAGE_URL)
+			.isPublic(0)
 			.build();
 
 		userDetails = CustomUserDetails.builder()
@@ -129,5 +135,69 @@ class ImageControllerTest extends CommonMockMvcControllerTestSetUp {
 			.andExpect(jsonPath("$.data[0].imageUrl").value(imageDto.getImageUrl()));
 
 		verify(imageService, times(1)).getImageListByUserId(userDetails.getUserId());
+	}
+
+	@Test
+	@DisplayName("인증된 사용자의 이미지 목록 조회 페이지네이션 성공")
+	void getMyImagesV2Success() throws Exception {
+		List<ImageDto> imageDtoList = List.of(imageDto);
+		PageInfo<ImageDto> pageInfo = new PageInfo<>(imageDtoList);
+		when(imageService.getImageListByUserIdV2(USER_ID, 1, 10)).thenReturn(pageInfo);
+
+		ResultActions result = mockMvc.perform(get("/api/images/v2/me")
+				.with(user(userDetails))
+				.queryParam("pageNum", "1")
+				.queryParam("pageSize", "10")
+			);
+
+		result
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value(200))
+			.andExpect(jsonPath("$.message").value("Ok"))
+			.andDo(document("get-my-images-v2",
+				queryParameters(
+					parameterWithName("pageNum").description("페이지 번호 (1부터 시작, 기본값 : 1)"),
+					parameterWithName("pageSize").description("페이지 크기 (기본값 : 10)")
+				),
+
+				responseFields(
+					fieldWithPath("code").description("응답 코드"),
+					fieldWithPath("message").description("응답 메시지"),
+					fieldWithPath("data").description("페이지네이션된 이미지 데이터"),
+					fieldWithPath("data.total").description("전체 이미지 개수"),
+					fieldWithPath("data.list").description("이미지 목록"),
+					fieldWithPath("data.list[].imageId").description("이미지 ID"),
+					fieldWithPath("data.list[].userId").description("사용자 ID"),
+					fieldWithPath("data.list[].imageRegDate").description("이미지 등록일시"),
+					fieldWithPath("data.list[].sdName").description("시도명"),
+					fieldWithPath("data.list[].sggName").description("시군구명"),
+					fieldWithPath("data.list[].latitude").description("위도"),
+					fieldWithPath("data.list[].longitude").description("경도"),
+					fieldWithPath("data.list[].imageName").description("이미지 파일명"),
+					fieldWithPath("data.list[].imageContent").description("이미지 설명"),
+					fieldWithPath("data.list[].imageDate").description("이미지 촬영일시"),
+					fieldWithPath("data.list[].isPublic").description("공개 여부").optional(),
+					fieldWithPath("data.list[].imageUrl").description("이미지 URL"),
+					fieldWithPath("data.pageNum").description("현재 페이지 번호"),
+					fieldWithPath("data.pageSize").description("페이지 크기"),
+					fieldWithPath("data.size").description("현재 페이지의 데이터 개수"),
+					fieldWithPath("data.startRow").description("시작 행 번호"),
+					fieldWithPath("data.endRow").description("끝 행 번호"),
+					fieldWithPath("data.pages").description("전체 페이지 수"),
+					fieldWithPath("data.prePage").description("이전 페이지 번호"),
+					fieldWithPath("data.nextPage").description("다음 페이지 번호"),
+					fieldWithPath("data.isFirstPage").description("첫 번째 페이지 여부"),
+					fieldWithPath("data.isLastPage").description("마지막 페이지 여부"),
+					fieldWithPath("data.hasPreviousPage").description("이전 페이지 존재 여부"),
+					fieldWithPath("data.hasNextPage").description("다음 페이지 존재 여부"),
+					fieldWithPath("data.navigatePages").description("네비게이션 페이지 수"),
+					fieldWithPath("data.navigatepageNums").description("네비게이션 페이지 번호 배열"),
+					fieldWithPath("data.navigateFirstPage").description("네비게이션 첫 페이지"),
+					fieldWithPath("data.navigateLastPage").description("네비게이션 마지막 페이지")
+				)
+			));
+
+		verify(imageService, times(1)).getImageListByUserIdV2(USER_ID, 1, 10);
 	}
 }

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/image/service/ImageServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/image/service/ImageServiceTest.java
@@ -23,6 +23,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.cache.CacheManager;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.github.pagehelper.PageInfo;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
 import com.trackery.trackerybackapiserver.domain.image.dto.ImageDto;
@@ -197,34 +198,42 @@ class ImageServiceTest {
 			verify(imageS3Service, never()).generatePreSignedGetUrl(anyString());
 		}
 
-		@Test
-		@DisplayName("유저 ID로 다건 조회 테스트 - 성공")
-		void getImagesByUserId_success() {
-			when(imageS3Service.generatePreSignedGetUrl(anyString())).thenReturn(testPresignedUrl);
-			when(imageMapper.findImagesByUserId(testUserId)).thenReturn(List.of(testImage1));
+		@Nested
+		@DisplayName("유저 ID로 다건 조회 테스트")
+		class getImagesByUserIdV2Test {
+			@Test
+			@DisplayName("성공")
+			void getImageListByUserIdV2_success() {
+				when(imageMapper.findImagesByUserId(testUserId)).thenReturn(List.of(testImage1));
+				when(imageS3Service.generatePreSignedGetUrl(anyString())).thenReturn(testPresignedUrl);
 
-			List<ImageDto> resultList = imageService.getImageListByUserId(testUserId);
+				PageInfo<ImageDto> pageInfo = imageService.getImageListByUserIdV2(testUserId, 1, 10);
 
-			ImageDto result = resultList.get(0);
+				assertNotNull(pageInfo);
+				assertFalse(pageInfo.getList().isEmpty());
+				ImageDto result = pageInfo.getList().get(0);
 
-			assertNotNull(result);
-			assertEquals(testImageId, result.getImageId());
-			assertEquals(testUserId, result.getUserId());
-			assertEquals("테스트 이미지", result.getImageName());
-			assertEquals("테스트 이미지 설명", result.getImageContent());
-			assertEquals(testPresignedUrl, result.getImageUrl());
-			assertEquals("서울특별시", result.getSdName());
-			assertEquals("강남구", result.getSggName());
-		}
+				assertEquals(testImageId, result.getImageId());
+				assertEquals(testUserId, result.getUserId());
+				assertEquals(testPresignedUrl, result.getImageUrl());
+				assertEquals("서울특별시", result.getSdName());
+				assertEquals("강남구", result.getSggName());
 
-		@Test
-		@DisplayName("유저 ID로 다건 조회 테스트 - 성공 - 유저가 아직 이미지를 올리지 않았을 때")
-		void getImagesByUserId_success_2() {
-			when(imageMapper.findImagesByUserId(testUserId)).thenReturn(List.of());
+				verify(imageMapper).findImagesByUserId(testUserId);
+			}
 
-			List<ImageDto> resultList = imageService.getImageListByUserId(testUserId);
+			@Test
+			@DisplayName("성공 - 결과 데이터 없음")
+			void getImageListByUserIdV2_emptyResult() {
+				when(imageMapper.findImagesByUserId(testUserId)).thenReturn(List.of());
 
-			assertTrue(resultList.isEmpty());
+				PageInfo<ImageDto> pageInfo = imageService.getImageListByUserIdV2(testUserId, 1, 10);
+
+				assertNotNull(pageInfo);
+				assertTrue(pageInfo.getList().isEmpty());
+
+				verify(imageMapper).findImagesByUserId(testUserId);
+			}
 		}
 	}
 }


### PR DESCRIPTION
1. 한 번에 너무 많은 데이터를 가져오는 것을 방지하기 위해서
페이지네이션 기능을 위한 PageHelper 종속성을 추가했습니다.

자세한 사용 방법은
https://github.com/pagehelper/Mybatis-PageHelper/blob/master/README_en.md
https://github.com/pagehelper/Mybatis-PageHelper/blob/master/wikis/en/HowToUse.md
를 참고바랍니다.

2. 내 이미지 목록 조회 API의 페이지네이션 버전을 만들었습니다. 이 PR이 합쳐진 후 프론트엔드에서도 적용하고나면 기존 API는 삭제 예정입니다.

앨범 이미지를 불러오는 기능도 적용예정입니다. 