### PR TITLE
feature/Spring-REST-Docs 모든 api 문서화

### DIFF
--- a/src/docs/asciidoc/auth-api.adoc
+++ b/src/docs/asciidoc/auth-api.adoc
@@ -1,0 +1,27 @@
+== 인증 API
+'''
+
+=== 인증 정보 확인 API
+==== GET /api/auth/me
+
+현재 로그인한 사용자의 인증 정보를 조회하는 API입니다.
+JWT 토큰을 통해 인증된 사용자의 기본 정보를 반환합니다.
+
+===== 요청
+include::{snippets}/auth-check-success/http-request.adoc[]
+
+===== 응답
+include::{snippets}/auth-check-success/http-response.adoc[]
+include::{snippets}/auth-check-success/response-fields.adoc[]
+
+===== 예외 상황
+- 인증되지 않은 사용자의 경우: `ApiException(ErrorCode.UNAUTHORIZED)` 발생
+- 유효하지 않은 JWT 토큰의 경우: `ApiException(ErrorCode.INVALID_TOKEN)` 발생
+- 만료된 JWT 토큰의 경우: `ApiException(ErrorCode.EXPIRED_TOKEN)` 발생
+
+===== 테스트 케이스
+- 정상적인 인증 정보 조회 (JWT 토큰 유효)
+- 인증되지 않은 사용자의 접근 시도
+- 유효하지 않은 토큰으로 접근 시도
+- 만료된 토큰으로 접근 시도
+'''

--- a/src/docs/asciidoc/image-api.adoc
+++ b/src/docs/asciidoc/image-api.adoc
@@ -1,0 +1,91 @@
+== 이미지 API
+'''
+
+=== 이미지 단건 조회 API
+==== GET /api/images
+
+이미지 ID를 통해 특정 이미지의 상세 정보를 조회하는 API입니다.
+이미지의 메타데이터와 위치 정보, URL 등을 반환합니다.
+
+===== 요청
+include::{snippets}/get-image-by-id-success/http-request.adoc[]
+include::{snippets}/get-image-by-id-success/query-parameters.adoc[]
+
+===== 응답
+include::{snippets}/get-image-by-id-success/http-response.adoc[]
+include::{snippets}/get-image-by-id-success/response-fields.adoc[]
+'''
+
+=== 내 이미지 목록 조회 API
+==== GET /api/images/me
+
+인증된 사용자가 업로드한 모든 이미지 목록을 조회하는 API입니다.
+JWT 토큰을 통해 사용자를 식별하고 해당 사용자의 이미지만 반환합니다.
+
+===== 요청
+include::{snippets}/get-my-images-success/http-request.adoc[]
+
+===== 응답
+include::{snippets}/get-my-images-success/http-response.adoc[]
+include::{snippets}/get-my-images-success/response-fields.adoc[]
+'''
+
+=== S3 업로드 URL 요청 API
+==== GET /api/images/presigned-url/put
+
+이미지를 S3에 업로드하기 위한 presigned URL을 요청하는 API입니다.
+클라이언트는 이 URL을 사용하여 직접 S3에 이미지를 업로드할 수 있습니다.
+
+===== 요청
+include::{snippets}/get-presigned-url-success/http-request.adoc[]
+include::{snippets}/get-presigned-url-success/query-parameters.adoc[]
+
+===== 응답
+include::{snippets}/get-presigned-url-success/http-response.adoc[]
+include::{snippets}/get-presigned-url-success/response-fields.adoc[]
+'''
+
+=== 이미지 메타데이터 저장 API
+==== POST /api/images
+
+S3에 업로드된 이미지의 메타데이터를 데이터베이스에 저장하는 API입니다.
+이미지 업로드 후 호출하여 이미지 정보를 시스템에 등록합니다.
+
+===== 요청
+include::{snippets}/save-image-metadata-success/http-request.adoc[]
+include::{snippets}/save-image-metadata-success/request-fields.adoc[]
+
+===== 응답
+include::{snippets}/save-image-metadata-success/http-response.adoc[]
+include::{snippets}/save-image-metadata-success/response-fields.adoc[]
+
+===== 예외 상황
+- 인증되지 않은 사용자의 경우: `ApiException(ErrorCode.UNAUTHORIZED)` 발생
+- 잘못된 요청 데이터의 경우: `ApiException(ErrorCode.BAD_REQUEST)` 발생
+- S3 업로드 실패의 경우: `ApiException(ErrorCode.INTERNAL_SERVER_ERROR)` 발생
+
+===== 이미지 업로드 플로우
+1. 클라이언트가 `GET /api/images/presigned-url/put`으로 presigned URL 요청
+2. 받은 presigned URL로 S3에 직접 이미지 업로드
+3. 업로드 성공 후 `POST /api/images`로 메타데이터 저장
+4. 저장된 이미지는 `GET /api/images/me`로 조회 가능
+'''
+
+=== 공개 이미지 목록 API
+==== GET /api/home/images
+
+랜딩 페이지에서 사용할 공개 이미지 URL 목록을 조회하는 API입니다.
+인증이 필요하지 않으며, 공개 설정된 이미지들의 URL을 반환합니다.
+
+===== 요청
+include::{snippets}/get-public-images/http-request.adoc[]
+
+===== 응답
+include::{snippets}/get-public-images/http-response.adoc[]
+include::{snippets}/get-public-images/response-fields.adoc[]
+
+===== 사용 목적
+- 랜딩 페이지에서 공개 이미지 URL 목록 표시
+- 인증 없이 접근 가능한 공개 API
+- 사용자가 업로드한 이미지 중 공개로 설정된 것들만 반환
+'''

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -2,14 +2,14 @@
 :toc: left
 :toclevels: 2
 
