### PR TITLE
앨범 페이지네이션 기능 적용

### DIFF
--- a/src/docs/asciidoc/album-api.adoc
+++ b/src/docs/asciidoc/album-api.adoc
@@ -60,15 +60,28 @@ include::{snippets}/delete-images-from-album/response-fields.adoc[]
 === 앨범 상세 정보 조회 API
 ==== GET /api/albums/{앨범 ID}
 
-앨범의 정보와 앨범에 포함돼있는 이미지를 불러오는 API입니다. 이미지 응답 데이터 형식은 이미지 API 문서를 참고 바랍니다.
+앨범의 상세 정보를 조회할 수 있는 API입니다.
 
 ===== 요청
-include::{snippets}/get-album-detailed-info/http-request.adoc[]
+include::{snippets}/get-album-metadata/http-request.adoc[]
 
 ===== 응답
-include::{snippets}/get-album-detailed-info/http-response.adoc[]
-include::{snippets}/get-album-detailed-info/response-fields.adoc[]
+include::{snippets}/get-album-metadata/http-response.adoc[]
+include::{snippets}/get-album-metadata/response-fields.adoc[]
 '''
+
+=== 앨범 이미지 조회 API
+==== GET /api/albums/{앨범 ID}/images
+
+앨범에 포함된 이미지를 조회할 수 있는 API입니다.
+
+===== 요청
+include::{snippets}/get-album-images/http-request.adoc[]
+include::{snippets}/get-album-images/query-parameters.adoc[]
+
+===== 응답
+include::{snippets}/get-album-images/http-response.adoc[]
+include::{snippets}/get-album-images/response-fields.adoc[]
 
 === 앨범 정보 수정 API
 ==== PATCH /api/albums/{앨범 ID}

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/album/controller/AlbumController.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/album/controller/AlbumController.java
@@ -1,4 +1,3 @@
-
 package com.trackery.trackerybackapiserver.domain.album.controller;
 
 import org.springframework.http.ResponseEntity;
@@ -99,27 +98,12 @@ public class AlbumController {
 	}
 
 	/**
-	 * 앨범 상세 정보 조회 API
-	 * @deprecated 앨범 이미지 페이지네이션을 구현하면서 메타데이터 조회 API, 이미지 조회 API로 분리했습니다. 프론트엔드 적용 후 삭제 예정입니다.
-	 * @param albumId 앨범 ID
-	 * @param userDetails 인증된 유저 정보
-	 * @return 앨범 정보, 앨범에 있는 이미지를 담은 상세 정보 DTO
-	 */
-	@Deprecated(forRemoval = true)
-	@GetMapping("/{albumId}")
-	public ResponseEntity<ApiResponse<AlbumDetailedResponseDto>> getAlbumDetailedInfo(@PathVariable Long albumId,
-		@AuthenticationPrincipal CustomUserDetails userDetails) {
-		AlbumDetailedResponseDto result = albumService.getAlbumDetailedInfo(userDetails.getUserId(), albumId);
-		return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, result));
-	}
-
-	/**
 	 * 앨범 상세 정보 메타데이터 조회 API
 	 * @param albumId 조회할 앨범 ID
 	 * @param userDetails 인증된 유저 정보
 	 * @return 앨범 정보를 담은 상세 정보 DTO
 	 */
-	@GetMapping("/v2/{albumId}")
+	@GetMapping("/{albumId}")
 	public ResponseEntity<ApiResponse<AlbumDetailedResponseDto>> getAlbumMetadata(@PathVariable Long albumId,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		AlbumDetailedResponseDto result = albumService.getAlbumMetadata(userDetails.getUserId(), albumId);

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/album/controller/AlbumController.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/album/controller/AlbumController.java
@@ -10,8 +10,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.github.pagehelper.PageInfo;
 import com.trackery.trackerybackapiserver.domain.album.dto.request.AlbumCreateRequestDto;
 import com.trackery.trackerybackapiserver.domain.album.dto.request.AlbumImageEditRequestDto;
 import com.trackery.trackerybackapiserver.domain.album.dto.request.AlbumUpdateRequestDto;
@@ -22,6 +24,7 @@ import com.trackery.trackerybackapiserver.domain.album.dto.response.MyAlbumRespo
 import com.trackery.trackerybackapiserver.domain.album.service.AlbumService;
 import com.trackery.trackerybackapiserver.domain.common.response.ApiResponse;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.SuccessCode;
+import com.trackery.trackerybackapiserver.domain.image.dto.ImageDto;
 import com.trackery.trackerybackapiserver.domain.user.entity.CustomUserDetails;
 
 import jakarta.validation.Valid;
@@ -97,14 +100,43 @@ public class AlbumController {
 
 	/**
 	 * 앨범 상세 정보 조회 API
+	 * @deprecated 앨범 이미지 페이지네이션을 구현하면서 메타데이터 조회 API, 이미지 조회 API로 분리했습니다. 프론트엔드 적용 후 삭제 예정입니다.
 	 * @param albumId 앨범 ID
 	 * @param userDetails 인증된 유저 정보
 	 * @return 앨범 정보, 앨범에 있는 이미지를 담은 상세 정보 DTO
 	 */
+	@Deprecated(forRemoval = true)
 	@GetMapping("/{albumId}")
 	public ResponseEntity<ApiResponse<AlbumDetailedResponseDto>> getAlbumDetailedInfo(@PathVariable Long albumId,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		AlbumDetailedResponseDto result = albumService.getAlbumDetailedInfo(userDetails.getUserId(), albumId);
+		return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, result));
+	}
+
+	/**
+	 * 앨범 상세 정보 메타데이터 조회 API
+	 * @param albumId 조회할 앨범 ID
+	 * @param userDetails 인증된 유저 정보
+	 * @return 앨범 정보를 담은 상세 정보 DTO
+	 */
+	@GetMapping("/v2/{albumId}")
+	public ResponseEntity<ApiResponse<AlbumDetailedResponseDto>> getAlbumMetadata(@PathVariable Long albumId,
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
+		AlbumDetailedResponseDto result = albumService.getAlbumMetadata(userDetails.getUserId(), albumId);
+		return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, result));
+	}
+
+	/**
+	 * 앨범 이미지 조회 API
+	 * @param albumId 조회할 앨범 ID
+	 * @param pageNum 페이지 번호 (기본값 : 1)
+	 * @param pageSize 페이지 크기 (기본값 : 10)
+	 * @return 페이지네이션된 이미지 DTO 리스트
+	 */
+	@GetMapping("/{albumId}/images")
+	public ResponseEntity<ApiResponse<PageInfo<ImageDto>>> getAlbumImages(@PathVariable Long albumId,
+		@RequestParam(defaultValue = "1") int pageNum, @RequestParam(defaultValue = "10") int pageSize) {
+		PageInfo<ImageDto> result = albumService.getAlbumImages(albumId, pageNum, pageSize);
 		return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, result));
 	}
 

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/album/dto/response/AlbumDetailedResponseDto.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/album/dto/response/AlbumDetailedResponseDto.java
@@ -1,10 +1,5 @@
 package com.trackery.trackerybackapiserver.domain.album.dto.response;
 
-import java.util.List;
-
-import com.trackery.trackerybackapiserver.domain.album.entity.Album;
-import com.trackery.trackerybackapiserver.domain.image.dto.ImageDto;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -32,18 +27,4 @@ public class AlbumDetailedResponseDto {
 	private String albumDescription;
 	private Integer isPublic;
 	private Integer imageCount;
-
-	private List<ImageDto> imageList;
-
-	public static AlbumDetailedResponseDto of(Album album, List<ImageDto> imageList) {
-		return AlbumDetailedResponseDto.builder()
-			.albumId(album.getAlbumId())
-			.createdUserId(album.getUserId())
-			.albumTitle(album.getAlbumTitle())
-			.albumDescription(album.getAlbumDescription())
-			.imageList(imageList)
-			.isPublic(album.getIsPublic())
-			.imageCount(imageList.size())
-			.build();
-	}
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/album/service/AlbumService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/album/service/AlbumService.java
@@ -12,6 +12,8 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.github.pagehelper.PageHelper;
+import com.github.pagehelper.PageInfo;
 import com.trackery.trackerybackapiserver.domain.album.dto.request.AlbumCreateRequestDto;
 import com.trackery.trackerybackapiserver.domain.album.dto.request.AlbumUpdateRequestDto;
 import com.trackery.trackerybackapiserver.domain.album.dto.response.AlbumCreateResponseDto;
@@ -198,11 +200,13 @@ public class AlbumService {
 
 	/**
 	 * 앨범 상세 정보 조회
+	 * @deprecated 앨범 메타데이터 조회 + 이미지 페이지네이션 조회 두 개로 나누기 위해 삭제 예정입니다.
 	 * @param userId 유저 ID
 	 * @param albumId 앨범 ID
 	 * @return 앨범 정보, 앨범에 포함돼있는 이미지 정보를 담은 DTO
 	 */
 	@Transactional(readOnly = true)
+	@Deprecated(since = "2025-06-23")
 	public AlbumDetailedResponseDto getAlbumDetailedInfo(Long userId, Long albumId) {
 		Album album = albumMapper.findByAlbumId(albumId).orElseThrow(() -> new ApiException(ErrorCode.NOT_FOUND_ALBUM));
 
@@ -220,6 +224,57 @@ public class AlbumService {
 		List<ImageDto> imageDtoList = imageList.stream().map(imageService::convertImageToImageDto).toList();
 
 		return AlbumDetailedResponseDto.of(album, imageDtoList);
+	}
+
+	/*
+	앨범 상세 정보 조회
+	 */
+	public AlbumDetailedResponseDto getAlbumMetadata(Long userId, Long albumId) {
+		Album album = albumMapper.findByAlbumId(albumId).orElseThrow(
+			() -> new ApiException(ErrorCode.NOT_FOUND_ALBUM)
+		);
+
+		if (album.getIsPublic() == 0 && !userId.equals(album.getUserId())) {
+			throw new ApiException(ErrorCode.FORBIDDEN);
+		}
+
+		List<AlbumImage> albumImageList = albumMapper.findAlbumImagesByAlbumId(albumId);
+
+		return AlbumDetailedResponseDto.builder()
+			.albumId(album.getAlbumId())
+			.createdUserId(album.getUserId())
+			.albumTitle(album.getAlbumTitle())
+			.albumDescription(album.getAlbumDescription())
+			.isPublic(album.getIsPublic())
+			.imageCount(albumImageList.size())
+			.build();
+	}
+
+	/*
+	앨범 이미지 조회
+	 */
+	@SuppressWarnings("squid:S3252")
+	public PageInfo<ImageDto> getAlbumImages(Long userId, Long albumId, int pageNum, int pageSize) {
+		Album album = albumMapper.findByAlbumId(albumId).orElseThrow(
+			() -> new ApiException(ErrorCode.NOT_FOUND_ALBUM)
+		);
+
+		if (album.getIsPublic() == 0 && !userId.equals(album.getUserId())) {
+			throw new ApiException(ErrorCode.FORBIDDEN);
+		}
+
+		List<AlbumImage> albumImageList = albumMapper.findAlbumImagesByAlbumId(albumId);
+
+		List<ImageDto> albumImageDtoList = albumImageList.stream()
+			.map(albumImage -> imageMapper.findImageByImageId(albumImage.getImageId()).orElseThrow(
+				() -> new ApiException(ErrorCode.NOT_FOUND_IMAGE)
+			))
+			.map(imageService::convertImageToImageDto)
+			.toList();
+
+		PageHelper.startPage(pageNum, pageSize);
+
+		return new PageInfo<>(albumImageDtoList);
 	}
 
 	/**

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/album/service/AlbumService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/album/service/AlbumService.java
@@ -226,8 +226,11 @@ public class AlbumService {
 		return AlbumDetailedResponseDto.of(album, imageDtoList);
 	}
 
-	/*
-	앨범 상세 정보 조회
+	/**
+	 * 앨범 메타데이터 조회
+	 * @param userId 요청한 유저 ID
+	 * @param albumId 조회할 앨범 ID
+	 * @return 앨범의 정보를 담은 DTO
 	 */
 	public AlbumDetailedResponseDto getAlbumMetadata(Long userId, Long albumId) {
 		Album album = albumMapper.findByAlbumId(albumId).orElseThrow(
@@ -250,18 +253,16 @@ public class AlbumService {
 			.build();
 	}
 
-	/*
-	앨범 이미지 조회
+	/**
+	 * 앨범 이미지 조회
+	 * @param albumId 조회할 이미지 ID
+	 * @param pageNum 페이지 번호
+	 * @param pageSize 페이지 크기
+	 * @return 페이지네이션된 이미지 DTO 리스트
 	 */
 	@SuppressWarnings("squid:S3252")
-	public PageInfo<ImageDto> getAlbumImages(Long userId, Long albumId, int pageNum, int pageSize) {
-		Album album = albumMapper.findByAlbumId(albumId).orElseThrow(
-			() -> new ApiException(ErrorCode.NOT_FOUND_ALBUM)
-		);
-
-		if (album.getIsPublic() == 0 && !userId.equals(album.getUserId())) {
-			throw new ApiException(ErrorCode.FORBIDDEN);
-		}
+	public PageInfo<ImageDto> getAlbumImages(Long albumId, int pageNum, int pageSize) {
+		PageHelper.startPage(pageNum, pageSize);
 
 		List<AlbumImage> albumImageList = albumMapper.findAlbumImagesByAlbumId(albumId);
 
@@ -271,8 +272,6 @@ public class AlbumService {
 			))
 			.map(imageService::convertImageToImageDto)
 			.toList();
-
-		PageHelper.startPage(pageNum, pageSize);
 
 		return new PageInfo<>(albumImageDtoList);
 	}

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/album/service/AlbumService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/album/service/AlbumService.java
@@ -199,34 +199,6 @@ public class AlbumService {
 	}
 
 	/**
-	 * 앨범 상세 정보 조회
-	 * @deprecated 앨범 메타데이터 조회 + 이미지 페이지네이션 조회 두 개로 나누기 위해 삭제 예정입니다.
-	 * @param userId 유저 ID
-	 * @param albumId 앨범 ID
-	 * @return 앨범 정보, 앨범에 포함돼있는 이미지 정보를 담은 DTO
-	 */
-	@Transactional(readOnly = true)
-	@Deprecated(since = "2025-06-23")
-	public AlbumDetailedResponseDto getAlbumDetailedInfo(Long userId, Long albumId) {
-		Album album = albumMapper.findByAlbumId(albumId).orElseThrow(() -> new ApiException(ErrorCode.NOT_FOUND_ALBUM));
-
-		if (album.getIsPublic() == 0 && !userId.equals(album.getUserId())) {
-			throw new ApiException(ErrorCode.FORBIDDEN);
-		}
-
-		List<AlbumImage> albumImageList = albumMapper.findAlbumImagesByAlbumId(albumId);
-
-		List<Image> imageList = albumImageList.stream()
-			.map(albumImage -> imageMapper.findImageByImageId(albumImage.getImageId())
-				.orElseThrow(() -> new ApiException(ErrorCode.NOT_FOUND_IMAGE)))
-			.toList();
-
-		List<ImageDto> imageDtoList = imageList.stream().map(imageService::convertImageToImageDto).toList();
-
-		return AlbumDetailedResponseDto.of(album, imageDtoList);
-	}
-
-	/**
 	 * 앨범 메타데이터 조회
 	 * @param userId 요청한 유저 ID
 	 * @param albumId 조회할 앨범 ID

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/controller/ImageController.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/controller/ImageController.java
@@ -1,20 +1,15 @@
 package com.trackery.trackerybackapiserver.domain.image.controller;
 
-import java.util.List;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import jakarta.validation.Valid;
 
 import com.github.pagehelper.PageInfo;
 import com.trackery.trackerybackapiserver.domain.common.response.ApiResponse;
@@ -24,6 +19,7 @@ import com.trackery.trackerybackapiserver.domain.image.dto.ImageUpdateRequestDto
 import com.trackery.trackerybackapiserver.domain.image.service.ImageService;
 import com.trackery.trackerybackapiserver.domain.user.entity.CustomUserDetails;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -57,28 +53,13 @@ public class ImageController {
 	}
 
 	/**
-	 * 현재 인증된 유저가 업로드한 이미지 다건 조회 API
-	 * @deprecated 페이지네이션 사용 버전으로 프론트 수정 후 삭제 예정 {@link #getMyImagesV2(CustomUserDetails, int, int)}
-	 * @param userDetails 인증 유저 정보
-	 * @return 이미지 정보 DTO
-	 */
-	@Deprecated(forRemoval = true)
-	@GetMapping("/me")
-	public ResponseEntity<ApiResponse<List<ImageDto>>> getMyImages(
-		@AuthenticationPrincipal CustomUserDetails userDetails) {
-		List<ImageDto> imageDtoList = imageService.getImageListByUserId(userDetails.getUserId());
-
-		return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, imageDtoList));
-	}
-
-	/**
 	 * 현재 인증된 유저가 업로드한 이미지 조회 API 페이지네이션 버전
 	 * @param userDetails 인증 유저 정보
 	 * @param pageNum 페이지 번호 (기본값 : 1)
 	 * @param pageSize 페이지 크기 (기본값 : 10)
 	 * @return 페이지네이션된 이미지 DTO 리스트
 	 */
-	@GetMapping("/v2/me")
+	@GetMapping("/me")
 	public ResponseEntity<ApiResponse<PageInfo<ImageDto>>> getMyImagesV2(
 		@AuthenticationPrincipal CustomUserDetails userDetails,
 		@RequestParam(defaultValue = "1") int pageNum,

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageService.java
@@ -109,6 +109,7 @@ public class ImageService {
 	 * @param pageSize 페이지 사이즈
 	 * @return 페이지네이션된 이미지 DTO 리스트
 	 */
+	@SuppressWarnings("squid:S3252")
 	public PageInfo<ImageDto> getImageListByUserIdV2(Long userId, int pageNum, int pageSize) {
 		PageHelper.startPage(pageNum, pageSize);
 

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/album/controller/AlbumControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/album/controller/AlbumControllerTest.java
@@ -378,6 +378,10 @@ class AlbumControllerTest extends CommonMockMvcControllerTestSetUp {
 		result.andExpect(status().isOk());
 
 		result.andDo(document("get-album-images",
+			queryParameters(
+				PaginationDocumentationUtils.getPageableQueryParameters()
+			),
+
 			responseFields(
 				fieldWithPath("code").description("응답 코드"),
 				fieldWithPath("message").description("응답 메시지"),

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/album/controller/AlbumControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/album/controller/AlbumControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -20,6 +21,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.ResultActions;
 
+import com.github.pagehelper.PageInfo;
 import com.trackery.trackerybackapiserver.domain.album.dto.request.AlbumCreateRequestDto;
 import com.trackery.trackerybackapiserver.domain.album.dto.request.AlbumImageEditRequestDto;
 import com.trackery.trackerybackapiserver.domain.album.dto.request.AlbumUpdateRequestDto;
@@ -29,7 +31,9 @@ import com.trackery.trackerybackapiserver.domain.album.dto.response.AlbumImageEd
 import com.trackery.trackerybackapiserver.domain.album.dto.response.AlbumSimpledResponseDto;
 import com.trackery.trackerybackapiserver.domain.album.dto.response.MyAlbumResponseDto;
 import com.trackery.trackerybackapiserver.domain.album.service.AlbumService;
+import com.trackery.trackerybackapiserver.domain.common.util.PaginationDocumentationUtils;
 import com.trackery.trackerybackapiserver.domain.config.CommonMockMvcControllerTestSetUp;
+import com.trackery.trackerybackapiserver.domain.image.dto.ImageDto;
 import com.trackery.trackerybackapiserver.domain.user.entity.CustomUserDetails;
 
 /**
@@ -341,6 +345,57 @@ class AlbumControllerTest extends CommonMockMvcControllerTestSetUp {
 				)
 			)
 		);
+	}
+
+	@Test
+	void getAlbumImagesSuccess() throws Exception {
+		ImageDto imageDto = ImageDto.builder()
+			.imageId(1L)
+			.userId(2L)
+			.imageRegDate(LocalDateTime.of(2025, 5, 22, 0, 0))
+			.sdName("서울특별시")
+			.sggName("강남구")
+			.latitude(15.57)
+			.longitude(121.45)
+			.imageName("image.jpg")
+			.imageContent("테스트용 이미지")
+			.imageDate(LocalDateTime.of(2000, 1, 1, 0, 0))
+			.imageUrl("http://test.com/api/images/image.jpg")
+			.isPublic(0)
+			.build();
+
+		List<ImageDto> imageDtoList = List.of(imageDto);
+
+		PageInfo<ImageDto> pageInfo = new PageInfo<>(imageDtoList);
+		when(albumService.getAlbumImages(16L, 1, 10)).thenReturn(pageInfo);
+
+		ResultActions result = mockMvc.perform(get("/api/albums/{albumId}/images", 16L)
+			.with(user(customUserDetails))
+			.queryParam("pageNum", "1")
+			.queryParam("pageSize", "10")
+		);
+
+		result.andExpect(status().isOk());
+
+		result.andDo(document("get-album-images",
+			responseFields(
+				fieldWithPath("code").description("응답 코드"),
+				fieldWithPath("message").description("응답 메시지"),
+				fieldWithPath("data.list[]").description("이미지 목록"),
+				fieldWithPath("data.list[].imageId").description("이미지 ID"),
+				fieldWithPath("data.list[].userId").description("사용자 ID"),
+				fieldWithPath("data.list[].imageRegDate").description("이미지 등록일"),
+				fieldWithPath("data.list[].sdName").description("시도명"),
+				fieldWithPath("data.list[].sggName").description("시군구명"),
+				fieldWithPath("data.list[].latitude").description("위도"),
+				fieldWithPath("data.list[].longitude").description("경도"),
+				fieldWithPath("data.list[].imageName").description("이미지 파일명"),
+				fieldWithPath("data.list[].imageContent").description("이미지 설명"),
+				fieldWithPath("data.list[].imageDate").description("이미지 촬영일"),
+				fieldWithPath("data.list[].isPublic").description("공개 여부"),
+				fieldWithPath("data.list[].imageUrl").description("이미지 URL")
+			).andWithPrefix("", PaginationDocumentationUtils.getPageableResponseFields())
+		));
 	}
 
 	@Test

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/album/controller/AlbumControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/album/controller/AlbumControllerTest.java
@@ -24,7 +24,6 @@ import com.trackery.trackerybackapiserver.domain.album.dto.request.AlbumCreateRe
 import com.trackery.trackerybackapiserver.domain.album.dto.request.AlbumImageEditRequestDto;
 import com.trackery.trackerybackapiserver.domain.album.dto.request.AlbumUpdateRequestDto;
 import com.trackery.trackerybackapiserver.domain.album.dto.response.AlbumCreateResponseDto;
-import com.trackery.trackerybackapiserver.domain.album.dto.response.AlbumDetailedResponseDto;
 import com.trackery.trackerybackapiserver.domain.album.dto.response.AlbumImageEditResponseDto;
 import com.trackery.trackerybackapiserver.domain.album.dto.response.AlbumSimpledResponseDto;
 import com.trackery.trackerybackapiserver.domain.album.dto.response.MyAlbumResponseDto;
@@ -151,55 +150,6 @@ class AlbumControllerTest extends CommonMockMvcControllerTestSetUp {
 						fieldWithPath("data.succeededImageIds").description("성공한 이미지 ID 리스트"),
 						fieldWithPath("data.failedImageIds").description("실패한 이미지 ID 맵"),
 						fieldWithPath("data.failedImageIds.*").description("실패한 이미지 ID별 오류 메시지")
-					)
-				)
-			);
-	}
-
-	@Test
-	void getAlbumDetailedInfoSuccess() throws Exception {
-		Long albumId = 1L;
-
-		AlbumDetailedResponseDto responseDto = AlbumDetailedResponseDto.builder()
-			.albumId(albumId)
-			.createdUserId(customUserDetails.getUserId())
-			.albumTitle("강릉 여행")
-			.albumDescription("강릉 여행 기록")
-			.imageList(List.of())
-			.isPublic(0)
-			.imageCount(0)
-			.build();
-
-		when(albumService.getAlbumDetailedInfo(any(), eq(albumId))).thenReturn(responseDto);
-
-		ResultActions result = mockMvc.perform(get("/api/albums/{albumId}", albumId)
-			.with(user(customUserDetails)));
-
-		result
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.data").exists())
-			.andExpect(jsonPath("$.data.albumId").value(1))
-			.andExpect(jsonPath("$.data.createdUserId").value(1))
-			.andExpect(jsonPath("$.data.albumTitle").value("강릉 여행"))
-			.andExpect(jsonPath("$.data.albumDescription").value("강릉 여행 기록"))
-			.andExpect(jsonPath("$.data.imageList").isArray())
-			.andExpect(jsonPath("$.data.imageList").exists());
-
-		result
-			.andDo(document("get-album-detailed-info",
-					pathParameters(
-						parameterWithName("albumId").description("앨범 ID")
-					),
-					responseFields(
-						fieldWithPath("code").description("응답 코드"),
-						fieldWithPath("message").description("응답 메시지"),
-						fieldWithPath("data.albumId").description("앨범 ID"),
-						fieldWithPath("data.createdUserId").description("앨벙을 생성한 유저 ID"),
-						fieldWithPath("data.albumTitle").description("앨범 제목"),
-						fieldWithPath("data.albumDescription").description("앨범 설명"),
-						fieldWithPath("data.isPublic").description("공개 여부").type(JsonFieldType.NUMBER),
-						fieldWithPath("data.imageCount").description("이미지 개수").type(JsonFieldType.NUMBER),
-						fieldWithPath("data.imageList").description("앨범 이미지 리스트")
 					)
 				)
 			);

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/album/controller/AlbumControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/album/controller/AlbumControllerTest.java
@@ -24,6 +24,7 @@ import com.trackery.trackerybackapiserver.domain.album.dto.request.AlbumCreateRe
 import com.trackery.trackerybackapiserver.domain.album.dto.request.AlbumImageEditRequestDto;
 import com.trackery.trackerybackapiserver.domain.album.dto.request.AlbumUpdateRequestDto;
 import com.trackery.trackerybackapiserver.domain.album.dto.response.AlbumCreateResponseDto;
+import com.trackery.trackerybackapiserver.domain.album.dto.response.AlbumDetailedResponseDto;
 import com.trackery.trackerybackapiserver.domain.album.dto.response.AlbumImageEditResponseDto;
 import com.trackery.trackerybackapiserver.domain.album.dto.response.AlbumSimpledResponseDto;
 import com.trackery.trackerybackapiserver.domain.album.dto.response.MyAlbumResponseDto;
@@ -293,6 +294,50 @@ class AlbumControllerTest extends CommonMockMvcControllerTestSetUp {
 					fieldWithPath("data.albumList[].albumImageCount").description("앨범 이미지 개수"),
 					fieldWithPath("data.albumList[].isPublic").description("공개 여부"),
 					fieldWithPath("data.albumList[0].albumThumbnailUrl").description("앨범 썸네일 이미지 URL")
+				)
+			)
+		);
+	}
+
+	@Test
+	void getAlbumMetadataSuccess() throws Exception {
+		final Long ALBUM_ID = 16L;
+		final Long USER_ID = 1L;
+		final String TITLE = "부산 여행";
+		final String DESCRIPTION = "서면-광안리-해운대 여행";
+		final int IS_PUBLIC = 1;
+		final int IMAGE_COUNT = 3;
+		AlbumDetailedResponseDto albumDetailedResponseDto = AlbumDetailedResponseDto
+			.builder()
+			.albumId(ALBUM_ID)
+			.createdUserId(USER_ID)
+			.albumTitle(TITLE)
+			.albumDescription(DESCRIPTION)
+			.isPublic(IS_PUBLIC)
+			.imageCount(IMAGE_COUNT)
+			.build();
+
+		when(albumService.getAlbumMetadata(USER_ID, ALBUM_ID)).thenReturn(albumDetailedResponseDto);
+
+		ResultActions result = mockMvc.perform(get("/api/albums/{albumId}", ALBUM_ID)
+			.with(user(customUserDetails)));
+
+		result.andExpect(status().isOk());
+
+		result.andDo(document("get-album-metadata",
+				pathParameters(
+					parameterWithName("albumId").description("앨범 ID")
+				),
+
+				responseFields(
+					fieldWithPath("code").description("응답 코드"),
+					fieldWithPath("message").description("응답 메시지"),
+					fieldWithPath("data.albumId").description("앨범 ID"),
+					fieldWithPath("data.createdUserId").description("앨범 생성한 유저 ID"),
+					fieldWithPath("data.albumTitle").description("앨범 제목"),
+					fieldWithPath("data.albumDescription").description("앨범 설명"),
+					fieldWithPath("data.isPublic").description("공개 여부"),
+					fieldWithPath("data.imageCount").description("이미지 장수")
 				)
 			)
 		);

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/album/service/AlbumServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/album/service/AlbumServiceTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
 import org.springframework.context.ApplicationEventPublisher;
@@ -24,7 +23,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 import com.trackery.trackerybackapiserver.domain.album.dto.request.AlbumCreateRequestDto;
 import com.trackery.trackerybackapiserver.domain.album.dto.request.AlbumUpdateRequestDto;
 import com.trackery.trackerybackapiserver.domain.album.dto.response.AlbumCreateResponseDto;
-import com.trackery.trackerybackapiserver.domain.album.dto.response.AlbumDetailedResponseDto;
 import com.trackery.trackerybackapiserver.domain.album.dto.response.AlbumImageEditResponseDto;
 import com.trackery.trackerybackapiserver.domain.album.dto.response.MyAlbumResponseDto;
 import com.trackery.trackerybackapiserver.domain.album.entity.Album;
@@ -35,9 +33,6 @@ import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiEx
 import com.trackery.trackerybackapiserver.domain.image.entity.Image;
 import com.trackery.trackerybackapiserver.domain.image.mapper.ImageMapper;
 import com.trackery.trackerybackapiserver.domain.image.service.ImageService;
-import com.trackery.trackerybackapiserver.domain.location.dto.LocationInfoDto;
-import com.trackery.trackerybackapiserver.domain.location.entity.CoordinatePoint;
-import com.trackery.trackerybackapiserver.domain.location.service.LocationUtil;
 
 @ExtendWith(MockitoExtension.class)
 class AlbumServiceTest {
@@ -282,76 +277,6 @@ class AlbumServiceTest {
 			assertTrue(response.getFailedImageIds().containsKey(5L));
 
 			verify(albumMapper, never()).insertAlbumImage(any(AlbumImage.class));
-		}
-	}
-
-	@Nested
-	@DisplayName("앨범 상세 정보 조회 테스트")
-	class GetAlbumDetailedInfoTest {
-		@Test
-		@DisplayName("성공")
-		void testGetAlbumDetailedInfo_Success() {
-			CoordinatePoint mockCoordPoint = mock(CoordinatePoint.class);
-
-			ReflectionTestUtils.setField(image1, "coordPoint", mockCoordPoint);
-			ReflectionTestUtils.setField(image2, "coordPoint", mockCoordPoint);
-
-			ReflectionTestUtils.setField(image1, "imageFile", "image1.jpg");
-			ReflectionTestUtils.setField(image2, "imageFile", "image2.jpg");
-
-			when(albumMapper.findByAlbumId(ALBUM_ID)).thenReturn(Optional.of(album));
-			when(albumMapper.findAlbumImagesByAlbumId(ALBUM_ID)).thenReturn(
-				List.of(
-					AlbumImage.builder().albumId(ALBUM_ID).imageId(1L).build(),
-					AlbumImage.builder().albumId(ALBUM_ID).imageId(2L).build()
-				)
-			);
-
-			when(imageMapper.findImageByImageId(1L)).thenReturn(Optional.of(image1));
-			when(imageMapper.findImageByImageId(2L)).thenReturn(Optional.of(image2));
-
-			try (MockedStatic<LocationUtil> mockedLocationUtil = mockStatic(LocationUtil.class)) {
-				mockedLocationUtil.when(() -> LocationUtil.getLocationInfoByCoordinatePoint(any(CoordinatePoint.class)))
-					.thenReturn(new LocationInfoDto(37.497942, 127.027621, "서울특별시", "강남구"));
-
-				AlbumDetailedResponseDto response = albumService.getAlbumDetailedInfo(USER_ID, ALBUM_ID);
-
-				assertNotNull(response);
-				assertEquals(album.getAlbumId(), response.getAlbumId());
-				assertEquals(album.getAlbumTitle(), response.getAlbumTitle());
-				assertEquals(2, response.getImageList().size());
-				verify(albumMapper).findByAlbumId(ALBUM_ID);
-				verify(albumMapper).findAlbumImagesByAlbumId(ALBUM_ID);
-				verify(imageMapper, times(2)).findImageByImageId(anyLong());
-				verify(imageService, times(2)).convertImageToImageDto(any(Image.class));
-			}
-		}
-
-		@Test
-		@DisplayName("실패 - 앨범을 찾을 수 없음")
-		void testGetAlbumDetailedInfo_AlbumNotFound() {
-			when(albumMapper.findByAlbumId(ALBUM_ID)).thenReturn(Optional.empty());
-
-			ApiException exception = assertThrows(ApiException.class,
-				() -> albumService.getAlbumDetailedInfo(USER_ID, ALBUM_ID));
-
-			assertEquals(ErrorCode.NOT_FOUND_ALBUM, exception.getErrorCode());
-			verify(albumMapper).findByAlbumId(ALBUM_ID);
-		}
-
-		@Test
-		@DisplayName("실패 - 유저가 앨범에 접근 권한이 없음")
-		void testGetAlbumDetailedInfo_ForbiddenAccessToPrivateAlbum() {
-			Album privateAlbum = Album.builder().userId(2L).isPublic(0).build();
-			ReflectionTestUtils.setField(privateAlbum, "albumId", ALBUM_ID);
-
-			when(albumMapper.findByAlbumId(ALBUM_ID)).thenReturn(Optional.of(privateAlbum));
-
-			ApiException exception = assertThrows(ApiException.class,
-				() -> albumService.getAlbumDetailedInfo(USER_ID, ALBUM_ID));
-
-			assertEquals(ErrorCode.FORBIDDEN, exception.getErrorCode());
-			verify(albumMapper).findByAlbumId(ALBUM_ID);
 		}
 	}
 

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/album/service/AlbumServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/album/service/AlbumServiceTest.java
@@ -20,9 +20,11 @@ import org.mockito.stubbing.Answer;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.github.pagehelper.PageInfo;
 import com.trackery.trackerybackapiserver.domain.album.dto.request.AlbumCreateRequestDto;
 import com.trackery.trackerybackapiserver.domain.album.dto.request.AlbumUpdateRequestDto;
 import com.trackery.trackerybackapiserver.domain.album.dto.response.AlbumCreateResponseDto;
+import com.trackery.trackerybackapiserver.domain.album.dto.response.AlbumDetailedResponseDto;
 import com.trackery.trackerybackapiserver.domain.album.dto.response.AlbumImageEditResponseDto;
 import com.trackery.trackerybackapiserver.domain.album.dto.response.MyAlbumResponseDto;
 import com.trackery.trackerybackapiserver.domain.album.entity.Album;
@@ -30,6 +32,7 @@ import com.trackery.trackerybackapiserver.domain.album.entity.AlbumImage;
 import com.trackery.trackerybackapiserver.domain.album.mapper.AlbumMapper;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
+import com.trackery.trackerybackapiserver.domain.image.dto.ImageDto;
 import com.trackery.trackerybackapiserver.domain.image.entity.Image;
 import com.trackery.trackerybackapiserver.domain.image.mapper.ImageMapper;
 import com.trackery.trackerybackapiserver.domain.image.service.ImageService;
@@ -400,6 +403,134 @@ class AlbumServiceTest {
 			assertTrue(response.getAlbumList().isEmpty());
 
 			verify(albumMapper).findAlbumsByUserId(USER_ID);
+		}
+	}
+
+	@Nested
+	@DisplayName("앨범 메타데이터 조회 테스트")
+	class getAlbumMetaInfoTest {
+		@Test
+		void success() {
+			AlbumImage albumImage1 = AlbumImage.builder().albumId(ALBUM_ID).imageId(1L).build();
+			AlbumImage albumImage2 = AlbumImage.builder().albumId(ALBUM_ID).imageId(2L).build();
+			List<AlbumImage> albumImages = List.of(albumImage1, albumImage2);
+
+			when(albumMapper.findByAlbumId(ALBUM_ID)).thenReturn(Optional.of(album));
+			when(albumMapper.findAlbumImagesByAlbumId(ALBUM_ID)).thenReturn(albumImages);
+
+			AlbumDetailedResponseDto result = albumService.getAlbumMetadata(USER_ID, ALBUM_ID);
+
+			assertEquals(ALBUM_ID, result.getAlbumId());
+			assertEquals(USER_ID, result.getCreatedUserId());
+			assertEquals(1, result.getIsPublic());
+			assertEquals(2, result.getImageCount());
+		}
+	}
+
+	@Nested
+	@DisplayName("앨범 이미지 조회 테스트")
+	class getAlbumImagesTest {
+		@Test
+		@DisplayName("성공 - 앨범 이미지들이 정상적으로 조회됨")
+		void testGetAlbumImages_Success() {
+			int pageNum = 1;
+			int pageSize = 10;
+			
+			AlbumImage albumImage1 = AlbumImage.builder().albumId(ALBUM_ID).imageId(1L).build();
+			AlbumImage albumImage2 = AlbumImage.builder().albumId(ALBUM_ID).imageId(2L).build();
+			AlbumImage albumImage3 = AlbumImage.builder().albumId(ALBUM_ID).imageId(3L).build();
+			List<AlbumImage> albumImages = List.of(albumImage1, albumImage2, albumImage3);
+			
+			when(albumMapper.findAlbumImagesByAlbumId(ALBUM_ID)).thenReturn(albumImages);
+			when(imageMapper.findImageByImageId(1L)).thenReturn(Optional.of(image1));
+			when(imageMapper.findImageByImageId(2L)).thenReturn(Optional.of(image2));
+			when(imageMapper.findImageByImageId(3L)).thenReturn(Optional.of(image3));
+
+			when(imageService.convertImageToImageDto(image1)).thenReturn(
+				ImageDto.builder()
+					.imageId(1L)
+					.userId(USER_ID)
+					.build()
+			);
+			when(imageService.convertImageToImageDto(image2)).thenReturn(
+				ImageDto.builder()
+					.imageId(2L)
+					.userId(USER_ID)
+					.build()
+			);
+			when(imageService.convertImageToImageDto(image3)).thenReturn(
+				ImageDto.builder()
+					.imageId(3L)
+					.userId(USER_ID)
+					.build()
+			);
+
+			PageInfo<ImageDto> result =
+				albumService.getAlbumImages(ALBUM_ID, pageNum, pageSize);
+			
+			// Then
+			assertNotNull(result);
+			assertEquals(3, result.getList().size());
+			assertEquals(1L, result.getList().get(0).getImageId());
+			assertEquals(2L, result.getList().get(1).getImageId());
+			assertEquals(3L, result.getList().get(2).getImageId());
+			
+			verify(albumMapper).findAlbumImagesByAlbumId(ALBUM_ID);
+			verify(imageMapper).findImageByImageId(1L);
+			verify(imageMapper).findImageByImageId(2L);
+			verify(imageMapper).findImageByImageId(3L);
+			verify(imageService).convertImageToImageDto(image1);
+			verify(imageService).convertImageToImageDto(image2);
+			verify(imageService).convertImageToImageDto(image3);
+		}
+		
+		@Test
+		@DisplayName("실패 - 앨범 이미지 중 일부 이미지를 찾을 수 없는 경우")
+		void testGetAlbumImages_ImageNotFound() {
+			// Given
+			int pageNum = 1;
+			int pageSize = 10;
+			
+			AlbumImage albumImage1 = AlbumImage.builder().albumId(ALBUM_ID).imageId(1L).build();
+			AlbumImage albumImage2 = AlbumImage.builder().albumId(ALBUM_ID).imageId(2L).build();
+			List<AlbumImage> albumImages = List.of(albumImage1, albumImage2);
+			
+			when(albumMapper.findAlbumImagesByAlbumId(ALBUM_ID)).thenReturn(albumImages);
+			when(imageMapper.findImageByImageId(1L)).thenReturn(Optional.of(image1));
+			when(imageMapper.findImageByImageId(2L)).thenReturn(Optional.empty()); // 이미지를 찾을 수 없음
+			
+			// When & Then
+			ApiException exception = assertThrows(ApiException.class,
+				() -> albumService.getAlbumImages(ALBUM_ID, pageNum, pageSize));
+			
+			assertEquals(ErrorCode.NOT_FOUND_IMAGE, exception.getErrorCode());
+			
+			verify(albumMapper).findAlbumImagesByAlbumId(ALBUM_ID);
+			verify(imageMapper).findImageByImageId(1L);
+			verify(imageMapper).findImageByImageId(2L);
+		}
+		
+		@Test
+		@DisplayName("성공 - 앨범에 이미지가 없는 경우 빈 목록 반환")
+		void testGetAlbumImages_EmptyAlbum() {
+			// Given
+			int pageNum = 1;
+			int pageSize = 10;
+			
+			when(albumMapper.findAlbumImagesByAlbumId(ALBUM_ID)).thenReturn(List.of());
+			
+			// When
+			com.github.pagehelper.PageInfo<com.trackery.trackerybackapiserver.domain.image.dto.ImageDto> result = 
+				albumService.getAlbumImages(ALBUM_ID, pageNum, pageSize);
+			
+			// Then
+			assertNotNull(result);
+			assertTrue(result.getList().isEmpty());
+			assertEquals(0, result.getList().size());
+			
+			verify(albumMapper).findAlbumImagesByAlbumId(ALBUM_ID);
+			verify(imageMapper, never()).findImageByImageId(anyLong());
+			verify(imageService, never()).convertImageToImageDto(any());
 		}
 	}
 

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/common/util/PaginationDocumentationUtils.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/common/util/PaginationDocumentationUtils.java
@@ -1,8 +1,10 @@
 package com.trackery.trackerybackapiserver.domain.common.util;
 
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 
 import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.request.ParameterDescriptor;
 
 /**
  * packageName    : com.trackery.trackerybackapiserver.domain.common.util
@@ -35,6 +37,13 @@ public class PaginationDocumentationUtils {
 			fieldWithPath("data.navigatepageNums").description("네비게이션 페이지 번호 배열"),
 			fieldWithPath("data.navigateFirstPage").description("네비게이션 첫 페이지"),
 			fieldWithPath("data.navigateLastPage").description("네비게이션 마지막 페이지")
+		};
+	}
+
+	public static ParameterDescriptor[] getPageableQueryParameters() {
+		return new ParameterDescriptor[] {
+			parameterWithName("pageNum").description("페이지 번호 (기본값 : 1)"),
+			parameterWithName("pageSize").description("페이지 크기 (기본값 : 10)")
 		};
 	}
 }

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/common/util/PaginationDocumentationUtils.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/common/util/PaginationDocumentationUtils.java
@@ -1,0 +1,40 @@
+package com.trackery.trackerybackapiserver.domain.common.util;
+
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+
+import org.springframework.restdocs.payload.FieldDescriptor;
+
+/**
+ * packageName    : com.trackery.trackerybackapiserver.domain.common.util
+ * fileName       : PaginationDocumentationUtils
+ * author         : durururuk
+ * date           : 25. 6. 24.
+ * description    : 페이지네이션 문서화 템플릿
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 25. 6. 24.		durururuk		최초 생성
+ */
+public class PaginationDocumentationUtils {
+	public static FieldDescriptor[] getPageableResponseFields() {
+		return new FieldDescriptor[] {
+			fieldWithPath("data.total").description("전체 항목 수"),
+			fieldWithPath("data.pageNum").description("현재 페이지 번호"),
+			fieldWithPath("data.pageSize").description("페이지당 항목 수"),
+			fieldWithPath("data.size").description("현재 페이지의 실제 항목 수"),
+			fieldWithPath("data.startRow").description("시작 행 번호"),
+			fieldWithPath("data.endRow").description("끝 행 번호"),
+			fieldWithPath("data.pages").description("전체 페이지 수"),
+			fieldWithPath("data.prePage").description("이전 페이지 번호"),
+			fieldWithPath("data.nextPage").description("다음 페이지 번호"),
+			fieldWithPath("data.isFirstPage").description("첫 번째 페이지 여부"),
+			fieldWithPath("data.isLastPage").description("마지막 페이지 여부"),
+			fieldWithPath("data.hasPreviousPage").description("이전 페이지 존재 여부"),
+			fieldWithPath("data.hasNextPage").description("다음 페이지 존재 여부"),
+			fieldWithPath("data.navigatePages").description("네비게이션 페이지 수"),
+			fieldWithPath("data.navigatepageNums").description("네비게이션 페이지 번호 배열"),
+			fieldWithPath("data.navigateFirstPage").description("네비게이션 첫 페이지"),
+			fieldWithPath("data.navigateLastPage").description("네비게이션 마지막 페이지")
+		};
+	}
+}

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/image/controller/ImageControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/image/controller/ImageControllerTest.java
@@ -1,19 +1,14 @@
 package com.trackery.trackerybackapiserver.domain.image.controller;
 
 import static org.mockito.Mockito.*;
+import static org.springframework.http.MediaType.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.*;
-import static org.springframework.http.MediaType.*;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -23,10 +18,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.data.rest.webmvc.json.patch.Patch;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.pagehelper.PageInfo;
 import com.trackery.trackerybackapiserver.domain.config.CommonMockMvcControllerTestSetUp;
 import com.trackery.trackerybackapiserver.domain.image.dto.ImageDto;
@@ -139,61 +134,13 @@ class ImageControllerTest extends CommonMockMvcControllerTestSetUp {
 	}
 
 	@Test
-	@DisplayName("인증된 사용자의 이미지 목록 조회 성공")
-	void getMyImagesSuccess() throws Exception {
-		List<ImageDto> imageDtoList = List.of(imageDto);
-		when(imageService.getImageListByUserId(userDetails.getUserId())).thenReturn(imageDtoList);
-
-		ResultActions result = mockMvc.perform(get("/api/images/me")
-			.with(user(userDetails)));
-
-		result
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.code").value(200))
-			.andExpect(jsonPath("$.message").value("Ok"))
-			.andExpect(jsonPath("$.data").isArray())
-			.andExpect(jsonPath("$.data.length()").value(imageDtoList.size()))
-			.andExpect(jsonPath("$.data[0].imageId").value(imageDto.getImageId()))
-			.andExpect(jsonPath("$.data[0].userId").value(imageDto.getUserId()))
-			.andExpect(jsonPath("$.data[0].sdName").value(imageDto.getSdName()))
-			.andExpect(jsonPath("$.data[0].sggName").value(imageDto.getSggName()))
-			.andExpect(jsonPath("$.data[0].latitude").value(imageDto.getLatitude()))
-			.andExpect(jsonPath("$.data[0].longitude").value(imageDto.getLongitude()))
-			.andExpect(jsonPath("$.data[0].imageName").value(imageDto.getImageName()))
-			.andExpect(jsonPath("$.data[0].imageContent").value(imageDto.getImageContent()))
-			.andExpect(jsonPath("$.data[0].imageDate").value(imageDto.getImageDate().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)))
-			.andExpect(jsonPath("$.data[0].imageUrl").value(imageDto.getImageUrl()))
-			.andDo(document("get-my-images-success",
-				responseFields(
-					fieldWithPath("code").description("상태 코드"),
-					fieldWithPath("message").description("응답 메시지"),
-					fieldWithPath("data[]").description("이미지 목록"),
-					fieldWithPath("data[].imageId").description("이미지 ID"),
-					fieldWithPath("data[].userId").description("이미지 업로드 사용자 ID"),
-					fieldWithPath("data[].imageRegDate").description("이미지 등록 일시"),
-					fieldWithPath("data[].sdName").description("시도명"),
-					fieldWithPath("data[].sggName").description("시군구명"),
-					fieldWithPath("data[].latitude").description("위도"),
-					fieldWithPath("data[].longitude").description("경도"),
-					fieldWithPath("data[].imageName").description("이미지 파일명"),
-					fieldWithPath("data[].imageContent").description("이미지 설명"),
-					fieldWithPath("data[].imageDate").description("이미지 촬영 일시"),
-					fieldWithPath("data[].isPublic").description("공개 여부 (true: 공개, false: 비공개, null: 미설정)"),
-					fieldWithPath("data[].imageUrl").description("이미지 URL")
-				)
-			));
-
-		verify(imageService, times(1)).getImageListByUserId(userDetails.getUserId());
-	}
-
-	@Test
 	@DisplayName("인증된 사용자의 이미지 목록 조회 페이지네이션 성공")
 	void getMyImagesV2Success() throws Exception {
 		List<ImageDto> imageDtoList = List.of(imageDto);
 		PageInfo<ImageDto> pageInfo = new PageInfo<>(imageDtoList);
 		when(imageService.getImageListByUserIdV2(USER_ID, 1, 10)).thenReturn(pageInfo);
 
-		ResultActions result = mockMvc.perform(get("/api/images/v2/me")
+		ResultActions result = mockMvc.perform(get("/api/images/me")
 				.with(user(userDetails))
 				.queryParam("pageNum", "1")
 				.queryParam("pageSize", "10")


### PR DESCRIPTION
- 앨범 이미지 조회 기능에 페이지네이션을 적용했습니다.
- 앨범 정보+이미지를 받아오는 API를 앨범 정보 API, 앨범 이미지 조회 API로 분리하였습니다.
- Deprecated된 이전 이미지 조회 API를 삭제했습니다.

- PaginationDocumentationUtils.java : 페이지네이션 문서화 코드가 너무 중복되고 길어서 그걸 담고있는 클래스를 만들었습니다. 