### PR TITLE
feature/이미지-수정시-지역변경-매핑추가 이미지 메타데이터 수정시 좌표 인서트가 아닌 업데이트로 변경

### DIFF
--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageService.java
@@ -38,6 +38,7 @@ import lombok.extern.slf4j.Slf4j;
  * 25. 5. 15.		durururuk	 이미지 단건/다건 조회 기능 작성
  * 25. 6. 16.		 inari		 지도를 통한 이미지 조회 기능 추가
  * 25. 6. 20.		 inari		 이미지 수정 및 삭제 추가
+ * 25. 6. 22.		 inari		 이미지 수정시 좌표 인서트가 아닌 업데이트로 변경
  */
 @Slf4j
 @Service
@@ -202,12 +203,12 @@ public class ImageService {
 					updateRequest.longitude()
 				);
 
-				CoordinatePoint newCoordinatePoint = locationService.insertCoordinatePoint(coordinateDto);
-				
-				imageMapper.updateImageLocation(imageId, newCoordinatePoint.getCoordinatePointId());
+				// 기존 이미지의 coord_point_id를 사용하여 업데이트
+				Long existingCoordPointId = existingImage.getCoordPoint().getCoordinatePointId();
+				locationService.updateCoordinatePoint(existingCoordPointId, coordinateDto);
 