-== 공개 이미지 목록 API
-
-=== GET /api/home/images
-
-include::{snippets}/get-public-images/http-request.adoc[]
-include::{snippets}/get-public-images/http-response.adoc[]
-include::{snippets}/get-public-images/response-fields.adoc[]
-
 include::album-api.adoc[]
+
+include::auth-api.adoc[]
+
+include::image-api.adoc[]
+
 include::location-api.adoc[]
+
+include::mail-api.adoc[]
+
 include::user-api.adoc[]

--- a/src/docs/asciidoc/mail-api.adoc
+++ b/src/docs/asciidoc/mail-api.adoc
@@ -1,0 +1,93 @@
+== 메일 API
+'''
+
+=== 이메일 인증 요청 API
+==== POST /api/mail/request-verify/email
+
+이메일 인증을 위한 인증번호를 발송하는 API입니다.
+입력된 이메일 주소로 6자리 인증번호가 포함된 이메일을 전송합니다.
+
+===== 요청
+include::{snippets}/request-email-verification/http-request.adoc[]
+include::{snippets}/request-email-verification/request-fields.adoc[]
+
+===== 응답
+include::{snippets}/request-email-verification/http-response.adoc[]
+include::{snippets}/request-email-verification/response-fields.adoc[]
+
+===== 사용 목적
+- 사용자 회원가입 시 이메일 인증
+- 비밀번호 재설정 시 이메일 인증
+- 이메일 주소 유효성 확인
+
+===== 주의사항
+- 동일한 이메일 주소로 반복 요청 시 제한이 있을 수 있음
+- 이메일 전송 실패 시 적절한 에러 응답 반환
+'''
+
+=== 이메일 인증 확인 API
+==== POST /api/mail/verify/email
+
+이메일로 받은 인증번호를 검증하는 API입니다.
+인증 성공 시 이메일 토큰을 HTTP-Only 쿠키로 발급합니다.
+
+===== 요청
+include::{snippets}/verify-email/http-request.adoc[]
+include::{snippets}/verify-email/request-fields.adoc[]
+
+===== 응답
+include::{snippets}/verify-email/http-response.adoc[]
+include::{snippets}/verify-email/response-fields.adoc[]
+
+===== 특별 응답 헤더
+- **Set-Cookie**: `emailToken` (HTTP-Only, 10분 유효)
+  - 이메일 인증이 완료되었음을 나타내는 JWT 토큰
+  - 이후 회원가입이나 비밀번호 재설정 시 사용
+
+===== 보안 고려사항
+- 인증번호는 제한된 시간 내에만 유효
+- 잘못된 인증번호 입력 시 횟수 제한
+- 성공한 토큰은 일회성으로 사용 후 무효화
+'''
+
+=== 사용자명 찾기 이메일 발송 API
+==== POST /api/mail/find-username
+
+등록된 이메일 주소로 해당 계정의 사용자명을 전송하는 API입니다.
+사용자가 자신의 사용자명을 잊었을 때 이메일을 통해 확인할 수 있습니다.
+
+===== 요청
+include::{snippets}/find-username-by-email/http-request.adoc[]
+include::{snippets}/find-username-by-email/request-fields.adoc[]
+
+===== 응답
+include::{snippets}/find-username-by-email/http-response.adoc[]
+include::{snippets}/find-username-by-email/response-fields.adoc[]
+
+===== 동작 방식
+1. 입력된 이메일 주소가 시스템에 등록되어 있는지 확인
+2. 등록된 이메일인 경우 해당 계정의 사용자명을 이메일로 전송
+3. 등록되지 않은 이메일인 경우에도 보안을 위해 동일한 성공 응답 반환
+
+===== 보안 정책
+- 실제 등록 여부와 관계없이 항상 성공 응답
+- 이메일 주소 노출 방지를 위한 정보 마스킹
+- 반복 요청에 대한 빈도 제한
+'''
+
+=== 메일 서비스 공통 특징
+
+==== 템플릿 시스템
+- **Thymeleaf** 템플릿 엔진 사용
+- 브랜드 통일성을 위한 일관된 디자인
+- HTML 이메일 지원
+
+==== 에러 처리
+- 이메일 전송 실패 시 내부 에러 로그 기록
+- 사용자에게는 일반적인 성공 메시지 반환 (보안상 이유)
+- 네트워크 오류, SMTP 서버 오류 등 다양한 실패 상황 대응
+
+==== 성능 최적화
+- 비동기 이메일 전송 처리
+- 이메일 큐잉 시스템으로 대량 발송 지원
+- Redis를 활용한 인증번호 저장 및 만료 관리

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/auth/controller/AuthControllerTest.java
@@ -3,6 +3,9 @@ package com.trackery.trackerybackapiserver.domain.auth.controller;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import org.junit.jupiter.api.Test;
@@ -13,8 +16,8 @@ import org.springframework.test.web.servlet.ResultActions;
 import com.trackery.trackerybackapiserver.domain.config.CommonMockMvcControllerTestSetUp;
 import com.trackery.trackerybackapiserver.domain.auth.dto.AuthUserDto;
 import com.trackery.trackerybackapiserver.domain.auth.service.AuthService;
