### PR TITLE
feature/이미지-수정-및-삭제 이미지 수정 및 삭제기능 추가

### DIFF
--- a/src/docs/asciidoc/image-api.adoc
+++ b/src/docs/asciidoc/image-api.adoc
@@ -91,10 +91,10 @@ include::{snippets}/get-public-images/response-fields.adoc[]
 '''
 
 === 이미지 메타데이터 수정 API
-==== PUT /api/images/{imageId}
+==== PATCH /api/images/{imageId}
 
-업로드된 이미지의 메타데이터를 수정하는 API입니다.
-이미지 이름, 설명, 촬영 날짜, 공개 여부, 위치 정보를 수정할 수 있습니다.
+업로드된 이미지의 메타데이터를 부분 수정하는 API입니다.
+이미지 이름, 설명, 촬영 날짜, 공개 여부, 위치 정보를 선택적으로 수정할 수 있습니다.
 
 ===== 요청
 include::{snippets}/update-image-metadata-success/http-request.adoc[]
@@ -112,13 +112,14 @@ include::{snippets}/update-image-metadata-success/response-fields.adoc[]
 - 잘못된 위도/경도 값: `ApiException(ErrorCode.BAD_REQUEST)` 발생
 
 ===== 참고 사항
-- 모든 필드는 선택사항이며, 제공된 필드만 수정됩니다
-- 위도는 33.0~43.0 범위, 경도는 124.0~132.0 범위로 제한됩니다 (한국 지역)
-- 위치 정보 수정 시 새로운 좌표 포인트가 생성되고 행정구역 정보가 자동으로 업데이트됩니다
+- **PATCH 메서드**: 부분 수정을 위한 HTTP 메서드로, 모든 필드는 선택사항입니다
+- **필드별 수정**: 요청에 포함된 필드만 수정되며, 누락된 필드는 기존 값이 유지됩니다
+- **위도/경도 범위**: 위도 33.0~43.0, 경도 124.0~132.0 (한국 지역 내)
+- **위치 정보 수정**: 좌표 제공 시 새로운 CoordinatePoint 생성 및 행정구역 자동 업데이트
 '''
 
 === 이미지 지역 정보 포함 메타데이터 수정 API
-==== PUT /api/images/{imageId} (위치 정보 포함)
+==== PATCH /api/images/{imageId} (위치 정보 포함)
 
 이미지의 메타데이터와 함께 위치 정보도 수정하는 API입니다.
 위도와 경도를 함께 제공하면 해당 좌표의 행정구역 정보가 자동으로 업데이트됩니다.

--- a/src/docs/asciidoc/image-api.adoc
+++ b/src/docs/asciidoc/image-api.adoc
@@ -89,3 +89,76 @@ include::{snippets}/get-public-images/response-fields.adoc[]
 - 인증 없이 접근 가능한 공개 API
 - 사용자가 업로드한 이미지 중 공개로 설정된 것들만 반환
 '''
+
+=== 이미지 메타데이터 수정 API
+==== PUT /api/images/{imageId}
+
+업로드된 이미지의 메타데이터를 수정하는 API입니다.
+이미지 이름, 설명, 촬영 날짜, 공개 여부, 위치 정보를 수정할 수 있습니다.
+
+===== 요청
+include::{snippets}/update-image-metadata-success/http-request.adoc[]
+include::{snippets}/update-image-metadata-success/path-parameters.adoc[]
+include::{snippets}/update-image-metadata-success/request-fields.adoc[]
+
+===== 응답
+include::{snippets}/update-image-metadata-success/http-response.adoc[]
+include::{snippets}/update-image-metadata-success/response-fields.adoc[]
+
+===== 예외 상황
+- 인증되지 않은 사용자의 경우: `ApiException(ErrorCode.UNAUTHORIZED)` 발생
+- 다른 사용자의 이미지 수정 시도: `ApiException(ErrorCode.FORBIDDEN)` 발생
+- 존재하지 않는 이미지의 경우: `ApiException(ErrorCode.NOT_FOUND_IMAGE)` 발생
+- 잘못된 위도/경도 값: `ApiException(ErrorCode.BAD_REQUEST)` 발생
+
+===== 참고 사항
+- 모든 필드는 선택사항이며, 제공된 필드만 수정됩니다
+- 위도는 33.0~43.0 범위, 경도는 124.0~132.0 범위로 제한됩니다 (한국 지역)
+- 위치 정보 수정 시 새로운 좌표 포인트가 생성되고 행정구역 정보가 자동으로 업데이트됩니다
+'''
+
+=== 이미지 지역 정보 포함 메타데이터 수정 API
+==== PUT /api/images/{imageId} (위치 정보 포함)
+
+이미지의 메타데이터와 함께 위치 정보도 수정하는 API입니다.
+위도와 경도를 함께 제공하면 해당 좌표의 행정구역 정보가 자동으로 업데이트됩니다.
+
+===== 요청
+include::{snippets}/update-image-metadata-with-location-success/http-request.adoc[]
+include::{snippets}/update-image-metadata-with-location-success/path-parameters.adoc[]
+include::{snippets}/update-image-metadata-with-location-success/request-fields.adoc[]
+
+===== 응답
+include::{snippets}/update-image-metadata-with-location-success/http-response.adoc[]
+include::{snippets}/update-image-metadata-with-location-success/response-fields.adoc[]
+
+===== 위치 정보 수정 특징
+- 위도/경도를 제공하면 자동으로 해당 위치의 시도명, 시군구명이 업데이트됩니다
+- 좌표 기반으로 새로운 CoordinatePoint가 생성되어 연결됩니다
+- 한국 지역 내의 좌표만 허용됩니다 (위도: 33.0~43.0, 경도: 124.0~132.0)
+'''
+
+=== 이미지 삭제 API
+==== DELETE /api/images/{imageId}
+
+업로드된 이미지를 삭제하는 API입니다.
+실제로는 논리적 삭제(is_deleted = 1)를 수행하여 데이터 복구가 가능합니다.
+
+===== 요청
+include::{snippets}/delete-image-success/http-request.adoc[]
+include::{snippets}/delete-image-success/path-parameters.adoc[]
+
+===== 응답
+include::{snippets}/delete-image-success/http-response.adoc[]
+include::{snippets}/delete-image-success/response-fields.adoc[]
+
+===== 예외 상황
+- 인증되지 않은 사용자의 경우: `ApiException(ErrorCode.UNAUTHORIZED)` 발생
+- 다른 사용자의 이미지 삭제 시도: `ApiException(ErrorCode.FORBIDDEN)` 발생
+- 존재하지 않는 이미지의 경우: `ApiException(ErrorCode.NOT_FOUND_IMAGE)` 발생
+
+===== 참고 사항
+- 논리적 삭제로 실제 데이터는 보존됩니다 (is_deleted = 1 설정)
+- 삭제된 이미지는 일반 조회 API에서 제외됩니다
+- 본인이 업로드한 이미지만 삭제할 수 있습니다
+'''

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/common/response/enums/ErrorCode.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/common/response/enums/ErrorCode.java
@@ -21,6 +21,7 @@ import lombok.Getter;
  * 25. 2. 26.        inari			 UNAUTHORIZED_OAUTH_FAILED, BAD_REQUEST_INVALID_OAUTH_PROVIDER 추가
  * 25. 3. 20.        inari			 BAD_REQUEST_INVALID_INPUT 추가
  * 25. 5. 30.        inari			 지도관련 NOT_FOUND 추가