-				log.info("이미지 위치 정보 수정 완료 - imageId: {}, 새로운 위치: {}, {}", 
-					imageId, updateRequest.latitude(), updateRequest.longitude());
+				log.info("이미지 위치 정보 수정 완료 - imageId: {}, coord_point_id: {}, 새로운 위치: {}, {}", 
+					imageId, existingCoordPointId, updateRequest.latitude(), updateRequest.longitude());
 			} catch (Exception e) {
 				log.error("이미지 위치 정보 수정 실패 - imageId: {}, 에러: {}", imageId, e.getMessage());
 				throw new ApiException(ErrorCode.UPDATE_FAILED_LOCATION);

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/location/mapper/LocationMapper.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/location/mapper/LocationMapper.java
@@ -1,9 +1,11 @@
 package com.trackery.trackerybackapiserver.domain.location.mapper;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 import org.locationtech.jts.geom.Point;
 
 import com.trackery.trackerybackapiserver.domain.location.dto.CoordinateDto;
@@ -25,6 +27,7 @@ import com.trackery.trackerybackapiserver.domain.location.entity.JusoSigungu;
  * 25. 4. 15.		durururuk		최초 생성
  * 25. 6. 13.		inari			시군구 ID로 시군구 정보를 조회 매퍼 추가
  * 25. 6. 14.		inari			홈화면 전국지도용 통계 추가
+ * 25. 6. 22.		inari			좌표 업데이트 메서드 추가
  */
 @Mapper
 public interface LocationMapper {
@@ -47,6 +50,18 @@ public interface LocationMapper {
 	 * @param coordinatePoint CoordinatePoint 객체
 	 */
 	void insertCoordinatePoint(CoordinatePoint coordinatePoint);
+
+	/**
+	 * ID로 CoordinatePoint 정보를 수정합니다.
+	 * @param coordinatePointId 좌표 포인트 ID
+	 * @param coordinatePointName 좌표 포인트 이름
+	 * @param coordinatePointPoint 좌표 포인트
+	 * @param sigunguId 시군구 ID
+	 * @param lastModifiedDate 수정 시간
+	 * @return 수정된 행 수
+	 */
+	int updateCoordinatePointById(Long coordinatePointId, String coordinatePointName, Point coordinatePointPoint, 
+		Long sigunguId, LocalDateTime lastModifiedDate);
 
 	/**
 	 * 대한민국의 모든 시도 목록을 조회합니다.

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/location/service/LocationService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/location/service/LocationService.java
@@ -14,7 +14,6 @@ import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
 import com.trackery.trackerybackapiserver.domain.location.dto.CoordinateDto;
 import com.trackery.trackerybackapiserver.domain.location.dto.CoordinateRequestDto;
-import com.trackery.trackerybackapiserver.domain.location.dto.HomeStatsResponseDto;
 import com.trackery.trackerybackapiserver.domain.location.dto.MapResponseDto;
 import com.trackery.trackerybackapiserver.domain.location.dto.UserStatsDto;
 import com.trackery.trackerybackapiserver.domain.location.entity.CoordinatePoint;
@@ -37,6 +36,7 @@ import lombok.extern.slf4j.Slf4j;
  * 25. 4. 15.		durururuk		최초 생성
  * 25. 6. 13.		inari			시군구 ID로 시군구 정보를 조회 메서드 추가
  * 25. 6. 14.		inari			홈화면 전국지도용 통계 추가
+ * 25. 6. 22.		inari			좌표 업데이트 메서드 추가
  */
 @Slf4j
 @Service
@@ -103,6 +103,22 @@ public class LocationService {
 		locationMapper.insertCoordinatePoint(coordinatePoint);
 
 		return coordinatePoint;
+	}
+
+	/**
+	 * 기존 CoordinatePoint 객체의 좌표 정보를 업데이트하는 메서드입니다.
+	 * @param coordinatePointId 업데이트할 좌표 포인트 ID
+	 * @param coordinateDto 새로운 좌표 DTO
+	 * @return 업데이트된 행 수
+	 */
+	@Transactional
+	public int updateCoordinatePoint(Long coordinatePointId, CoordinateDto coordinateDto) {
+		Point point = getPointByCoord(coordinateDto);
+		JusoSigungu sigungu = getSigunguByPoint(point);
+		String pointName = String.format("%s %s", sigungu.getSido().getSidoName(), sigungu.getSigunguName());
+
+		return locationMapper.updateCoordinatePointById(coordinatePointId, pointName, point, sigungu.getSigunguId(),
+			LocalDateTime.now(ZoneId.of("Asia/Seoul")));
 	}
 
 	/**

--- a/src/main/resources/mapper/LocationMapper.xml
+++ b/src/main/resources/mapper/LocationMapper.xml
@@ -81,6 +81,26 @@
         );
     </insert>
 
+    <update id="updateCoordinatePoint" parameterType="com.trackery.trackerybackapiserver.domain.location.entity.CoordinatePoint">
+        UPDATE coord_poi 
+        SET coord_point_name = #{coordinatePointName},
+            coord_point_point = #{coordinatePointPoint},
+            coord_point_type = #{coordinatePointType},
+            last_mod_dt = #{lastModifiedDate},
+            sgg_id = #{sigungu.sigunguId}
+        WHERE coord_point_id = #{coordinatePointId}
+    </update>
+
+    <update id="updateCoordinatePointById">
+        UPDATE coord_poi 
+        SET coord_point_name = #{coordinatePointName},
+            coord_point_point = #{coordinatePointPoint},
+            coord_point_type = 1,
+            last_mod_dt = #{lastModifiedDate},
+            sgg_id = #{sigunguId}
+        WHERE coord_point_id = #{coordinatePointId}
+    </update>
+
     <!-- Map domain integration queries -->
 
     <resultMap id="JusoSidoMap" type="com.trackery.trackerybackapiserver.domain.location.entity.JusoSido">

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/image/service/ImageServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/image/service/ImageServiceTest.java
@@ -348,14 +348,10 @@ class ImageServiceTest {
 				.longitude(126.978)
 				.build();
 
-			CoordinatePoint newCoordinatePoint = new CoordinatePoint();
-			ReflectionTestUtils.setField(newCoordinatePoint, "coordinatePointId", 100L);
-
 			when(imageMapper.findImageByImageId(imageId)).thenReturn(Optional.of(existingImage));
 			when(imageMapper.updateImageMetadata(eq(imageId), eq("수정된 이미지"), eq("수정된 설명"), isNull(), eq(1)))
 				.thenReturn(1);
-			when(locationService.insertCoordinatePoint(any())).thenReturn(newCoordinatePoint);
-			when(imageMapper.updateImageLocation(imageId, 100L)).thenReturn(1);
+			when(locationService.updateCoordinatePoint(eq(1L), any())).thenReturn(1);
 			when(imageS3Service.generatePreSignedGetUrl(anyString())).thenReturn("test-url");
 
 			ImageDto result = imageService.updateImageMetadata(imageId, userId, updateRequest);
@@ -363,8 +359,7 @@ class ImageServiceTest {
 			assertNotNull(result);
 			verify(imageMapper, times(2)).findImageByImageId(imageId);
 			verify(imageMapper).updateImageMetadata(eq(imageId), eq("수정된 이미지"), eq("수정된 설명"), isNull(), eq(1));
-			verify(locationService).insertCoordinatePoint(any());
-			verify(imageMapper).updateImageLocation(imageId, 100L);
+			verify(locationService).updateCoordinatePoint(eq(1L), any());
 		}
 	}
 

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/location/service/LocationServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/location/service/LocationServiceTest.java
@@ -3,6 +3,7 @@ package com.trackery.trackerybackapiserver.domain.location.service;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -40,6 +41,7 @@ import com.trackery.trackerybackapiserver.domain.location.mapper.LocationMapper;
  * DATE              AUTHOR             NOTE
  * -----------------------------------------------------------
  * 25. 6. 13.		Narilee			최초 생성
+ * 25. 6. 22.		Narilee			좌표 업데이트 테스트 추가
  */
 
 @ExtendWith(MockitoExtension.class)
@@ -153,6 +155,75 @@ class LocationServiceTest {
 			verify(locationMapper, times(1)).insertCoordinatePoint(any(CoordinatePoint.class));
 
 			assertEquals("서울특별시 동작구", coordinatePoint.getCoordinatePointName());
+		}
+	}
+
+	@Nested
+	@DisplayName("CoordinatePoint 업데이트 테스트")
+	class updateCoordinatePointTest {
+		Long coordinatePointId;
+		CoordinateDto coordinateDto;
+		Point point;
+		JusoSigungu sigungu;
+		JusoSido sido;
+
+		@BeforeEach
+		void setUp() {
+			coordinatePointId = 1L;
+			coordinateDto = new CoordinateDto(37.5665, 126.9780);
+			point = mock(Point.class);
+			sigungu = mock(JusoSigungu.class);
+			sido = mock(JusoSido.class);
+		}
+
+		@Test
+		@DisplayName("성공 - 좌표 포인트 업데이트 성공")
+		void success() {
+			when(locationMapper.findSigunguByPoint(any(Point.class))).thenReturn(Optional.of(sigungu));
+			when(sigungu.getSigunguName()).thenReturn("강남구");
+			when(sigungu.getSido()).thenReturn(sido);
+			when(sido.getSidoName()).thenReturn("서울특별시");
+			when(sigungu.getSigunguId()).thenReturn(11680L);
+			when(locationMapper.updateCoordinatePointById(eq(coordinatePointId), eq("서울특별시 강남구"), 
+				any(Point.class), eq(11680L), any(LocalDateTime.class))).thenReturn(1);
+
+			int result = locationService.updateCoordinatePoint(coordinatePointId, coordinateDto);
+
+			assertEquals(1, result);
+			verify(locationMapper, times(1)).findSigunguByPoint(any(Point.class));
+			verify(locationMapper, times(1)).updateCoordinatePointById(eq(coordinatePointId), eq("서울특별시 강남구"), 
+				any(Point.class), eq(11680L), any(LocalDateTime.class));
+		}
+
+		@Test
+		@DisplayName("실패 - 좌표로 시군구를 찾을 수 없는 경우")
+		void failureNotFoundSigungu() {
+			when(locationMapper.findSigunguByPoint(any(Point.class))).thenReturn(Optional.empty());
+
+			ApiException exception = assertThrows(ApiException.class,
+				() -> locationService.updateCoordinatePoint(coordinatePointId, coordinateDto));
+
+			assertEquals(ErrorCode.NOT_FOUND, exception.getErrorCode());
+			verify(locationMapper, times(1)).findSigunguByPoint(any(Point.class));
+			verify(locationMapper, never()).updateCoordinatePointById(any(), any(), any(), any(), any());
+		}
+
+		@Test
+		@DisplayName("성공 - 업데이트된 행이 0개인 경우")
+		void successZeroRowsUpdated() {
+			when(locationMapper.findSigunguByPoint(any(Point.class))).thenReturn(Optional.of(sigungu));
+			when(sigungu.getSigunguName()).thenReturn("동작구");
+			when(sigungu.getSido()).thenReturn(sido);
+			when(sido.getSidoName()).thenReturn("서울특별시");
+			when(sigungu.getSigunguId()).thenReturn(11200L);
+			when(locationMapper.updateCoordinatePointById(eq(coordinatePointId), eq("서울특별시 동작구"), 
+				any(Point.class), eq(11200L), any(LocalDateTime.class))).thenReturn(0);
+
+			int result = locationService.updateCoordinatePoint(coordinatePointId, coordinateDto);
+
+			assertEquals(0, result);
+			verify(locationMapper, times(1)).updateCoordinatePointById(eq(coordinatePointId), eq("서울특별시 동작구"), 
+				any(Point.class), eq(11200L), any(LocalDateTime.class));
 		}
 	}
 


### PR DESCRIPTION
이미지 메타데이터 수정시 좌표 인서트가 아닌 업데이트로 변경했습니다.
이전에는 기존 인서트를 이용하여 coord_poi에 메타데이터 업데이트할때마다 새로 컬럼이 추가되는 문제가 있었습니다.