+import com.trackery.trackerybackapiserver.domain.user.entity.CustomUserDetails;
 
-import jakarta.servlet.http.Cookie;
 
 /**
  * packageName    : com.trackery.trackerybackapiserver.domain.auth.controller
@@ -28,6 +31,7 @@ import jakarta.servlet.http.Cookie;
  * 25. 3. 26.       durururuk		최초 생성
  * 25. 3. 26.		durururuk		api/auth/me 테스트 코드 작성
  * 25. 3. 26.		durururuk		바뀐 로직에 맞게 테스트 코드 수정
+ * 25. 6. 18.		inari		    Spring-Rest-Docs api문서 추가
  */
 @WebMvcTest(AuthController.class)
 class AuthControllerTest extends CommonMockMvcControllerTestSetUp {
@@ -36,16 +40,30 @@ class AuthControllerTest extends CommonMockMvcControllerTestSetUp {
 
 	@Test
 	void 인증_확인_성공() throws Exception {
+		CustomUserDetails customUserDetails = CustomUserDetails.builder()
+			.userId(1L)
+			.roleId(1L)
+			.build();
+		
 		AuthUserDto authUserDto = new AuthUserDto(1L, "abcdefg", 1L);
 		when(authService.toAuthUserDto(any())).thenReturn(authUserDto);
 
 		ResultActions result = mockMvc.perform(get("/api/auth/me")
-			.cookie(new Cookie("accessToken", "JwtToken")));
+			.with(user(customUserDetails)));
 
 		result
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.userId").value(1))
 			.andExpect(jsonPath("$.data.userName").value("abcdefg"))
-			.andExpect(jsonPath("$.data.userRoleId").value(1));
+			.andExpect(jsonPath("$.data.userRoleId").value(1))
+			.andDo(document("auth-check-success",
+				responseFields(
+					fieldWithPath("code").description("상태 코드"),
+					fieldWithPath("message").description("응답 메시지"),
+					fieldWithPath("data.userId").description("사용자 ID"),
+					fieldWithPath("data.userName").description("사용자명"),
+					fieldWithPath("data.userRoleId").description("사용자 역할 ID")
+				)
+			));
 	}
 }

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/image/controller/ImageControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/image/controller/ImageControllerTest.java
@@ -2,6 +2,9 @@ package com.trackery.trackerybackapiserver.domain.image.controller;
 
 import static org.mockito.Mockito.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -31,6 +34,7 @@ import com.trackery.trackerybackapiserver.domain.user.entity.CustomUserDetails;
  * DATE              AUTHOR             NOTE
  * -----------------------------------------------------------
  * 25. 5. 22.		durururuk		최초 생성