+ * 25. 6. 20.        inari			 이미지 수정 관련 UPDATE_FAILED 추가
  */
 @Getter
 @AllArgsConstructor
@@ -161,7 +162,11 @@ public enum ErrorCode {
 	 * 유효하지 않은 좌표 (HttpStatus.BAD_REQUEST, 400, "유효하지 않은 좌표입니다.")
 	 * 한국 영토 범위를 벗어난 좌표로 조회 시도할 때 발생
 	 */
-	BAD_REQUEST_INVALID_COORDINATE(HttpStatus.BAD_REQUEST, 400, "유효하지 않은 좌표입니다.");
+	BAD_REQUEST_INVALID_COORDINATE(HttpStatus.BAD_REQUEST, 400, "유효하지 않은 좌표입니다."),
+
+	UPDATE_FAILED_META(HttpStatus.INTERNAL_SERVER_ERROR, 500, "이미지 메타데이터 업데이트에 실패했습니다. 다른 요청에 의해 리소스가 변경되었을 수 있습니다."),
+
+	UPDATE_FAILED_LOCATION(HttpStatus.INTERNAL_SERVER_ERROR, 500, "이미지 위치 정보 업데이트에 실패했습니다. 다른 요청에 의해 리소스가 변경되었을 수 있습니다.");
 
 	/**
 	 * HTTP 상태 코드

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/controller/ImageController.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/controller/ImageController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -95,7 +96,7 @@ public class ImageController {
 	 * @param userDetails 인증된 사용자 정보
 	 * @return 수정된 이미지 정보
 	 */
-	@PutMapping("/{imageId}")
+	@PatchMapping("/{imageId}")
 	public ResponseEntity<ApiResponse<ImageDto>> updateImageMetadata(
 		@PathVariable Long imageId,
 		@Valid @RequestBody ImageUpdateRequestDto updateRequest,

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/controller/ImageController.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/controller/ImageController.java
@@ -4,15 +4,22 @@ import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
 
 import com.github.pagehelper.PageInfo;
 import com.trackery.trackerybackapiserver.domain.common.response.ApiResponse;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.SuccessCode;
 import com.trackery.trackerybackapiserver.domain.image.dto.ImageDto;
+import com.trackery.trackerybackapiserver.domain.image.dto.ImageUpdateRequestDto;
 import com.trackery.trackerybackapiserver.domain.image.service.ImageService;
 import com.trackery.trackerybackapiserver.domain.user.entity.CustomUserDetails;
 
@@ -28,6 +35,7 @@ import lombok.RequiredArgsConstructor;
  * DATE              AUTHOR             NOTE
  * -----------------------------------------------------------
  * 25. 5. 15.		durururuk		최초 생성
+ * 25. 6. 20.		 inari		 이미지 수정 및 삭제 추가
  */
 @RestController
 @RequiredArgsConstructor
@@ -78,5 +86,37 @@ public class ImageController {
 		PageInfo<ImageDto> imageDtoList = imageService.getImageListByUserIdV2(userDetails.getUserId(), pageNum,
 			pageSize);
 		return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, imageDtoList));
+	}
+
+	/**
+	 * 이미지 메타데이터 수정 API
+	 * @param imageId 수정할 이미지 ID
+	 * @param updateRequest 수정할 메타데이터
+	 * @param userDetails 인증된 사용자 정보
+	 * @return 수정된 이미지 정보
+	 */
+	@PutMapping("/{imageId}")
+	public ResponseEntity<ApiResponse<ImageDto>> updateImageMetadata(
+		@PathVariable Long imageId,
+		@Valid @RequestBody ImageUpdateRequestDto updateRequest,
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	) {
+		ImageDto updatedImage = imageService.updateImageMetadata(imageId, userDetails.getUserId(), updateRequest);
+		return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, updatedImage));
+	}
+
+	/**
+	 * 이미지 삭제 API (논리적 삭제)
+	 * @param imageId 삭제할 이미지 ID
+	 * @param userDetails 인증된 사용자 정보
+	 * @return 삭제 성공 응답
+	 */
+	@DeleteMapping("/{imageId}")
+	public ResponseEntity<ApiResponse<Void>> deleteImage(
+		@PathVariable Long imageId,
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	) {
+		imageService.deleteImage(imageId, userDetails.getUserId());
+		return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, null));
 	}
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/dto/ImageUpdateRequestDto.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/dto/ImageUpdateRequestDto.java
@@ -1,0 +1,41 @@
+package com.trackery.trackerybackapiserver.domain.image.dto;
+
+import java.time.LocalDateTime;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+
+/**
+ * packageName    : com.trackery.trackerybackapiserver.domain.image.dto
+ * fileName       : ImageUpdateRequestDto
+ * author         : inari
+ * date           : 25. 6. 20.
+ * description    : 이미지 메타데이터 수정 요청 DTO
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 25. 6. 20.        inari       최초 생성
+ */
+@Builder
+public record ImageUpdateRequestDto(
+	@Size(max = 100, message = "이미지 이름은 100자를 초과할 수 없습니다.")
+	String imageName,
+	
+	@Size(max = 500, message = "이미지 설명은 500자를 초과할 수 없습니다.")
+	String imageContent,
+	
+	LocalDateTime imageDate,
+	
+	Integer isPublic,
+	
+	@DecimalMin(value = "33.0", message = "위도는 33.0 이상이어야 합니다.")
+	@DecimalMax(value = "43.0", message = "위도는 43.0 이하여야 합니다.")
+	Double latitude,
+	
+	@DecimalMin(value = "124.0", message = "경도는 124.0 이상이어야 합니다.")
+	@DecimalMax(value = "132.0", message = "경도는 132.0 이하여야 합니다.")
+	Double longitude
+) {
+}

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/dto/LandingImagesResponse.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/dto/LandingImagesResponse.java
@@ -6,7 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 /**
- * packageName    : com.trackery.trackerybackapiserver.domain.home.dto
+ * packageName    : com.trackery.trackerybackapiserver.domain.image.dto
  * fileName       : LandingImagesResponse
  * author         : inari
  * date           : 25. 2. 14.

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/mapper/ImageMapper.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/mapper/ImageMapper.java
@@ -1,5 +1,6 @@
 package com.trackery.trackerybackapiserver.domain.image.mapper;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -19,6 +20,7 @@ import com.trackery.trackerybackapiserver.domain.image.entity.Image;
  * -----------------------------------------------------------
  * 25. 2. 14.        inari       최초 생성
  * 25. 6. 16.        inari       지도를 통한 이미지 조회 기능 추가
+ * 25. 6. 20.		 inari		 이미지 수정 및 삭제 추가
  */
 @Mapper
 public interface ImageMapper {
@@ -39,8 +41,6 @@ public interface ImageMapper {
 
 	List<Image> findImagesByUserId(@Param("userId") Long userId);
 
-	boolean isImageExist(Long imageId);
-
 	/**
 	 * 특정 시도에 등록된 특정 사용자의 이미지를 조회합니다.
 	 * @param sidoId 시도 ID
@@ -56,4 +56,34 @@ public interface ImageMapper {
 	 * @return 해당 시군구의 사용자 이미지 목록
 	 */
 	List<Image> findImagesBySigunguIdAndUserId(@Param("sigunguId") Long sigunguId, @Param("userId") Long userId);
+
+	/**
+	 * 이미지의 메타데이터를 수정합니다.
+	 * @param imageId 이미지 ID
+	 * @param imageName 이미지 이름
+	 * @param imageContent 이미지 설명
+	 * @param imageDate 이미지 촬영 날짜
+	 * @param isPublic 공개 여부
+	 * @return 수정된 행의 수
+	 */
+	int updateImageMetadata(@Param("imageId") Long imageId,
+			@Param("imageName") String imageName,
+			@Param("imageContent") String imageContent,
+			@Param("imageDate") LocalDateTime imageDate,
+			@Param("isPublic") Integer isPublic);
+
+	/**
+	 * 이미지를 논리적으로 삭제합니다 (is_deleted = 1).
+	 * @param imageId 이미지 ID
+	 * @return 삭제된 행의 수
+	 */
+	int deleteImage(@Param("imageId") Long imageId);
+
+	/**
+	 * 이미지의 좌표 정보를 수정합니다.
+	 * @param imageId 이미지 ID
+	 * @param coordinatePointId 새로운 좌표 포인트 ID
+	 * @return 수정된 행의 수
+	 */
+	int updateImageLocation(@Param("imageId") Long imageId, @Param("coordinatePointId") Long coordinatePointId);
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageService.java
@@ -195,7 +195,7 @@ public class ImageService {
 		);
 
 		if (updatedRows == 0) {
-			throw new ApiException(ErrorCode.NOT_FOUND_IMAGE);
+			throw new ApiException(ErrorCode.UPDATE_FAILED_META);
 		}
 
 		// 위치 정보가 제공된 경우 위치 정보도 수정
@@ -210,7 +210,7 @@ public class ImageService {
 			int locationUpdatedRows = imageMapper.updateImageLocation(imageId, newCoordinatePoint.getCoordinatePointId());
 			
 			if (locationUpdatedRows == 0) {
-				throw new ApiException(ErrorCode.NOT_FOUND_IMAGE);
+				throw new ApiException(ErrorCode.UPDATE_FAILED_LOCATION);
 			}
 
 			log.info("이미지 위치 정보 수정 완료 - imageId: {}, 새로운 위치: {}, {}", 

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageService.java
@@ -186,7 +186,7 @@ public class ImageService {
 		}
 
 		// 기본 메타데이터 수정
-		int updatedRows = imageMapper.updateImageMetadata(
+		imageMapper.updateImageMetadata(
 			imageId,
 			updateRequest.imageName(),
 			updateRequest.imageContent(),
@@ -194,27 +194,24 @@ public class ImageService {
 			updateRequest.isPublic()
 		);
 
-		if (updatedRows == 0) {
-			throw new ApiException(ErrorCode.UPDATE_FAILED_META);
-		}
-
 		// 위치 정보가 제공된 경우 위치 정보도 수정
 		if (updateRequest.latitude() != null && updateRequest.longitude() != null) {
-			CoordinateDto coordinateDto = new CoordinateDto(
-				updateRequest.latitude(),
-				updateRequest.longitude()
-			);
+			try {
+				CoordinateDto coordinateDto = new CoordinateDto(
+					updateRequest.latitude(),
+					updateRequest.longitude()
+				);
 
-			CoordinatePoint newCoordinatePoint = locationService.insertCoordinatePoint(coordinateDto);
-			
-			int locationUpdatedRows = imageMapper.updateImageLocation(imageId, newCoordinatePoint.getCoordinatePointId());
-			
-			if (locationUpdatedRows == 0) {
+				CoordinatePoint newCoordinatePoint = locationService.insertCoordinatePoint(coordinateDto);
+				
+				imageMapper.updateImageLocation(imageId, newCoordinatePoint.getCoordinatePointId());
+
+				log.info("이미지 위치 정보 수정 완료 - imageId: {}, 새로운 위치: {}, {}", 
+					imageId, updateRequest.latitude(), updateRequest.longitude());
+			} catch (Exception e) {
+				log.error("이미지 위치 정보 수정 실패 - imageId: {}, 에러: {}", imageId, e.getMessage());
 				throw new ApiException(ErrorCode.UPDATE_FAILED_LOCATION);
 			}
-
-			log.info("이미지 위치 정보 수정 완료 - imageId: {}, 새로운 위치: {}, {}", 
-				imageId, updateRequest.latitude(), updateRequest.longitude());
 		}
 
 		return getImageByImageId(imageId);

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageService.java
@@ -12,8 +12,10 @@ import com.github.pagehelper.PageInfo;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
 import com.trackery.trackerybackapiserver.domain.image.dto.ImageDto;
+import com.trackery.trackerybackapiserver.domain.image.dto.ImageUpdateRequestDto;
 import com.trackery.trackerybackapiserver.domain.image.entity.Image;
 import com.trackery.trackerybackapiserver.domain.image.mapper.ImageMapper;
+import com.trackery.trackerybackapiserver.domain.location.dto.CoordinateDto;
 import com.trackery.trackerybackapiserver.domain.location.dto.LocationInfoDto;
 import com.trackery.trackerybackapiserver.domain.location.entity.CoordinatePoint;
 import com.trackery.trackerybackapiserver.domain.location.service.LocationService;
@@ -35,6 +37,7 @@ import lombok.extern.slf4j.Slf4j;
  * 25. 2. 19.        inari       이미지를 불러오지 못했을시 예외 처리
  * 25. 5. 15.		durururuk	 이미지 단건/다건 조회 기능 작성
  * 25. 6. 16.		 inari		 지도를 통한 이미지 조회 기능 추가
+ * 25. 6. 20.		 inari		 이미지 수정 및 삭제 추가
  */
 @Slf4j
 @Service
@@ -164,5 +167,79 @@ public class ImageService {
 		return images.stream()
 			.map(this::convertImageToImageDto)
 			.toList();
+	}
+
+	/**
+	 * 이미지 메타데이터를 수정합니다.
+	 * @param imageId 이미지 ID
+	 * @param userId 요청하는 사용자 ID (권한 확인용)
+	 * @param updateRequest 수정할 데이터
+	 * @return 수정된 이미지 정보
+	 */
+	@CacheEvict(value = "publicImageUrls", allEntries = true)
+	public ImageDto updateImageMetadata(Long imageId, Long userId, ImageUpdateRequestDto updateRequest) {
+		Image existingImage = imageMapper.findImageByImageId(imageId)
+			.orElseThrow(() -> new ApiException(ErrorCode.NOT_FOUND_IMAGE));
+
+		if (!existingImage.getUserId().equals(userId)) {
+			throw new ApiException(ErrorCode.FORBIDDEN);
+		}
+
+		// 기본 메타데이터 수정
+		int updatedRows = imageMapper.updateImageMetadata(
+			imageId,
+			updateRequest.imageName(),
+			updateRequest.imageContent(),
+			updateRequest.imageDate(),
+			updateRequest.isPublic()
+		);
+
+		if (updatedRows == 0) {
+			throw new ApiException(ErrorCode.NOT_FOUND_IMAGE);
+		}
+
+		// 위치 정보가 제공된 경우 위치 정보도 수정
+		if (updateRequest.latitude() != null && updateRequest.longitude() != null) {
+			CoordinateDto coordinateDto = new CoordinateDto(
+				updateRequest.latitude(),
+				updateRequest.longitude()
+			);
+
+			CoordinatePoint newCoordinatePoint = locationService.insertCoordinatePoint(coordinateDto);
+			
+			int locationUpdatedRows = imageMapper.updateImageLocation(imageId, newCoordinatePoint.getCoordinatePointId());
+			
+			if (locationUpdatedRows == 0) {
+				throw new ApiException(ErrorCode.NOT_FOUND_IMAGE);
+			}
+
+			log.info("이미지 위치 정보 수정 완료 - imageId: {}, 새로운 위치: {}, {}", 
+				imageId, updateRequest.latitude(), updateRequest.longitude());
+		}
+
+		return getImageByImageId(imageId);
+	}
+
+	/**
+	 * 이미지를 삭제합니다 (논리적 삭제).
+	 * @param imageId 삭제할 이미지 ID
+	 * @param userId 요청하는 사용자 ID (권한 확인용)
+	 */
+	@CacheEvict(value = "publicImageUrls", allEntries = true)
+	public void deleteImage(Long imageId, Long userId) {
+		Image existingImage = imageMapper.findImageByImageId(imageId)
+			.orElseThrow(() -> new ApiException(ErrorCode.NOT_FOUND_IMAGE));
+
+		if (!existingImage.getUserId().equals(userId)) {
+			throw new ApiException(ErrorCode.FORBIDDEN);
+		}
+
+		int deletedRows = imageMapper.deleteImage(imageId);
+
+		if (deletedRows == 0) {
+			throw new ApiException(ErrorCode.NOT_FOUND_IMAGE);
+		}
+
+		log.info("이미지 삭제 완료 - imageId: {}, userId: {}", imageId, userId);
 	}
 }

--- a/src/main/resources/mapper/ImageMapper.xml
+++ b/src/main/resources/mapper/ImageMapper.xml
@@ -165,4 +165,32 @@
         ORDER BY i.image_reg_date DESC
     </select>
 
+    <!-- 이미지 메타데이터 수정 -->
+    <update id="updateImageMetadata">
+        UPDATE image 
+        SET 
+            <if test="imageName != null">image_name = #{imageName},</if>
+            <if test="imageContent != null">image_contents = #{imageContent},</if>
+            <if test="imageDate != null">image_date = #{imageDate},</if>
+            <if test="isPublic != null">is_public = #{isPublic}</if>
+        WHERE image_id = #{imageId}
+          AND is_deleted = 0
+    </update>
+
+    <!-- 이미지 논리적 삭제 -->
+    <update id="deleteImage">
+        UPDATE image 
+        SET is_deleted = 1
+        WHERE image_id = #{imageId}
+          AND is_deleted = 0
+    </update>
+
+    <!-- 이미지 위치 정보 수정 -->
+    <update id="updateImageLocation">
+        UPDATE image 
+        SET coord_point_id = #{coordinatePointId}
+        WHERE image_id = #{imageId}
+          AND is_deleted = 0
+    </update>
+
 </mapper>

--- a/src/main/resources/mapper/ImageMapper.xml
+++ b/src/main/resources/mapper/ImageMapper.xml
@@ -167,14 +167,15 @@
 
     <!-- 이미지 메타데이터 수정 -->
     <update id="updateImageMetadata">
-        UPDATE image 
-        SET 
+        UPDATE image
+        <set>
             <if test="imageName != null">image_name = #{imageName},</if>
             <if test="imageContent != null">image_contents = #{imageContent},</if>
             <if test="imageDate != null">image_date = #{imageDate},</if>
-            <if test="isPublic != null">is_public = #{isPublic}</if>
+            <if test="isPublic != null">is_public = #{isPublic},</if>
+        </set>
         WHERE image_id = #{imageId}
-          AND is_deleted = 0
+        AND is_deleted = 0
     </update>
 
     <!-- 이미지 논리적 삭제 -->

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/image/controller/ImageControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/image/controller/ImageControllerTest.java
@@ -11,6 +11,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.http.MediaType.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -26,6 +29,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import com.github.pagehelper.PageInfo;
 import com.trackery.trackerybackapiserver.domain.config.CommonMockMvcControllerTestSetUp;
 import com.trackery.trackerybackapiserver.domain.image.dto.ImageDto;
+import com.trackery.trackerybackapiserver.domain.image.dto.ImageUpdateRequestDto;
 import com.trackery.trackerybackapiserver.domain.image.service.ImageService;
 import com.trackery.trackerybackapiserver.domain.user.entity.CustomUserDetails;
 
@@ -243,5 +247,185 @@ class ImageControllerTest extends CommonMockMvcControllerTestSetUp {
 			));
 
 		verify(imageService, times(1)).getImageListByUserIdV2(USER_ID, 1, 10);
+	}
+
+	@Test
+	@DisplayName("이미지 메타데이터 수정 성공")
+	void updateImageMetadataSuccess() throws Exception {
+		ImageUpdateRequestDto updateRequest = ImageUpdateRequestDto.builder()
+			.imageName("수정된 이미지")
+			.imageContent("수정된 설명")
+			.isPublic(1)
+			.build();
+
+		ImageDto updatedImageDto = ImageDto.builder()
+			.imageId(IMAGE_ID)
+			.userId(USER_ID)
+			.imageRegDate(IMAGE_REG_DATE)
+			.sdName(SD_NAME)
+			.sggName(SGG_NAME)
+			.latitude(LATITUDE)
+			.longitude(LONGITUDE)
+			.imageName("수정된 이미지")
+			.imageContent("수정된 설명")
+			.imageDate(IMAGE_DATE)
+			.imageUrl(IMAGE_URL)
+			.isPublic(1)
+			.build();
+
+		when(imageService.updateImageMetadata(eq(IMAGE_ID), eq(USER_ID), any(ImageUpdateRequestDto.class)))
+			.thenReturn(updatedImageDto);
+
+		ObjectMapper objectMapper = new ObjectMapper();
+		String requestJson = objectMapper.writeValueAsString(updateRequest);
+
+		ResultActions result = mockMvc.perform(put("/api/images/{imageId}", IMAGE_ID)
+			.with(user(userDetails))
+			.contentType(APPLICATION_JSON)
+			.content(requestJson));
+
+		result
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value(200))
+			.andExpect(jsonPath("$.message").value("Ok"))
+			.andExpect(jsonPath("$.data.imageId").value(IMAGE_ID))
+			.andExpect(jsonPath("$.data.imageName").value("수정된 이미지"))
+			.andExpect(jsonPath("$.data.imageContent").value("수정된 설명"))
+			.andExpect(jsonPath("$.data.isPublic").value(1))
+			.andDo(document("update-image-metadata-success",
+				pathParameters(
+					parameterWithName("imageId").description("수정할 이미지 ID")
+				),
+				requestFields(
+					fieldWithPath("imageName").description("수정할 이미지 이름 (선택사항)").optional(),
+					fieldWithPath("imageContent").description("수정할 이미지 설명 (선택사항)").optional(),
+					fieldWithPath("imageDate").description("수정할 이미지 촬영 날짜 (선택사항)").optional(),
+					fieldWithPath("isPublic").description("수정할 공개 여부 (0: 비공개, 1: 공개, 선택사항)").optional(),
+					fieldWithPath("latitude").description("수정할 위도 (33.0-43.0, 선택사항)").optional(),
+					fieldWithPath("longitude").description("수정할 경도 (124.0-132.0, 선택사항)").optional()
+				),
+				responseFields(
+					fieldWithPath("code").description("상태 코드"),
+					fieldWithPath("message").description("응답 메시지"),
+					fieldWithPath("data.imageId").description("이미지 ID"),
+					fieldWithPath("data.userId").description("이미지 업로드 사용자 ID"),
+					fieldWithPath("data.imageRegDate").description("이미지 등록 일시"),
+					fieldWithPath("data.sdName").description("시도명"),
+					fieldWithPath("data.sggName").description("시군구명"),
+					fieldWithPath("data.latitude").description("위도"),
+					fieldWithPath("data.longitude").description("경도"),
+					fieldWithPath("data.imageName").description("이미지 파일명"),
+					fieldWithPath("data.imageContent").description("이미지 설명"),
+					fieldWithPath("data.imageDate").description("이미지 촬영 일시"),
+					fieldWithPath("data.isPublic").description("공개 여부"),
+					fieldWithPath("data.imageUrl").description("이미지 URL")
+				)
+			));
+
+		verify(imageService, times(1)).updateImageMetadata(eq(IMAGE_ID), eq(USER_ID), any(ImageUpdateRequestDto.class));
+	}
+
+	@Test
+	@DisplayName("이미지 지역 정보 포함 메타데이터 수정 성공")
+	void updateImageMetadataWithLocationSuccess() throws Exception {
+		ImageUpdateRequestDto updateRequest = ImageUpdateRequestDto.builder()
+			.imageName("수정된 이미지")
+			.imageContent("수정된 설명")
+			.isPublic(1)
+			.latitude(37.5665)
+			.longitude(126.978)
+			.build();
+
+		ImageDto updatedImageDto = ImageDto.builder()
+			.imageId(IMAGE_ID)
+			.userId(USER_ID)
+			.imageRegDate(IMAGE_REG_DATE)
+			.sdName("서울특별시")
+			.sggName("중구")
+			.latitude(37.5665)
+			.longitude(126.978)
+			.imageName("수정된 이미지")
+			.imageContent("수정된 설명")
+			.imageDate(IMAGE_DATE)
+			.imageUrl(IMAGE_URL)
+			.isPublic(1)
+			.build();
+
+		when(imageService.updateImageMetadata(eq(IMAGE_ID), eq(USER_ID), any(ImageUpdateRequestDto.class)))
+			.thenReturn(updatedImageDto);
+
+		ObjectMapper objectMapper = new ObjectMapper();
+		String requestJson = objectMapper.writeValueAsString(updateRequest);
+
+		ResultActions result = mockMvc.perform(put("/api/images/{imageId}", IMAGE_ID)
+			.with(user(userDetails))
+			.contentType(APPLICATION_JSON)
+			.content(requestJson));
+
+		result
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value(200))
+			.andExpect(jsonPath("$.message").value("Ok"))
+			.andExpect(jsonPath("$.data.imageId").value(IMAGE_ID))
+			.andExpect(jsonPath("$.data.latitude").value(37.5665))
+			.andExpect(jsonPath("$.data.longitude").value(126.978))
+			.andExpect(jsonPath("$.data.sggName").value("중구"))
+			.andDo(document("update-image-metadata-with-location-success",
+				pathParameters(
+					parameterWithName("imageId").description("수정할 이미지 ID")
+				),
+				requestFields(
+					fieldWithPath("imageName").description("수정할 이미지 이름"),
+					fieldWithPath("imageContent").description("수정할 이미지 설명"),
+					fieldWithPath("imageDate").description("수정할 이미지 촬영 날짜").optional(),
+					fieldWithPath("isPublic").description("수정할 공개 여부 (0: 비공개, 1: 공개)"),
+					fieldWithPath("latitude").description("수정할 위도 (33.0-43.0)"),
+					fieldWithPath("longitude").description("수정할 경도 (124.0-132.0)")
+				),
+				responseFields(
+					fieldWithPath("code").description("상태 코드"),
+					fieldWithPath("message").description("응답 메시지"),
+					fieldWithPath("data.imageId").description("이미지 ID"),
+					fieldWithPath("data.userId").description("이미지 업로드 사용자 ID"),
+					fieldWithPath("data.imageRegDate").description("이미지 등록 일시"),
+					fieldWithPath("data.sdName").description("시도명 (수정된 위치 기준)"),
+					fieldWithPath("data.sggName").description("시군구명 (수정된 위치 기준)"),
+					fieldWithPath("data.latitude").description("수정된 위도"),
+					fieldWithPath("data.longitude").description("수정된 경도"),
+					fieldWithPath("data.imageName").description("수정된 이미지 파일명"),
+					fieldWithPath("data.imageContent").description("수정된 이미지 설명"),
+					fieldWithPath("data.imageDate").description("이미지 촬영 일시"),
+					fieldWithPath("data.isPublic").description("수정된 공개 여부"),
+					fieldWithPath("data.imageUrl").description("이미지 URL")
+				)
+			));
+
+		verify(imageService, times(1)).updateImageMetadata(eq(IMAGE_ID), eq(USER_ID), any(ImageUpdateRequestDto.class));
+	}
+
+	@Test
+	@DisplayName("이미지 삭제 성공")
+	void deleteImageSuccess() throws Exception {
+		doNothing().when(imageService).deleteImage(IMAGE_ID, USER_ID);
+
+		ResultActions result = mockMvc.perform(delete("/api/images/{imageId}", IMAGE_ID)
+			.with(user(userDetails)));
+
+		result
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value(200))
+			.andExpect(jsonPath("$.message").value("Ok"))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andDo(document("delete-image-success",
+				pathParameters(
+					parameterWithName("imageId").description("삭제할 이미지 ID")
+				),
+				responseFields(
+					fieldWithPath("code").description("상태 코드"),
+					fieldWithPath("message").description("응답 메시지")
+				)
+			));
+
+		verify(imageService, times(1)).deleteImage(IMAGE_ID, USER_ID);
 	}
 }

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/image/controller/ImageControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/image/controller/ImageControllerTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.rest.webmvc.json.patch.Patch;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -279,7 +280,7 @@ class ImageControllerTest extends CommonMockMvcControllerTestSetUp {
 		ObjectMapper objectMapper = new ObjectMapper();
 		String requestJson = objectMapper.writeValueAsString(updateRequest);
 
-		ResultActions result = mockMvc.perform(put("/api/images/{imageId}", IMAGE_ID)
+		ResultActions result = mockMvc.perform(patch("/api/images/{imageId}", IMAGE_ID)
 			.with(user(userDetails))
 			.contentType(APPLICATION_JSON)
 			.content(requestJson));
@@ -357,7 +358,7 @@ class ImageControllerTest extends CommonMockMvcControllerTestSetUp {
 		ObjectMapper objectMapper = new ObjectMapper();
 		String requestJson = objectMapper.writeValueAsString(updateRequest);
 
-		ResultActions result = mockMvc.perform(put("/api/images/{imageId}", IMAGE_ID)
+		ResultActions result = mockMvc.perform(patch("/api/images/{imageId}", IMAGE_ID)
 			.with(user(userDetails))
 			.contentType(APPLICATION_JSON)
 			.content(requestJson));

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/image/service/ImageServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/image/service/ImageServiceTest.java
@@ -27,10 +27,12 @@ import com.github.pagehelper.PageInfo;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
 import com.trackery.trackerybackapiserver.domain.image.dto.ImageDto;
+import com.trackery.trackerybackapiserver.domain.image.dto.ImageUpdateRequestDto;
 import com.trackery.trackerybackapiserver.domain.image.entity.Image;
 import com.trackery.trackerybackapiserver.domain.image.mapper.ImageMapper;
 import com.trackery.trackerybackapiserver.domain.location.dto.LocationInfoDto;
 import com.trackery.trackerybackapiserver.domain.location.entity.CoordinatePoint;
+import com.trackery.trackerybackapiserver.domain.location.service.LocationService;
 import com.trackery.trackerybackapiserver.domain.location.entity.JusoSido;
 import com.trackery.trackerybackapiserver.domain.location.entity.JusoSigungu;
 
@@ -44,7 +46,8 @@ import com.trackery.trackerybackapiserver.domain.location.entity.JusoSigungu;
  * DATE              AUTHOR             NOTE
  * -----------------------------------------------------------
  * 25. 2. 14.        inari       최초 생성
- * 25. 5. 19.		durururul	이미지 조회 단위 테스트 작성
+ * 25. 5. 19.		durururuk	이미지 조회 단위 테스트 작성
+ * 25. 6. 20.		inari		이미지 삭제 및 수정 테스트 작성
  */
 @ExtendWith(MockitoExtension.class)
 class ImageServiceTest {
@@ -55,6 +58,8 @@ class ImageServiceTest {
 	private CacheManager cacheManager;
 	@Mock
 	private ImageS3Service imageS3Service;
+	@Mock
+	private LocationService locationService;
 	@InjectMocks
 	private ImageService imageService;
 
@@ -234,6 +239,188 @@ class ImageServiceTest {
 
 				verify(imageMapper).findImagesByUserId(testUserId);
 			}
+		}
+	}
+
+	@Nested
+	@DisplayName("이미지 메타데이터 수정 테스트")
+	class UpdateImageMetadataTest {
+		private Image existingImage;
+		private final Long imageId = 1L;
+		private final Long userId = 2L;
+		private final Long otherUserId = 3L;
+
+		@BeforeEach
+		void setUp() {
+			JusoSido sido = new JusoSido();
+			ReflectionTestUtils.setField(sido, "sidoId", 1L);
+			ReflectionTestUtils.setField(sido, "sidoName", "서울특별시");
+
+			JusoSigungu sigungu = new JusoSigungu();
+			ReflectionTestUtils.setField(sigungu, "sigunguId", 1L);
+			ReflectionTestUtils.setField(sigungu, "sigunguName", "강남구");
+			ReflectionTestUtils.setField(sigungu, "sido", sido);
+
+			Coordinate coordinate = new Coordinate(127.0495556, 37.5398056);
+			PrecisionModel precisionModel = new PrecisionModel(PrecisionModel.FLOATING);
+			Point testPoint = new Point(coordinate, precisionModel, 4321);
+
+			CoordinatePoint coordPoint = new CoordinatePoint();
+			ReflectionTestUtils.setField(coordPoint, "coordinatePointId", 1L);
+			ReflectionTestUtils.setField(coordPoint, "coordinatePointName", "테스트 좌표");
+			ReflectionTestUtils.setField(coordPoint, "coordinatePointPoint", testPoint);
+			ReflectionTestUtils.setField(coordPoint, "sigungu", sigungu);
+
+			existingImage = Image.builder()
+				.coordPoint(coordPoint)
+				.imageName("기존 이미지")
+				.imageFile("images/test.jpg")
+				.imageContent("기존 설명")
+				.isPublic(0)
+				.userId(userId)
+				.build();
+			ReflectionTestUtils.setField(existingImage, "imageId", imageId);
+		}
+
+		@Test
+		@DisplayName("성공 - 메타데이터 수정")
+		void updateImageMetadata_success() {
+			ImageUpdateRequestDto updateRequest = ImageUpdateRequestDto.builder()
+				.imageName("수정된 이미지")
+				.imageContent("수정된 설명")
+				.isPublic(1)
+				.build();
+
+			when(imageMapper.findImageByImageId(imageId)).thenReturn(Optional.of(existingImage));
+			when(imageMapper.updateImageMetadata(eq(imageId), eq("수정된 이미지"), eq("수정된 설명"), isNull(), eq(1)))
+				.thenReturn(1);
+			when(imageS3Service.generatePreSignedGetUrl(anyString())).thenReturn("test-url");
+
+			ImageDto result = imageService.updateImageMetadata(imageId, userId, updateRequest);
+
+			assertNotNull(result);
+			verify(imageMapper, times(2)).findImageByImageId(imageId);
+			verify(imageMapper).updateImageMetadata(eq(imageId), eq("수정된 이미지"), eq("수정된 설명"), isNull(), eq(1));
+		}
+
+		@Test
+		@DisplayName("실패 - 이미지 존재하지 않음")
+		void updateImageMetadata_imageNotFound() {
+			ImageUpdateRequestDto updateRequest = ImageUpdateRequestDto.builder()
+				.imageName("수정된 이미지")
+				.build();
+
+			when(imageMapper.findImageByImageId(imageId)).thenReturn(Optional.empty());
+
+			assertThatThrownBy(() -> imageService.updateImageMetadata(imageId, userId, updateRequest))
+				.isInstanceOf(ApiException.class)
+				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_FOUND_IMAGE);
+
+			verify(imageMapper).findImageByImageId(imageId);
+			verify(imageMapper, never()).updateImageMetadata(any(), any(), any(), any(), any());
+		}
+
+		@Test
+		@DisplayName("실패 - 권한 없음 (다른 사용자)")
+		void updateImageMetadata_forbidden() {
+			ImageUpdateRequestDto updateRequest = ImageUpdateRequestDto.builder()
+				.imageName("수정된 이미지")
+				.build();
+
+			when(imageMapper.findImageByImageId(imageId)).thenReturn(Optional.of(existingImage));
+
+			assertThatThrownBy(() -> imageService.updateImageMetadata(imageId, otherUserId, updateRequest))
+				.isInstanceOf(ApiException.class)
+				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN);
+
+			verify(imageMapper).findImageByImageId(imageId);
+			verify(imageMapper, never()).updateImageMetadata(any(), any(), any(), any(), any());
+		}
+
+		@Test
+		@DisplayName("성공 - 지역 정보 포함 메타데이터 수정")
+		void updateImageMetadata_withLocation_success() {
+			ImageUpdateRequestDto updateRequest = ImageUpdateRequestDto.builder()
+				.imageName("수정된 이미지")
+				.imageContent("수정된 설명")
+				.isPublic(1)
+				.latitude(37.5665)
+				.longitude(126.978)
+				.build();
+
+			CoordinatePoint newCoordinatePoint = new CoordinatePoint();
+			ReflectionTestUtils.setField(newCoordinatePoint, "coordinatePointId", 100L);
+
+			when(imageMapper.findImageByImageId(imageId)).thenReturn(Optional.of(existingImage));
+			when(imageMapper.updateImageMetadata(eq(imageId), eq("수정된 이미지"), eq("수정된 설명"), isNull(), eq(1)))
+				.thenReturn(1);
+			when(locationService.insertCoordinatePoint(any())).thenReturn(newCoordinatePoint);
+			when(imageMapper.updateImageLocation(imageId, 100L)).thenReturn(1);
+			when(imageS3Service.generatePreSignedGetUrl(anyString())).thenReturn("test-url");
+
+			ImageDto result = imageService.updateImageMetadata(imageId, userId, updateRequest);
+
+			assertNotNull(result);
+			verify(imageMapper, times(2)).findImageByImageId(imageId);
+			verify(imageMapper).updateImageMetadata(eq(imageId), eq("수정된 이미지"), eq("수정된 설명"), isNull(), eq(1));
+			verify(locationService).insertCoordinatePoint(any());
+			verify(imageMapper).updateImageLocation(imageId, 100L);
+		}
+	}
+
+	@Nested
+	@DisplayName("이미지 삭제 테스트")
+	class DeleteImageTest {
+		private Image existingImage;
+		private final Long imageId = 1L;
+		private final Long userId = 2L;
+		private final Long otherUserId = 3L;
+
+		@BeforeEach
+		void setUp() {
+			existingImage = Image.builder()
+				.imageName("삭제할 이미지")
+				.userId(userId)
+				.build();
+			ReflectionTestUtils.setField(existingImage, "imageId", imageId);
+		}
+
+		@Test
+		@DisplayName("성공 - 이미지 삭제")
+		void deleteImage_success() {
+			when(imageMapper.findImageByImageId(imageId)).thenReturn(Optional.of(existingImage));
+			when(imageMapper.deleteImage(imageId)).thenReturn(1);
+
+			assertDoesNotThrow(() -> imageService.deleteImage(imageId, userId));
+
+			verify(imageMapper).findImageByImageId(imageId);
+			verify(imageMapper).deleteImage(imageId);
+		}
+
+		@Test
+		@DisplayName("실패 - 이미지 존재하지 않음")
+		void deleteImage_imageNotFound() {
+			when(imageMapper.findImageByImageId(imageId)).thenReturn(Optional.empty());
+
+			assertThatThrownBy(() -> imageService.deleteImage(imageId, userId))
+				.isInstanceOf(ApiException.class)
+				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_FOUND_IMAGE);
+
+			verify(imageMapper).findImageByImageId(imageId);
+			verify(imageMapper, never()).deleteImage(any());
+		}
+
+		@Test
+		@DisplayName("실패 - 권한 없음 (다른 사용자)")
+		void deleteImage_forbidden() {
+			when(imageMapper.findImageByImageId(imageId)).thenReturn(Optional.of(existingImage));
+
+			assertThatThrownBy(() -> imageService.deleteImage(imageId, otherUserId))
+				.isInstanceOf(ApiException.class)
+				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN);
+
+			verify(imageMapper).findImageByImageId(imageId);
+			verify(imageMapper, never()).deleteImage(any());
 		}
 	}
 }


### PR DESCRIPTION
이미지 메타데이터 수정 및 이미지 메타데이터 논리삭제 기능 구현했습니다.
현재 이미지 메타데이터 수정시 좌표가 복사되어 다시 인서트되는 문제가 있습니다.

나중에 논리 삭제한 이미지는 배치로 삭제후 아마존 s3도 삭제할수있게 해야함