### PR TITLE
Feature/간편로그인시 리프레시토큰 발급 및 코드 스멜 수정

### DIFF
--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/client/GenericOAuthClient.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/client/GenericOAuthClient.java
@@ -41,6 +41,7 @@ import lombok.extern.slf4j.Slf4j;
  * 25. 3. 05.        inari       프로필 사진 제거
  * 25. 3. 20.        inari       소나큐브 코드스멜 개선
  * 25. 3. 27.        inari		 provider를 enum으로 변경
+ * 25. 6. 25.        inari		 코드 스멜 수정
  */
 @Slf4j
 @Component
@@ -75,76 +76,123 @@ public class GenericOAuthClient implements OAuthClient {
 	 * OAuth 제공자별 사용자 정보 파싱을 위한 매핑
 	 */
 	private final Map<OAuthProvider, Function<JsonNode, OAuthUserInfoDto>> userInfoParsers
-		= new EnumMap<>(OAuthProvider.class);
+		= createUserInfoParsers();
 
-	{
-		// 네이버 간편 로그인 파서
-		userInfoParsers.put(OAuthProvider.NAVER, jsonNode -> {
-			JsonNode responseNode = jsonNode.get("response");
-			String id = responseNode.get(FIELD_ID).asText();
-			String email = responseNode.has(FIELD_EMAIL) ? responseNode.get(FIELD_EMAIL).asText() : null;
-			String nickname = responseNode.has(FIELD_NICKNAME) ? responseNode.get(FIELD_NICKNAME).asText() : null;
+	private Map<OAuthProvider, Function<JsonNode, OAuthUserInfoDto>> createUserInfoParsers() {
+		Map<OAuthProvider, Function<JsonNode, OAuthUserInfoDto>> parsers = new EnumMap<>(OAuthProvider.class);
+		parsers.put(OAuthProvider.NAVER, this::parseNaverUserInfo);
+		parsers.put(OAuthProvider.KAKAO, this::parseKakaoUserInfo);
+		parsers.put(OAuthProvider.GOOGLE, this::parseGoogleUserInfo);
+		parsers.put(OAuthProvider.GITHUB, this::parseGithubUserInfo);
 
-			return OAuthUserInfoDto.builder()
-				.email(email)
-				.nickname(nickname)
-				.provider(OAuthProvider.NAVER.name())
-				.providerUserId(id)
-				.build();
-		});
+		return parsers;
+	}
 
-		// 카카오 간편 로그인 파서
-		userInfoParsers.put(OAuthProvider.KAKAO, jsonNode -> {
-			JsonNode kakaoAccount = jsonNode.get("kakao_account");
-			JsonNode profile = kakaoAccount.get("profile");
+	/**
+	 * 네이버 간편 로그인 사용자 정보를 파싱하는 메서드입니다.
+	 *
+	 * @param jsonNode 네이버 API 응답 JSON
+	 * @return 파싱된 사용자 정보
+	 */
+	private OAuthUserInfoDto parseNaverUserInfo(JsonNode jsonNode) {
+		JsonNode responseNode = jsonNode.get("response");
+		String id = responseNode.get(FIELD_ID).asText();
+		String email = extractOptionalField(responseNode, FIELD_EMAIL);
+		String nickname = extractOptionalField(responseNode, FIELD_NICKNAME);
 
-			String id = jsonNode.get(FIELD_ID).asText();
-			String email = kakaoAccount.has(FIELD_EMAIL) ? kakaoAccount.get(FIELD_EMAIL).asText() : null;
-			String nickname = profile.has(FIELD_NICKNAME) ? profile.get(FIELD_NICKNAME).asText() : null;
+		return OAuthUserInfoDto.builder()
+			.email(email)
+			.nickname(nickname)
+			.provider(OAuthProvider.NAVER.name())
+			.providerUserId(id)
+			.build();
+	}
 
-			return OAuthUserInfoDto.builder()
-				.email(email)
-				.nickname(nickname)
-				.provider(OAuthProvider.KAKAO.name())
-				.providerUserId(id)
-				.build();
-		});
+	/**
+	 * 카카오 간편 로그인 사용자 정보를 파싱하는 메서드입니다.
+	 *
+	 * @param jsonNode 카카오 API 응답 JSON
+	 * @return 파싱된 사용자 정보
+	 */
+	private OAuthUserInfoDto parseKakaoUserInfo(JsonNode jsonNode) {
+		JsonNode kakaoAccount = jsonNode.get("kakao_account");
+		JsonNode profile = kakaoAccount.get("profile");
 
-		// 구글 간편 로그인 파서
-		userInfoParsers.put(OAuthProvider.GOOGLE, jsonNode -> {
-			String id = jsonNode.get("sub").asText();
-			String email = jsonNode.has(FIELD_EMAIL) ? jsonNode.get(FIELD_EMAIL).asText() : null;
-			String nickname = jsonNode.has("name") ? jsonNode.get("name").asText() : null;
+		String id = jsonNode.get(FIELD_ID).asText();
+		String email = extractOptionalField(kakaoAccount, FIELD_EMAIL);
+		String nickname = extractOptionalField(profile, FIELD_NICKNAME);
 
-			return OAuthUserInfoDto.builder()
-				.email(email)
-				.nickname(nickname)
-				.provider(OAuthProvider.GOOGLE.name())
-				.providerUserId(id)
-				.build();
-		});
+		return OAuthUserInfoDto.builder()
+			.email(email)
+			.nickname(nickname)
+			.provider(OAuthProvider.KAKAO.name())
+			.providerUserId(id)
+			.build();
+	}
 
-		// 깃허브 간편 로그인 파서
-		userInfoParsers.put(OAuthProvider.GITHUB, jsonNode -> {
-			String id = jsonNode.get(FIELD_ID).asText();
+	/**
+	 * 구글 간편 로그인 사용자 정보를 파싱하는 메서드입니다.
+	 *
+	 * @param jsonNode 구글 API 응답 JSON
+	 * @return 파싱된 사용자 정보
+	 */
+	private OAuthUserInfoDto parseGoogleUserInfo(JsonNode jsonNode) {
+		String id = jsonNode.get("sub").asText();
+		String email = extractOptionalField(jsonNode, FIELD_EMAIL);
+		String nickname = extractOptionalField(jsonNode, "name");
 
-			// email이 null이나 빈 문자열인 경우가 많음
-			String email = jsonNode.has(FIELD_EMAIL) && !jsonNode.get(FIELD_EMAIL).isNull()
-				? jsonNode.get(FIELD_EMAIL).asText() : null;
+		return OAuthUserInfoDto.builder()
+			.email(email)
+			.nickname(nickname)
+			.provider(OAuthProvider.GOOGLE.name())
+			.providerUserId(id)
+			.build();
+	}
 
-			// 로깅 추가
-			log.debug("GitHub 사용자 정보 원본: {}", jsonNode.toString());
-			log.debug("GitHub 이메일 (기본 응답): {}", email);
+	/**
+	 * 깃허브 간편 로그인 사용자 정보를 파싱하는 메서드입니다.
+	 *
+	 * @param jsonNode 깃허브 API 응답 JSON
+	 * @return 파싱된 사용자 정보
+	 */
+	private OAuthUserInfoDto parseGithubUserInfo(JsonNode jsonNode) {
+		String id = jsonNode.get(FIELD_ID).asText();
+		String email = extractGithubEmail(jsonNode);
+		String nickname = extractOptionalField(jsonNode, "login");
 
-			String nickname = jsonNode.has("login") ? jsonNode.get("login").asText() : null;
+		log.debug("GitHub 사용자 정보 원본: {}", jsonNode);
+		log.debug("GitHub 이메일 (기본 응답): {}", email);
 
-			return OAuthUserInfoDto.builder()
-				.email(email) // 기본 응답의 이메일 (나중에 보완될 수 있음)
-				.nickname(nickname)
-				.provider(OAuthProvider.GITHUB.name())
-				.providerUserId(id)
-				.build();
-		});
+		return OAuthUserInfoDto.builder()
+			.email(email)
+			.nickname(nickname)
+			.provider(OAuthProvider.GITHUB.name())
+			.providerUserId(id)
+			.build();
+	}
+
+	/**
+	 * JSON 노드에서 선택적 필드를 추출하는 메서드입니다.
+	 * 필드가 존재하지 않으면 null을 반환합니다.
+	 *
+	 * @param node JSON 노드
+	 * @param fieldName 추출할 필드명
+	 * @return 필드 값 또는 null
+	 */
+	private String extractOptionalField(JsonNode node, String fieldName) {
+		return node.has(fieldName) ? node.get(fieldName).asText() : null;
+	}
+
+	/**
+	 * 깃허브 사용자 정보에서 이메일을 추출하는 메서드입니다.
+	 * 깃허브는 이메일이 null이거나 비공개일 수 있어 특별한 처리가 필요합니다.
+	 *
+	 * @param jsonNode 깃허브 사용자 정보 JSON
+	 * @return 이메일 주소 또는 null
+	 */
+	private String extractGithubEmail(JsonNode jsonNode) {
+		return jsonNode.has(FIELD_EMAIL) && !jsonNode.get(FIELD_EMAIL).isNull()
+			? jsonNode.get(FIELD_EMAIL).asText() : null;
 	}
 
 	/**
@@ -377,7 +425,7 @@ public class GenericOAuthClient implements OAuthClient {
 	 * GitHub 이메일 목록에서 적절한 이메일 찾는 메서드입니다.
 	 */
 	private String findPrimaryEmail(JsonNode emailsNode) {
-		if (!emailsNode.isArray() || emailsNode.size() == 0) {
+		if (!emailsNode.isArray() || emailsNode.isEmpty()) {
 			return null;
 		}
 
@@ -420,17 +468,15 @@ public class GenericOAuthClient implements OAuthClient {
 	 * @return 제공자별 속성
 	 */
 	private OAuthProperties.ProviderProperties getProviderProperties(OAuthProvider provider) {
-		switch (provider) {
-			case NAVER:
-				return oAuthProperties.getNaver();
-			case KAKAO:
-				return oAuthProperties.getKakao();
-			case GOOGLE:
-				return oAuthProperties.getGoogle();
-			case GITHUB:
-				return oAuthProperties.getGithub();
-			default:
-				throw new ApiException(ErrorCode.BAD_REQUEST_INVALID_OAUTH_PROVIDER);
+		if (provider == null) {
+			throw new ApiException(ErrorCode.BAD_REQUEST_INVALID_OAUTH_PROVIDER);
 		}
+		
+		return switch (provider) {
+			case NAVER -> oAuthProperties.getNaver();
+			case KAKAO -> oAuthProperties.getKakao();
+			case GOOGLE -> oAuthProperties.getGoogle();
+			case GITHUB -> oAuthProperties.getGithub();
+		};
 	}
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/client/GenericOAuthClient.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/client/GenericOAuthClient.java
@@ -471,7 +471,6 @@ public class GenericOAuthClient implements OAuthClient {
 		if (provider == null) {
 			throw new ApiException(ErrorCode.BAD_REQUEST_INVALID_OAUTH_PROVIDER);
 		}
-		
 		return switch (provider) {
 			case NAVER -> oAuthProperties.getNaver();
 			case KAKAO -> oAuthProperties.getKakao();

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/controller/OAuthController.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/controller/OAuthController.java
@@ -169,12 +169,18 @@ public class OAuthController {
 
 		// 로그인 성공 또는 계정 연동 성공한 경우
 		// JWT 토큰을 쿠키에 설정
-		ResponseCookie cookie = CookieUtil.createHttpOnlyCookie("accessToken", result.getJwtToken(),
-			Duration.ofMinutes(60));
-
-		return ResponseEntity.ok()
-			.header(HttpHeaders.SET_COOKIE, cookie.toString())
-			.body(ApiResponse.success(SuccessCode.OK, responseDto));
+		if (result.getAuthTokenDto() != null) {
+			HttpHeaders authHeaders = CookieUtil.setAuthCookie(result.getAuthTokenDto());
+			return ResponseEntity.ok()
+				.headers(authHeaders)
+				.body(ApiResponse.success(SuccessCode.OK, responseDto));
+		} else {
+			ResponseCookie cookie = CookieUtil.createHttpOnlyCookie("accessToken", result.getJwtToken(),
+				Duration.ofMinutes(60));
+			return ResponseEntity.ok()
+				.header(HttpHeaders.SET_COOKIE, cookie.toString())
+				.body(ApiResponse.success(SuccessCode.OK, responseDto));
+		}
 	}
 
 	/**

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/controller/OAuthController.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/controller/OAuthController.java
@@ -47,6 +47,7 @@ import lombok.extern.slf4j.Slf4j;
  * 25. 4. 08.        inari			GlobalExceptionHandle로 ApiException 위임
  * 25. 6. 23.        inari		 	기존 유저에 간편 로그인 연동 추가
  * 25. 6. 24.        inari		 	linkToken을 이용하는 방식으로 변경
+ * 25. 6. 25.        inari		 	리프레시 토큰 발급 추가
  */
 @Slf4j
 @RestController

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/OAuthService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/OAuthService.java
@@ -14,6 +14,7 @@ import com.trackery.trackerybackapiserver.config.OAuthProperties;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
 import com.trackery.trackerybackapiserver.domain.common.util.PasswordUtil;
+import com.trackery.trackerybackapiserver.domain.jwt.dto.AuthTokenDto;
 import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
 import com.trackery.trackerybackapiserver.domain.user.client.OAuthClient;
 import com.trackery.trackerybackapiserver.domain.user.dto.OAuthLoginDto;
@@ -97,11 +98,12 @@ public class OAuthService {
 			UserRole userRole = userRoleMapper.findByUserId(user.getUserId())
 				.orElseThrow(() -> new ApiException(ErrorCode.INTERNAL_SERVER_ERROR));
 
-			String jwt = jwtService.generateAccessToken(user.getUserId(), user.getUserName(), userRole.getRoleId());
+			AuthTokenDto authTokenDto = jwtService.generateAccessTokenAndRefreshToken(user.getUserId(), user.getUserName(), userRole.getRoleId());
 
 			return new OAuthLoginResult(
 				OAuthResponseDto.builder().isExistingEmail(false).build(),
-				jwt
+				authTokenDto.accessToken(),
+				authTokenDto
 			);
 		}
 
@@ -129,7 +131,7 @@ public class OAuthService {
 			UserRole userRole = userRoleMapper.findByUserId(existingUser.getUserId())
 				.orElseThrow(() -> new ApiException(ErrorCode.INTERNAL_SERVER_ERROR));
 
-			String jwt = jwtService.generateAccessToken(
+			AuthTokenDto authTokenDto = jwtService.generateAccessTokenAndRefreshToken(
 				existingUser.getUserId(),
 				existingUser.getUserName(),
 				userRole.getRoleId()
@@ -137,7 +139,8 @@ public class OAuthService {
 
 			return new OAuthLoginResult(
 				OAuthResponseDto.builder().isExistingEmail(false).build(),
-				jwt
+				authTokenDto.accessToken(),
+				authTokenDto
 			);
 		}
 
@@ -153,6 +156,7 @@ public class OAuthService {
 							.isExistingEmail(true)
 							.email(userInfo.getEmail())
 							.build(),
+						null,
 						null
 					);
 				}
@@ -170,7 +174,7 @@ public class OAuthService {
 				UserRole userRole = userRoleMapper.findByUserId(existingUserByEmail.get().getUserId())
 					.orElseThrow(() -> new ApiException(ErrorCode.INTERNAL_SERVER_ERROR));
 
-				String jwt = jwtService.generateAccessToken(
+				AuthTokenDto authTokenDto = jwtService.generateAccessTokenAndRefreshToken(
 					existingUserByEmail.get().getUserId(),
 					existingUserByEmail.get().getUserName(),
 					userRole.getRoleId()
@@ -178,7 +182,8 @@ public class OAuthService {
 
 				return new OAuthLoginResult(
 					OAuthResponseDto.builder().isExistingEmail(false).build(),
-					jwt
+					authTokenDto.accessToken(),
+					authTokenDto
 				);
 			}
 		}
@@ -198,11 +203,12 @@ public class OAuthService {
 		UserRole userRole = userRoleMapper.findByUserId(newUser.getUserId())
 			.orElseThrow(() -> new ApiException(ErrorCode.INTERNAL_SERVER_ERROR));
 
-		String jwt = jwtService.generateAccessToken(newUser.getUserId(), newUser.getUserName(), userRole.getRoleId());
+		AuthTokenDto authTokenDto = jwtService.generateAccessTokenAndRefreshToken(newUser.getUserId(), newUser.getUserName(), userRole.getRoleId());
 
 		return new OAuthLoginResult(
 			OAuthResponseDto.builder().isExistingEmail(false).build(),
-			jwt
+			authTokenDto.accessToken(),
+			authTokenDto
 		);
 	}
 
@@ -377,5 +383,6 @@ public class OAuthService {
 	public static class OAuthLoginResult {
 		private OAuthResponseDto responseDto;
 		private String jwtToken;
+		private AuthTokenDto authTokenDto;
 	}
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/OAuthService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/OAuthService.java
@@ -50,6 +50,7 @@ import lombok.extern.slf4j.Slf4j;
  * 25. 3. 27.        inari		 provider를 enum으로 변경
  * 25. 6. 23.        inari		 기존 유저에 간편 로그인 연동 추가
  * 25. 6. 24.        inari		 linkToken을 이용하는 방식으로 변경 및 안쓰는 코드 제거
+ * 25. 6. 25.        inari		 리프레시 토큰 발급 추가
  */
 @Slf4j
 @Service

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/user/controller/OAuthControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/user/controller/OAuthControllerTest.java
@@ -42,6 +42,7 @@ import com.trackery.trackerybackapiserver.domain.user.service.OAuthService;
  * 25. 3. 26.       inari       계정 연동 토큰 테스트 추가
  * 25. 6. 17.		inari		Spring-Rest-Docs api문서 추가
  * 25. 6. 23.        inari		 기존 유저에 간편 로그인 연동 테스트 추가
+ * 25. 6. 25.        inari		 	리프레시 토큰 발급 테스트 추가
  */
 @WithMockUser
 @WebMvcTest({OAuthController.class, GlobalExceptionHandler.class})

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/user/controller/OAuthControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/user/controller/OAuthControllerTest.java
@@ -20,6 +20,7 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import com.trackery.trackerybackapiserver.domain.common.util.GlobalExceptionHandler;
 import com.trackery.trackerybackapiserver.domain.config.CommonMockMvcControllerTestSetUp;
+import com.trackery.trackerybackapiserver.domain.jwt.dto.AuthTokenDto;
 import com.trackery.trackerybackapiserver.domain.user.dto.OAuthLoginDto;
 import com.trackery.trackerybackapiserver.domain.user.dto.OAuthResponseDto;
 import com.trackery.trackerybackapiserver.domain.user.entity.CustomUserDetails;
@@ -64,7 +65,8 @@ class OAuthControllerTest extends CommonMockMvcControllerTestSetUp {
 			.isExistingEmail(false)
 			.build();
 
-		OAuthService.OAuthLoginResult result = new OAuthService.OAuthLoginResult(responseDto, JWT);
+		AuthTokenDto authTokenDto = new AuthTokenDto(JWT, "refresh_token");
+		OAuthService.OAuthLoginResult result = new OAuthService.OAuthLoginResult(responseDto, JWT, authTokenDto);
 
 		when(oAuthService.processOAuthLogin(any(OAuthLoginDto.class))).thenReturn(result);
 
@@ -87,7 +89,8 @@ class OAuthControllerTest extends CommonMockMvcControllerTestSetUp {
 			.isExistingEmail(false)
 			.build();
 
-		OAuthService.OAuthLoginResult result = new OAuthService.OAuthLoginResult(responseDto, "jwt");
+		AuthTokenDto authTokenDto = new AuthTokenDto("jwt", "refresh_token");
+		OAuthService.OAuthLoginResult result = new OAuthService.OAuthLoginResult(responseDto, "jwt", authTokenDto);
 
 		when(oAuthService.processOAuthLogin(any(OAuthLoginDto.class))).thenReturn(result);
 
@@ -129,7 +132,7 @@ class OAuthControllerTest extends CommonMockMvcControllerTestSetUp {
 			.isExistingEmail(true)
 			.build();
 
-		OAuthService.OAuthLoginResult result = new OAuthService.OAuthLoginResult(responseDto, null);
+		OAuthService.OAuthLoginResult result = new OAuthService.OAuthLoginResult(responseDto, null, null);
 
 		when(oAuthService.processOAuthLogin(any(OAuthLoginDto.class))).thenReturn(result);
 
@@ -160,7 +163,8 @@ class OAuthControllerTest extends CommonMockMvcControllerTestSetUp {
 			.isExistingEmail(false)
 			.build();
 
-		OAuthService.OAuthLoginResult result = new OAuthService.OAuthLoginResult(responseDto, JWT);
+		AuthTokenDto authTokenDto = new AuthTokenDto(JWT, "refresh_token");
+		OAuthService.OAuthLoginResult result = new OAuthService.OAuthLoginResult(responseDto, JWT, authTokenDto);
 
 		when(oAuthLinkTokenService.validateToken(LINK_TOKEN)).thenReturn(USER_ID);
 		when(oAuthService.processOAuthLogin(any(OAuthLoginDto.class))).thenReturn(result);

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/user/service/OAuthServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/user/service/OAuthServiceTest.java
@@ -39,6 +39,7 @@ import com.trackery.trackerybackapiserver.domain.user.mapper.UserRoleMapper;
  * -----------------------------------------------------------
  * 25. 3. 3.        inari       최초 생성
  * 25. 6. 24.        inari		 기존 유저에 간편 로그인 연동 테스트 추가
+ * 25. 6. 25.        inari		 	리프레시 토큰 발급 테스트 추가
  */
 @ExtendWith(MockitoExtension.class)
 class OAuthServiceTest {

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/user/service/OAuthServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/user/service/OAuthServiceTest.java
@@ -14,6 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.trackery.trackerybackapiserver.config.OAuthProperties;
+import com.trackery.trackerybackapiserver.domain.jwt.dto.AuthTokenDto;
 import com.trackery.trackerybackapiserver.domain.jwt.service.JwtService;
 import com.trackery.trackerybackapiserver.domain.user.client.OAuthClient;
 import com.trackery.trackerybackapiserver.domain.user.dto.OAuthLoginDto;
@@ -113,7 +114,7 @@ class OAuthServiceTest {
 		when(oAuthMapper.findByProviderAndProviderId(anyString(), anyString())).thenReturn(Optional.of(oAuth));
 		when(userMapper.findByUserId(anyLong())).thenReturn(Optional.of(user));
 		when(userRoleMapper.findByUserId(anyLong())).thenReturn(Optional.of(userRole));
-		when(jwtService.generateAccessToken(anyLong(), anyString(), anyLong())).thenReturn("jwt_token");
+		when(jwtService.generateAccessTokenAndRefreshToken(anyLong(), anyString(), anyLong())).thenReturn(new AuthTokenDto("jwt_token", "refresh_token"));
 
 		// when
 		OAuthService.OAuthLoginResult result = oAuthService.processOAuthLogin(oAuthLoginDto);
@@ -127,7 +128,7 @@ class OAuthServiceTest {
 		verify(oAuthMapper).findByProviderAndProviderId(anyString(), anyString());
 		verify(userMapper).findByUserId(anyLong());
 		verify(userRoleMapper).findByUserId(anyLong());
-		verify(jwtService).generateAccessToken(anyLong(), anyString(), anyLong());
+		verify(jwtService).generateAccessTokenAndRefreshToken(anyLong(), anyString(), anyLong());
 	}
 
 	@Test
@@ -166,7 +167,7 @@ class OAuthServiceTest {
 		when(oAuthMapper.findByProviderAndProviderId(anyString(), anyString())).thenReturn(Optional.empty());
 		when(userMapper.findByEmail(anyString())).thenReturn(Optional.of(user));
 		when(userRoleMapper.findByUserId(anyLong())).thenReturn(Optional.of(userRole));
-		when(jwtService.generateAccessToken(anyLong(), anyString(), anyLong())).thenReturn("jwt_token");
+		when(jwtService.generateAccessTokenAndRefreshToken(anyLong(), anyString(), anyLong())).thenReturn(new AuthTokenDto("jwt_token", "refresh_token"));
 
 		// when
 		OAuthService.OAuthLoginResult result = oAuthService.processOAuthLogin(oAuthLoginDto);
@@ -181,7 +182,7 @@ class OAuthServiceTest {
 		verify(userMapper).findByEmail(anyString());
 		verify(oAuthMapper).insertOAuth(any(OAuth.class));
 		verify(userRoleMapper).findByUserId(anyLong());
-		verify(jwtService).generateAccessToken(anyLong(), anyString(), anyLong());
+		verify(jwtService).generateAccessTokenAndRefreshToken(anyLong(), anyString(), anyLong());
 	}
 
 	@Test
@@ -200,7 +201,7 @@ class OAuthServiceTest {
 		}).when(userMapper).insertUser(any(User.class));
 
 		when(userRoleMapper.findByUserId(anyLong())).thenReturn(Optional.of(userRole));
-		when(jwtService.generateAccessToken(anyLong(), anyString(), anyLong())).thenReturn("jwt_token");
+		when(jwtService.generateAccessTokenAndRefreshToken(anyLong(), anyString(), anyLong())).thenReturn(new AuthTokenDto("jwt_token", "refresh_token"));
 
 		// when
 		OAuthService.OAuthLoginResult result = oAuthService.processOAuthLogin(oAuthLoginDto);
@@ -217,7 +218,7 @@ class OAuthServiceTest {
 		verify(userRoleMapper).insertUserRole(any(UserRole.class));
 		verify(oAuthMapper).insertOAuth(any(OAuth.class));
 		verify(userRoleMapper).findByUserId(anyLong());
-		verify(jwtService).generateAccessToken(anyLong(), anyString(), anyLong());
+		verify(jwtService).generateAccessTokenAndRefreshToken(anyLong(), anyString(), anyLong());
 	}
 
 	@Test
@@ -236,7 +237,7 @@ class OAuthServiceTest {
 		when(oAuthMapper.findByUserIdAndProvider(anyLong(), anyString())).thenReturn(Optional.empty());
 		when(userMapper.findByUserId(anyLong())).thenReturn(Optional.of(user));
 		when(userRoleMapper.findByUserId(anyLong())).thenReturn(Optional.of(userRole));
-		when(jwtService.generateAccessToken(anyLong(), anyString(), anyLong())).thenReturn("jwt_token");
+		when(jwtService.generateAccessTokenAndRefreshToken(anyLong(), anyString(), anyLong())).thenReturn(new AuthTokenDto("jwt_token", "refresh_token"));
 
 		// when
 		OAuthService.OAuthLoginResult result = oAuthService.processOAuthLogin(oAuthLoginDto);
@@ -252,7 +253,7 @@ class OAuthServiceTest {
 		verify(userMapper).findByUserId(anyLong());
 		verify(oAuthMapper).insertOAuth(any(OAuth.class));
 		verify(userRoleMapper).findByUserId(anyLong());
-		verify(jwtService).generateAccessToken(anyLong(), anyString(), anyLong());
+		verify(jwtService).generateAccessTokenAndRefreshToken(anyLong(), anyString(), anyLong());
 	}
 
 	@Test


### PR DESCRIPTION
간편로그인시 리프레시토큰을 발급하지않고 액세스토큰만 발급하는 문제가 있었습니다.
이를 해결하여 일반유저와 동일하게 리프레시토큰도 발급후 레디스와 대조하여 액세스토큰을 재발급하도록 하였습니다.

또한 소나큐브에서 크리티컬한 코드스멜이 발견되어 GenericOAuthClient 수정했습니다.
코드 스멜 발생이유는
 - 인스턴스 초기화 블록은 가독성이 떨어지고 디버깅이 어려움
 - 생성자보다 먼저 실행되어 예상치 못한 초기화 순서 문제 발생 가능
 - 복잡한 람다 함수들이 모두 한 메서드에 있어 코드 가독성이 좋지 못함
 - SLF4J 로거는 자동으로 toString()를 호출하여 불필요함
 - Enhanced switch는 더 간결하고 안전하고 break 누락 문제가 없음
 입니다.