+ * 25. 6. 18.		inari		    Spring-Rest-Docs api문서 추가
  */
 @WebMvcTest(ImageController.class)
 class ImageControllerTest extends CommonMockMvcControllerTestSetUp {
@@ -97,7 +101,28 @@ class ImageControllerTest extends CommonMockMvcControllerTestSetUp {
 			.andExpect(jsonPath("$.data.imageName").value(IMAGE_NAME))
 			.andExpect(jsonPath("$.data.imageContent").value(IMAGE_CONTENT))
 			.andExpect(jsonPath("$.data.imageDate").value(IMAGE_DATE.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)))
-			.andExpect(jsonPath("$.data.imageUrl").value(IMAGE_URL));
+			.andExpect(jsonPath("$.data.imageUrl").value(IMAGE_URL))
+			.andDo(document("get-image-by-id-success",
+				queryParameters(
+					parameterWithName("imageId").description("조회할 이미지 ID")
+				),
+				responseFields(
+					fieldWithPath("code").description("상태 코드"),
+					fieldWithPath("message").description("응답 메시지"),
+					fieldWithPath("data.imageId").description("이미지 ID"),
+					fieldWithPath("data.userId").description("이미지 업로드 사용자 ID"),
+					fieldWithPath("data.imageRegDate").description("이미지 등록 일시"),
+					fieldWithPath("data.sdName").description("시도명"),
+					fieldWithPath("data.sggName").description("시군구명"),
+					fieldWithPath("data.latitude").description("위도"),
+					fieldWithPath("data.longitude").description("경도"),
+					fieldWithPath("data.imageName").description("이미지 파일명"),
+					fieldWithPath("data.imageContent").description("이미지 설명"),
+					fieldWithPath("data.imageDate").description("이미지 촬영 일시"),
+					fieldWithPath("data.isPublic").description("공개 여부 (true: 공개, false: 비공개, null: 미설정)"),
+					fieldWithPath("data.imageUrl").description("이미지 URL")
+				)
+			));
 
 		verify(imageService, times(1)).getImageByImageId(IMAGE_ID);
 	}
@@ -126,7 +151,26 @@ class ImageControllerTest extends CommonMockMvcControllerTestSetUp {
 			.andExpect(jsonPath("$.data[0].imageName").value(imageDto.getImageName()))
 			.andExpect(jsonPath("$.data[0].imageContent").value(imageDto.getImageContent()))
 			.andExpect(jsonPath("$.data[0].imageDate").value(imageDto.getImageDate().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)))
