### PR TITLE
Refresh Token을 레디스에서 찾을 수 없을 때 예외처리 추가, JWT 토큰 만료시간 enum으로 관리

### DIFF
--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/enums/JwtExpirationTime.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/enums/JwtExpirationTime.java
@@ -19,7 +19,8 @@ import lombok.Getter;
 public enum JwtExpirationTime {
 	ACCESS_TOKEN(60 * 60),
 	REFRESH_TOKEN(60 * 60 * 24 * 7),
-	COMMON_1HOUR_TOKEN(60 * 60);
+	MAIL_VERIFICATION_TOKEN(60 * 60),
+	USER_NAME_VERIFICATION_TOKEN(60 * 60);
 
 	private final int expirationTime;
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/enums/JwtExpirationTime.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/enums/JwtExpirationTime.java
@@ -1,0 +1,25 @@
+package com.trackery.trackerybackapiserver.domain.jwt.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * packageName    : com.trackery.trackerybackapiserver.domain.jwt.enums
+ * fileName       : EXPIRATION_TIME
+ * author         : durururuk
+ * date           : 25. 6. 19.
+ * description    : JWT 토큰 만료 시간을 관리하는 enum입니다.
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 25. 6. 19.		durururuk		최초 생성
+ */
+@Getter
+@AllArgsConstructor
+public enum JwtExpirationTime {
+	ACCESS_TOKEN(60 * 60),
+	REFRESH_TOKEN(60 * 60 * 24 * 7),
+	COMMON_1HOUR_TOKEN(60 * 60);
+
+	private final int expirationTime;
+}

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtRedisService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtRedisService.java
@@ -75,10 +75,9 @@ public class JwtRedisService {
 	 * 한 번 사용된 리프레시 토큰을 레디스에서 제거하는 메서드입니다.
 	 * @param refreshToken : 사용된 리프레시 토큰
 	 */
-	//Todo 추후 unlink로 변경
 	public void deleteRefreshToken(String refreshToken) {
 		String redisKey = REFRESH_TOKEN_REDIS_KEY + refreshToken;
-		redisTemplate.delete(redisKey);
+		redisTemplate.unlink(redisKey);
 	}
 
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtRedisService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtRedisService.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.RefreshTokenDto;
+import com.trackery.trackerybackapiserver.domain.jwt.enums.JwtExpirationTime;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -46,7 +47,8 @@ public class JwtRedisService {
 			String redisKey = REFRESH_TOKEN_REDIS_KEY + refreshTokenDto.refreshToken();
 			String jsonRefreshTokenDto = objectMapper.writeValueAsString(refreshTokenDto);
 
-			redisTemplate.opsForValue().set(redisKey, jsonRefreshTokenDto);
+			redisTemplate.opsForValue()
+				.set(redisKey, jsonRefreshTokenDto, JwtExpirationTime.REFRESH_TOKEN.getExpirationTime());
 		} catch (JsonProcessingException e) {
 			log.error("Json 파싱 중 에러 발생 : ", e);
 			throw new ApiException(ErrorCode.INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtRedisService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtRedisService.java
@@ -1,5 +1,7 @@
 package com.trackery.trackerybackapiserver.domain.jwt.service;
 
+import java.util.Optional;
+
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -59,7 +61,8 @@ public class JwtRedisService {
 	 */
 	public RefreshTokenDto getRefreshTokenInfo(String refreshToken) {
 		String redisKey = REFRESH_TOKEN_REDIS_KEY + refreshToken;
-		String jsonRefreshTokenDto = redisTemplate.opsForValue().get(redisKey);
+		String jsonRefreshTokenDto = Optional.ofNullable(redisTemplate.opsForValue().get(redisKey))
+			.orElseThrow(() -> new ApiException(ErrorCode.UNAUTHORIZED));
 		try {
 			return objectMapper.readValue(jsonRefreshTokenDto, RefreshTokenDto.class);
 		} catch (JsonProcessingException e) {

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtService.java
@@ -16,6 +16,7 @@ import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.AuthTokenDto;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.RefreshTokenDto;
+import com.trackery.trackerybackapiserver.domain.jwt.enums.JwtExpirationTime;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -68,7 +69,7 @@ public class JwtService {
 				.withClaim("role", roleId)
 				.withNotBefore(Instant.now())
 				.withIssuedAt(Instant.now())
-				.withExpiresAt(Instant.now().plusSeconds(ACCESS_TOKEN_EXPIRATION_TIME))
+				.withExpiresAt(Instant.now().plusSeconds(JwtExpirationTime.ACCESS_TOKEN.getExpirationTime()))
 				.withJWTId(UUID.randomUUID().toString())
 				.sign(algorithm);
 		} catch (JWTCreationException e) {
@@ -94,7 +95,7 @@ public class JwtService {
 				.withSubject(userId.toString())
 				.withNotBefore(Instant.now())
 				.withIssuedAt(Instant.now())
-				.withExpiresAt(Instant.now().plusSeconds(REFRESH_TOKEN_EXPIRATION_TIME))
+				.withExpiresAt(Instant.now().plusSeconds(JwtExpirationTime.REFRESH_TOKEN.getExpirationTime()))
 				.sign(algorithm);
 		} catch (JWTCreationException e) {
 			log.error(e.getMessage());

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtService.java
@@ -147,14 +147,14 @@ public class JwtService {
 	 * @param subject : 설정할 Subject
 	 * @return : jwt 토큰
 	 */
-	public String generateTokenWithSubject(String subject) {
+	public String generateTokenWithSubject(String subject, JwtExpirationTime jwtExpirationTime) {
 		try {
 			return JWT.create()
 				.withIssuer(projectDomain)
 				.withSubject(subject)
 				.withNotBefore(Instant.now())
 				.withIssuedAt(Instant.now())
-				.withExpiresAt(Instant.now().plusSeconds(ACCESS_TOKEN_EXPIRATION_TIME))
+				.withExpiresAt(Instant.now().plusSeconds(jwtExpirationTime.getExpirationTime()))
 				.sign(algorithm);
 		} catch (JWTCreationException e) {
 			log.error(e.getMessage());

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtService.java
@@ -37,11 +37,6 @@ import lombok.extern.slf4j.Slf4j;
 public class JwtService {
 	private final JwtRedisService jwtRedisService;
 
-	//액세스 토큰 만료시간 1시간, 리프레시 토큰 만료시간 7일, 단위 : 초(s)
-	//TODO JWT 만료시간 일괄 설정되게 수정
-	private static final int ACCESS_TOKEN_EXPIRATION_TIME = 3600;
-	private static final int REFRESH_TOKEN_EXPIRATION_TIME = 604800;
-
 	private final String projectDomain;
 	private final Algorithm algorithm;
 

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtService.java
@@ -145,6 +145,7 @@ public class JwtService {
 	/**
 	 * 특정 Subject 가지는 JWT 토큰 생성 메서드
 	 * @param subject : 설정할 Subject
+	 * @param jwtExpirationTime : 만료시간 설정을 위한 JwtExpirationTime enum
 	 * @return : jwt 토큰
 	 */
 	public String generateTokenWithSubject(String subject, JwtExpirationTime jwtExpirationTime) {

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/mail/service/MailService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/mail/service/MailService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
+import com.trackery.trackerybackapiserver.domain.jwt.enums.JwtExpirationTime;
 import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
 import com.trackery.trackerybackapiserver.domain.user.entity.User;
 import com.trackery.trackerybackapiserver.domain.user.mapper.UserMapper;
@@ -87,7 +88,7 @@ public class MailService {
 
 		redisTemplate.delete(EMAIL_VERIFICATION_REDIS_KEY + emailAddress);
 
-		return jwtService.generateTokenWithSubject(emailAddress);
+		return jwtService.generateTokenWithSubject(emailAddress, JwtExpirationTime.MAIL_VERIFICATION_TOKEN);
 	}
 
 	/**

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/UserService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/UserService.java
@@ -13,6 +13,7 @@ import com.trackery.trackerybackapiserver.domain.common.util.PasswordUtil;
 import com.trackery.trackerybackapiserver.domain.image.service.ImageS3Service;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.AuthTokenDto;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.JwtUserInfoDto;
+import com.trackery.trackerybackapiserver.domain.jwt.enums.JwtExpirationTime;
 import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
 import com.trackery.trackerybackapiserver.domain.user.dto.DetailedUserInfoDto;
 import com.trackery.trackerybackapiserver.domain.user.dto.UserLoginDto;
@@ -121,7 +122,7 @@ public class UserService {
 	 */
 	public UserNameAvailabilityResponseDto checkUsernameAvailability(String userName) {
 		if (!userMapper.isExistsUserName(userName)) {
-			String jwt = jwtService.generateTokenWithSubject(userName);
+			String jwt = jwtService.generateTokenWithSubject(userName, JwtExpirationTime.USER_NAME_VERIFICATION_TOKEN);
 			return new UserNameAvailabilityResponseDto(true, jwt);
 		} else {
 			return new UserNameAvailabilityResponseDto(false, null);

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtRedisServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtRedisServiceTest.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.RefreshTokenDto;
+import com.trackery.trackerybackapiserver.domain.jwt.enums.JwtExpirationTime;
 
 /**
  * packageName    : com.trackery.trackerybackapiserver.domain.jwt.service
@@ -58,12 +59,14 @@ class JwtRedisServiceTest {
 			when(redisTemplate.opsForValue()).thenReturn(valueOperations);
 			String expectedJson = "refreshTokenDtoJson";
 			when(objectMapper.writeValueAsString(refreshTokenDto)).thenReturn(expectedJson);
-			doNothing().when(valueOperations).set(redisKey, expectedJson);
+			doNothing().when(valueOperations)
+				.set(redisKey, expectedJson, JwtExpirationTime.REFRESH_TOKEN.getExpirationTime());
 
 			jwtRedisService.saveRefreshToken(refreshTokenDto);
 
 			verify(objectMapper, times(1)).writeValueAsString(refreshTokenDto);
-			verify(redisTemplate.opsForValue(), times(1)).set(redisKey, expectedJson);
+			verify(redisTemplate.opsForValue(), times(1)).set(redisKey, expectedJson,
+				JwtExpirationTime.REFRESH_TOKEN.getExpirationTime());
 		}
 
 		@Test

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtRedisServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtRedisServiceTest.java
@@ -120,11 +120,11 @@ class JwtRedisServiceTest {
 		void success() {
 			String refreshToken = "<PASSWORD>";
 			String redisKey = "jwtRefreshToken:" + refreshToken;
-			when(redisTemplate.delete(redisKey)).thenReturn(true);
+			when(redisTemplate.unlink(redisKey)).thenReturn(true);
 
 			jwtRedisService.deleteRefreshToken(refreshToken);
 
-			verify(redisTemplate, times(1)).delete(redisKey);
+			verify(redisTemplate, times(1)).unlink(redisKey);
 		}
 
 	}

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtServiceTest.java
@@ -17,6 +17,7 @@ import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.AuthTokenDto;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.RefreshTokenDto;
+import com.trackery.trackerybackapiserver.domain.jwt.enums.JwtExpirationTime;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -107,7 +108,7 @@ class JwtServiceTest {
 	@Test
 	void JWT_이메일_토큰_생성_테스트() {
 		String email = "a@a.com";
-		String token = jwtService.generateTokenWithSubject(email);
+		String token = jwtService.generateTokenWithSubject(email, JwtExpirationTime.MAIL_VERIFICATION_TOKEN);
 
 		DecodedJWT decodedJWT = jwtService.verifyJwt(token);
 

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/mail/service/MailServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/mail/service/MailServiceTest.java
@@ -16,6 +16,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
+import com.trackery.trackerybackapiserver.domain.jwt.enums.JwtExpirationTime;
 import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
 import com.trackery.trackerybackapiserver.domain.user.entity.User;
 import com.trackery.trackerybackapiserver.domain.user.mapper.UserMapper;
@@ -82,7 +83,7 @@ class MailServiceTest {
 		String emailToken = "mockedEmailToken";
 
 		when(valueOperations.get(redisKey)).thenReturn(authNumber);
-		when(jwtService.generateTokenWithSubject(email)).thenReturn(emailToken);
+		when(jwtService.generateTokenWithSubject(email, JwtExpirationTime.MAIL_VERIFICATION_TOKEN)).thenReturn(emailToken);
 		when(redisTemplate.delete(redisKey)).thenReturn(true);
 		when(redisTemplate.opsForValue()).thenReturn(valueOperations);
 
@@ -90,7 +91,7 @@ class MailServiceTest {
 
 		assertEquals(emailToken, resultToken);
 		verify(valueOperations, times(1)).get(redisKey);
-		verify(jwtService, times(1)).generateTokenWithSubject(email);
+		verify(jwtService, times(1)).generateTokenWithSubject(email, JwtExpirationTime.MAIL_VERIFICATION_TOKEN);
 		verify(redisTemplate, times(1)).delete(redisKey);
 	}
 

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/user/service/UserServiceTest.java
@@ -25,6 +25,7 @@ import com.trackery.trackerybackapiserver.domain.common.util.PasswordUtil;
 import com.trackery.trackerybackapiserver.domain.image.service.ImageS3Service;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.AuthTokenDto;
 import com.trackery.trackerybackapiserver.domain.jwt.dto.JwtUserInfoDto;
+import com.trackery.trackerybackapiserver.domain.jwt.enums.JwtExpirationTime;
 import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
 import com.trackery.trackerybackapiserver.domain.user.dto.DetailedUserInfoDto;
 import com.trackery.trackerybackapiserver.domain.user.dto.UserLoginDto;
@@ -128,7 +129,7 @@ class UserServiceTest {
 	@Test
 	void 유저명_중복_확인_성공() {
 		when(userMapper.isExistsUserName(anyString())).thenReturn(false);
-		when(jwtService.generateTokenWithSubject("abcdefg")).thenReturn("jwt");
+		when(jwtService.generateTokenWithSubject("abcdefg", JwtExpirationTime.USER_NAME_VERIFICATION_TOKEN)).thenReturn("jwt");
 
 		UserNameAvailabilityResponseDto result = userService.checkUsernameAvailability("abcdefg");
 


### PR DESCRIPTION
fix #43 

Redis에서 리프레시 토큰을 찾을 수 없을 때 예외처리가 잘 안 되던 문제를 수정했습니다.
JWT 만료시간을 enum으로 한 곳에서 관리하게 수정했습니다.