-			.andExpect(jsonPath("$.data[0].imageUrl").value(imageDto.getImageUrl()));
+			.andExpect(jsonPath("$.data[0].imageUrl").value(imageDto.getImageUrl()))
+			.andDo(document("get-my-images-success",
+				responseFields(
+					fieldWithPath("code").description("상태 코드"),
+					fieldWithPath("message").description("응답 메시지"),
+					fieldWithPath("data[]").description("이미지 목록"),
+					fieldWithPath("data[].imageId").description("이미지 ID"),
+					fieldWithPath("data[].userId").description("이미지 업로드 사용자 ID"),
+					fieldWithPath("data[].imageRegDate").description("이미지 등록 일시"),
+					fieldWithPath("data[].sdName").description("시도명"),
+					fieldWithPath("data[].sggName").description("시군구명"),
+					fieldWithPath("data[].latitude").description("위도"),
+					fieldWithPath("data[].longitude").description("경도"),
+					fieldWithPath("data[].imageName").description("이미지 파일명"),
+					fieldWithPath("data[].imageContent").description("이미지 설명"),
+					fieldWithPath("data[].imageDate").description("이미지 촬영 일시"),
+					fieldWithPath("data[].isPublic").description("공개 여부 (true: 공개, false: 비공개, null: 미설정)"),
+					fieldWithPath("data[].imageUrl").description("이미지 URL")
+				)
+			));
 
 		verify(imageService, times(1)).getImageListByUserId(userDetails.getUserId());
 	}

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/image/controller/ImageUploadControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/image/controller/ImageUploadControllerTest.java
@@ -2,6 +2,9 @@ package com.trackery.trackerybackapiserver.domain.image.controller;
 
 import static org.mockito.Mockito.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -28,6 +31,7 @@ import com.trackery.trackerybackapiserver.domain.user.entity.CustomUserDetails;
  * DATE              AUTHOR             NOTE
  * -----------------------------------------------------------
  * 25. 4. 23.		durururuk		최초 생성
+ * 25. 6. 18.		inari		    Spring-Rest-Docs api문서 추가
  */
 @WebMvcTest(ImageUploadController.class)
 class ImageUploadControllerTest extends CommonMockMvcControllerTestSetUp {
@@ -52,12 +56,31 @@ class ImageUploadControllerTest extends CommonMockMvcControllerTestSetUp {
 
 		result
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.data").value("PresignedURL.com"));
+			.andExpect(jsonPath("$.data").value("PresignedURL.com"))
+			.andDo(document("get-presigned-url-success",
+				queryParameters(
+					parameterWithName("imageFileName").description("업로드할 이미지 파일명")
+				),
+				responseFields(
+					fieldWithPath("code").description("상태 코드"),
+					fieldWithPath("message").description("응답 메시지"),
+					fieldWithPath("data").description("S3 presigned URL")
+				)
+			));
 	}
 
 	@Test
 	void saveImageMetaDataSuccess() throws Exception {
 		ImageUploadDto imageUploadDto = new ImageUploadDto();
+		// Reflection을 사용해서 필드값 설정 (NoArgsConstructor만 있으므로)
+		org.springframework.test.util.ReflectionTestUtils.setField(imageUploadDto, "imageName", "test-image.jpg");
+		org.springframework.test.util.ReflectionTestUtils.setField(imageUploadDto, "imageType", "JPEG");
+		org.springframework.test.util.ReflectionTestUtils.setField(imageUploadDto, "description", "테스트 이미지 설명");
+		org.springframework.test.util.ReflectionTestUtils.setField(imageUploadDto, "tags", "여행,서울");
+		org.springframework.test.util.ReflectionTestUtils.setField(imageUploadDto, "longitude", 127.0276);
+		org.springframework.test.util.ReflectionTestUtils.setField(imageUploadDto, "latitude", 37.4979);
+		org.springframework.test.util.ReflectionTestUtils.setField(imageUploadDto, "dateString", "2025-01-01T10:30:00");
+		org.springframework.test.util.ReflectionTestUtils.setField(imageUploadDto, "isPublic", true);
 
 		when(imageUploadService.saveImage(customUserDetails.getUserId(), imageUploadDto)).thenReturn(mock(Image.class));
 
@@ -67,6 +90,23 @@ class ImageUploadControllerTest extends CommonMockMvcControllerTestSetUp {
 			.with(user(customUserDetails))
 			.with(csrf()));
 
-		result.andExpect(status().isOk());
+		result
+			.andExpect(status().isOk())
+			.andDo(document("save-image-metadata-success",
+				requestFields(
+					fieldWithPath("imageName").description("이미지 파일명"),
+					fieldWithPath("imageType").description("이미지 타입 (JPEG, PNG 등)"),
+					fieldWithPath("description").description("이미지 설명"),
+					fieldWithPath("tags").description("이미지 태그 (쉼표로 구분)"),
+					fieldWithPath("longitude").description("경도"),
+					fieldWithPath("latitude").description("위도"),
+					fieldWithPath("dateString").description("이미지 촬영 일시 (ISO 형식)"),
+					fieldWithPath("public").description("공개 여부 (true: 공개, false: 비공개)")
+				),
+				responseFields(
+					fieldWithPath("code").description("상태 코드"),
+					fieldWithPath("message").description("응답 메시지")
+				)
+			));
 	}
 }

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/mail/controller/MailControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/mail/controller/MailControllerTest.java
@@ -2,8 +2,10 @@ package com.trackery.trackerybackapiserver.domain.mail.controller;
 
 import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -33,6 +35,7 @@ import com.trackery.trackerybackapiserver.domain.mail.service.MailService;
  * -----------------------------------------------------------
  * 25. 3. 5.        durururuk      최초 생성
  * 25. 3. 5.		durururuk	   컨트롤러 테스트 코드 작성
+ * 25. 6. 18.      inari          Spring REST Docs API 문서 추가
  */
 @WithMockUser
 @WebMvcTest(MailController.class)
@@ -60,7 +63,17 @@ class MailControllerTest extends CommonMockMvcControllerTestSetUp {
 				.with(csrf()));
 
 		result
-			.andExpect(status().isOk());
+			.andExpect(status().isOk())
+			.andDo(document("request-email-verification",
+				requestFields(
+					fieldWithPath("email").description("인증을 요청할 이메일 주소"),
+					fieldWithPath("authNumber").description("인증번호 (요청 시에는 무시됨)").optional()
+				),
+				responseFields(
+					fieldWithPath("code").description("상태 코드"),
+					fieldWithPath("message").description("응답 메시지")
+				)
+			));
 	}
 
 	@Test
@@ -75,7 +88,17 @@ class MailControllerTest extends CommonMockMvcControllerTestSetUp {
 
 		result
 			.andExpect(status().isOk())
-			.andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("emailToken=")));
+			.andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("emailToken=")))
+			.andDo(document("verify-email",
+				requestFields(
+					fieldWithPath("email").description("인증할 이메일 주소"),
+					fieldWithPath("authNumber").description("이메일로 받은 인증번호")
+				),
+				responseFields(
+					fieldWithPath("code").description("상태 코드"),
+					fieldWithPath("message").description("응답 메시지")
+				)
+			));
 	}
 
 	@Test
@@ -88,6 +111,16 @@ class MailControllerTest extends CommonMockMvcControllerTestSetUp {
 				.with(csrf()));
 
 		result
-			.andExpect(status().isOk());
+			.andExpect(status().isOk())
+			.andDo(document("find-username-by-email",
+				requestFields(
+					fieldWithPath("email").description("사용자명을 찾을 이메일 주소"),
+					fieldWithPath("authNumber").description("인증번호 (이 API에서는 무시됨)").optional()
+				),
+				responseFields(
+					fieldWithPath("code").description("상태 코드"),
+					fieldWithPath("message").description("응답 메시지")
+				)
+			));
 	}
 }


### PR DESCRIPTION
남은 모든 API 도메인에 대한 Spring REST Docs 구현 완료
image, auth, mail 도메인에 대한 포괄적인 API 문서 추가
통합된 API 문서 구조로 모든 문서 통합

구조 재정리 - index에서 중복된 공개 이미지 API 섹션 제거

이후 기존 도메인의 컨트롤러나 컨트롤러 테스트에 수정사항이 있을시 adoc 또한 수정 부탁드립니다.
