### PR TITLE
Feature/간편로그인 회원가입 수정

### DIFF
--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/dto/OAuthResponseDto.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/dto/OAuthResponseDto.java
@@ -30,4 +30,10 @@ public class OAuthResponseDto {
 	 * 사용자 이메일입니다.
 	 */
 	private String email;
+
+	/**
+	 * 신규 사용자 여부를 나타냅니다.
+	 * 신규 회원가입이면 true, 기존 계정 연동이면 false를 리턴합니다.
+	 */
+	private boolean isNewUser;
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/dto/OAuthResponseDto.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/dto/OAuthResponseDto.java
@@ -15,6 +15,7 @@ import lombok.Getter;
  * 25. 2. 25.        inari       최초 생성
  * 25. 2. 26.        inari       JWT 인증 헤더 삭제
  * 25. 3. 14.        inari       이메일 추가
+ * 25. 7. 2.         inari       회원가입 유무 추가
  */
 @Getter
 @Builder

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/OAuthService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/OAuthService.java
@@ -329,6 +329,7 @@ public class OAuthService {
 					OAuthResponseDto.builder()
 						.isExistingEmail(true)
 						.email(userInfo.getEmail())
+						.isNewUser(false)
 						.build(),
 					null,
 					null
@@ -362,7 +363,7 @@ public class OAuthService {
 		linkOAuthToExistingUser(newUser.getUserId(), userInfo);
 		log.info("신규 회원가입 완료: userId={}", newUser.getUserId());
 
-		return generateLoginResult(newUser);
+		return generateNewUserLoginResult(newUser);
 	}
 
 	/**
@@ -382,7 +383,36 @@ public class OAuthService {
 			user.getUserId(), user.getUserName(), userRole.getRoleId());
 
 		return new OAuthLoginResult(
-			OAuthResponseDto.builder().isExistingEmail(false).build(),
+			OAuthResponseDto.builder()
+				.isExistingEmail(false)
+				.isNewUser(false)
+				.build(),
+			authTokenDto.accessToken(),
+			authTokenDto
+		);
+	}
+
+	/**
+	 * 신규 사용자 로그인 결과를 생성합니다.
+	 *
+	 * @param user 사용자 정보
+	 * @return OAuth 로그인 결과
+	 */
+	private OAuthLoginResult generateNewUserLoginResult(User user) {
+		// 로그인 시간 업데이트
+		userMapper.updateLastLoginByUserId(user.getUserId(), LocalDateTime.now());
+
+		UserRole userRole = userRoleMapper.findByUserId(user.getUserId())
+			.orElseThrow(() -> new ApiException(ErrorCode.INTERNAL_SERVER_ERROR));
+
+		AuthTokenDto authTokenDto = jwtService.generateAccessTokenAndRefreshToken(
+			user.getUserId(), user.getUserName(), userRole.getRoleId());
+
+		return new OAuthLoginResult(
+			OAuthResponseDto.builder()
+				.isExistingEmail(false)
+				.isNewUser(true)
+				.build(),
 			authTokenDto.accessToken(),
 			authTokenDto
 		);

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/user/controller/OAuthControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/user/controller/OAuthControllerTest.java
@@ -1,8 +1,8 @@
 package com.trackery.trackerybackapiserver.domain.user.controller;
 
 import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
@@ -24,9 +24,9 @@ import com.trackery.trackerybackapiserver.domain.jwt.dto.AuthTokenDto;
 import com.trackery.trackerybackapiserver.domain.user.dto.OAuthLinkRequestDto;
 import com.trackery.trackerybackapiserver.domain.user.dto.OAuthLoginDto;
 import com.trackery.trackerybackapiserver.domain.user.dto.OAuthResponseDto;
+import com.trackery.trackerybackapiserver.domain.user.dto.OAuthUrlResponseDto;
 import com.trackery.trackerybackapiserver.domain.user.entity.CustomUserDetails;
 import com.trackery.trackerybackapiserver.domain.user.enums.OAuthProvider;
-import com.trackery.trackerybackapiserver.domain.user.dto.OAuthUrlResponseDto;
 import com.trackery.trackerybackapiserver.domain.user.service.OAuthLinkTokenService;
 import com.trackery.trackerybackapiserver.domain.user.service.OAuthService;
 
@@ -45,6 +45,7 @@ import com.trackery.trackerybackapiserver.domain.user.service.OAuthService;
  * 25. 6. 23.        inari		 	기존 유저에 간편 로그인 연동 테스트 추가
  * 25. 6. 25.        inari		 	리프레시 토큰 발급 테스트 추가
  * 25. 6. 28.        inari		 	메서드 분리로 인한 테스트 코드 추가
+ * 25. 7. 1.         inari		 	isNewUser 파라미터 테스트 코드 추가
  */
 @WithMockUser
 @WebMvcTest({OAuthController.class, GlobalExceptionHandler.class})
@@ -66,6 +67,7 @@ class OAuthControllerTest extends CommonMockMvcControllerTestSetUp {
 
 		OAuthResponseDto responseDto = OAuthResponseDto.builder()
 			.isExistingEmail(false)
+			.isNewUser(false)
 			.build();
 
 		AuthTokenDto authTokenDto = new AuthTokenDto(JWT, "refresh_token");
@@ -82,7 +84,8 @@ class OAuthControllerTest extends CommonMockMvcControllerTestSetUp {
 		// then
 		resultActions
 			.andExpect(cookie().value("accessToken", JWT))
-			.andExpect(jsonPath("$.data.existingEmail").value(false));
+			.andExpect(jsonPath("$.data.existingEmail").value(false))
+			.andExpect(jsonPath("$.data.newUser").value(false));
 	}
 
 	@Test
@@ -90,6 +93,7 @@ class OAuthControllerTest extends CommonMockMvcControllerTestSetUp {
 		// given
 		OAuthResponseDto responseDto = OAuthResponseDto.builder()
 			.isExistingEmail(false)
+			.isNewUser(false)
 			.build();
 
 		AuthTokenDto authTokenDto = new AuthTokenDto("jwt", "refresh_token");
@@ -111,6 +115,7 @@ class OAuthControllerTest extends CommonMockMvcControllerTestSetUp {
 			.andExpect(cookie().httpOnly("accessToken", true))
 			.andExpect(cookie().value("accessToken", "jwt"))
 			.andExpect(jsonPath("$.data.existingEmail").value(false))
+			.andExpect(jsonPath("$.data.newUser").value(false))
 			.andDo(document("oauth-login-success",
 				pathParameters(
 					parameterWithName("provider").description("OAuth 제공자 (naver, kakao, google, github)")
@@ -123,7 +128,8 @@ class OAuthControllerTest extends CommonMockMvcControllerTestSetUp {
 					fieldWithPath("code").description("상태 코드"),
 					fieldWithPath("message").description("응답 메시지"),
 					fieldWithPath("data.email").description("사용자 이메일").optional(),
-					fieldWithPath("data.existingEmail").description("기존 이메일 존재 여부")
+					fieldWithPath("data.existingEmail").description("기존 이메일 존재 여부"),
+					fieldWithPath("data.newUser").description("신규 사용자 여부")
 				)
 			));
 	}
@@ -133,6 +139,7 @@ class OAuthControllerTest extends CommonMockMvcControllerTestSetUp {
 		// given
 		OAuthResponseDto responseDto = OAuthResponseDto.builder()
 			.isExistingEmail(true)
+			.isNewUser(false)
 			.build();
 
 		OAuthService.OAuthLoginResult result = new OAuthService.OAuthLoginResult(responseDto, null, null);
@@ -150,7 +157,8 @@ class OAuthControllerTest extends CommonMockMvcControllerTestSetUp {
 		resultActions
 			.andExpect(status().isOk())
 			.andExpect(cookie().doesNotExist("accessToken"))
-			.andExpect(jsonPath("$.data.existingEmail").value(true));
+			.andExpect(jsonPath("$.data.existingEmail").value(true))
+			.andExpect(jsonPath("$.data.newUser").value(false));
 	}
 
 	@Test
@@ -164,6 +172,7 @@ class OAuthControllerTest extends CommonMockMvcControllerTestSetUp {
 
 		OAuthResponseDto responseDto = OAuthResponseDto.builder()
 			.isExistingEmail(false)
+			.isNewUser(false)
 			.build();
 
 		AuthTokenDto authTokenDto = new AuthTokenDto(JWT, "refresh_token");
@@ -185,7 +194,8 @@ class OAuthControllerTest extends CommonMockMvcControllerTestSetUp {
 			.andExpect(cookie().exists("accessToken"))
 			.andExpect(cookie().httpOnly("accessToken", true))
 			.andExpect(cookie().value("accessToken", JWT))
-			.andExpect(jsonPath("$.data.existingEmail").value(false));
+			.andExpect(jsonPath("$.data.existingEmail").value(false))
+			.andExpect(jsonPath("$.data.newUser").value(false));
 
 		verify(oAuthLinkTokenService).validateToken(LINK_TOKEN);
 		verify(oAuthLinkTokenService).deleteToken(LINK_TOKEN);
@@ -324,6 +334,7 @@ class OAuthControllerTest extends CommonMockMvcControllerTestSetUp {
 
 		OAuthResponseDto responseDto = OAuthResponseDto.builder()
 			.isExistingEmail(false)
+			.isNewUser(false)
 			.build();
 
 		AuthTokenDto authTokenDto = new AuthTokenDto(JWT, "refresh_token");
@@ -344,7 +355,8 @@ class OAuthControllerTest extends CommonMockMvcControllerTestSetUp {
 			.andExpect(status().isOk())
 			.andExpect(cookie().exists("accessToken"))
 			.andExpect(cookie().value("accessToken", JWT))
-			.andExpect(jsonPath("$.data.existingEmail").value(false));
+			.andExpect(jsonPath("$.data.existingEmail").value(false))
+			.andExpect(jsonPath("$.data.newUser").value(false));
 
 		verify(oAuthLinkTokenService).validateToken(LINK_TOKEN);
 		verify(oAuthLinkTokenService).deleteToken(LINK_TOKEN);
@@ -360,6 +372,7 @@ class OAuthControllerTest extends CommonMockMvcControllerTestSetUp {
 
 		OAuthResponseDto responseDto = OAuthResponseDto.builder()
 			.isExistingEmail(false)
+			.isNewUser(false)
 			.build();
 
 		AuthTokenDto authTokenDto = new AuthTokenDto(JWT, "refresh_token");
@@ -378,7 +391,8 @@ class OAuthControllerTest extends CommonMockMvcControllerTestSetUp {
 		resultActions
 			.andExpect(status().isOk())
 			.andExpect(cookie().exists("accessToken"))
-			.andExpect(jsonPath("$.data.existingEmail").value(false));
+			.andExpect(jsonPath("$.data.existingEmail").value(false))
+			.andExpect(jsonPath("$.data.newUser").value(false));
 
 		verify(oAuthLinkTokenService, never()).validateToken(any());
 	}
@@ -393,6 +407,7 @@ class OAuthControllerTest extends CommonMockMvcControllerTestSetUp {
 
 		OAuthResponseDto responseDto = OAuthResponseDto.builder()
 			.isExistingEmail(false)
+			.isNewUser(false)
 			.build();
 
 		AuthTokenDto authTokenDto = new AuthTokenDto(JWT, "refresh_token");
@@ -413,7 +428,8 @@ class OAuthControllerTest extends CommonMockMvcControllerTestSetUp {
 		resultActions
 			.andExpect(status().isOk())
 			.andExpect(cookie().exists("accessToken"))
-			.andExpect(jsonPath("$.data.existingEmail").value(false));
+			.andExpect(jsonPath("$.data.existingEmail").value(false))
+			.andExpect(jsonPath("$.data.newUser").value(false));
 
 		verify(oAuthLinkTokenService).validateToken(INVALID_LINK_TOKEN);
 		verify(oAuthLinkTokenService, never()).deleteToken(any());
@@ -430,6 +446,7 @@ class OAuthControllerTest extends CommonMockMvcControllerTestSetUp {
 
 		OAuthResponseDto responseDto = OAuthResponseDto.builder()
 			.isExistingEmail(true)
+			.isNewUser(false)
 			.build();
 
 		AuthTokenDto authTokenDto = new AuthTokenDto(JWT, "refresh_token");
@@ -449,7 +466,8 @@ class OAuthControllerTest extends CommonMockMvcControllerTestSetUp {
 		resultActions
 			.andExpect(status().isOk())
 			.andExpect(cookie().exists("accessToken"))
-			.andExpect(jsonPath("$.data.existingEmail").value(true));
+			.andExpect(jsonPath("$.data.existingEmail").value(true))
+			.andExpect(jsonPath("$.data.newUser").value(false));
 	}
 
 	@Test
@@ -461,6 +479,7 @@ class OAuthControllerTest extends CommonMockMvcControllerTestSetUp {
 
 		OAuthResponseDto responseDto = OAuthResponseDto.builder()
 			.isExistingEmail(false)
+			.isNewUser(false)
 			.build();
 
 		// AuthTokenDto가 null인 경우
@@ -479,6 +498,39 @@ class OAuthControllerTest extends CommonMockMvcControllerTestSetUp {
 			.andExpect(status().isOk())
 			.andExpect(cookie().exists("accessToken"))
 			.andExpect(cookie().value("accessToken", JWT))
-			.andExpect(jsonPath("$.data.existingEmail").value(false));
+			.andExpect(jsonPath("$.data.existingEmail").value(false))
+			.andExpect(jsonPath("$.data.newUser").value(false));
+	}
+
+	@Test
+	@DisplayName("신규 사용자 OAuth 로그인 성공")
+	void 신규_사용자_OAuth_로그인_성공() throws Exception {
+		// given
+		final String AUTH_CODE = "auth_code";
+		final String JWT = "jwt_token";
+
+		OAuthResponseDto responseDto = OAuthResponseDto.builder()
+			.isExistingEmail(false)
+			.isNewUser(true)
+			.build();
+
+		AuthTokenDto authTokenDto = new AuthTokenDto(JWT, "refresh_token");
+		OAuthService.OAuthLoginResult result = new OAuthService.OAuthLoginResult(responseDto, JWT, authTokenDto);
+
+		when(oAuthService.processOAuthLogin(any(OAuthLoginDto.class))).thenReturn(result);
+
+		// when
+		ResultActions resultActions = mockMvc
+			.perform(get("/api/users/oauth/login/kakao")
+				.queryParam("code", AUTH_CODE)
+				.contentType(MediaType.APPLICATION_JSON));
+
+		// then
+		resultActions
+			.andExpect(status().isOk())
+			.andExpect(cookie().exists("accessToken"))
+			.andExpect(cookie().value("accessToken", JWT))
+			.andExpect(jsonPath("$.data.existingEmail").value(false))
+			.andExpect(jsonPath("$.data.newUser").value(true));
 	}
 }

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/user/service/OAuthServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/user/service/OAuthServiceTest.java
@@ -44,6 +44,7 @@ import com.trackery.trackerybackapiserver.domain.user.mapper.UserRoleMapper;
  * 25. 6. 27.		 inari	   	 로그인시 lastlogin 갱신 추가 및 이미 연동된 계정 타유저 접근 차단
  * 25. 6. 27.		 inari	   	 코드 복잡도 해결을 위해 메서드 분리 테스트
  * 25. 6. 28.		 inari	   	 코드 스멜 수정
+ * 25. 7. 1.         inari		 isNewUser 파라미터 테스트 코드 추가
  */
 @ExtendWith(MockitoExtension.class)
 class OAuthServiceTest {
@@ -128,6 +129,7 @@ class OAuthServiceTest {
 		assertNotNull(result);
 		assertEquals("jwt_token", result.getJwtToken());
 		assertFalse(result.getResponseDto().isExistingEmail());
+		assertFalse(result.getResponseDto().isNewUser());
 		verify(oAuthClient).getAccessToken(anyString(), any(OAuthProvider.class));
 		verify(oAuthClient).getUserInfo(anyString(), any(OAuthProvider.class));
 		verify(oAuthMapper).findByProviderAndProviderId(anyString(), anyString());
@@ -152,6 +154,7 @@ class OAuthServiceTest {
 		assertNotNull(result);
 		assertNull(result.getJwtToken());
 		assertTrue(result.getResponseDto().isExistingEmail());
+		assertFalse(result.getResponseDto().isNewUser());
 		verify(oAuthClient).getAccessToken(anyString(), any(OAuthProvider.class));
 		verify(oAuthClient).getUserInfo(anyString(), any(OAuthProvider.class));
 		verify(oAuthMapper).findByProviderAndProviderId(anyString(), anyString());
@@ -182,6 +185,7 @@ class OAuthServiceTest {
 		assertNotNull(result);
 		assertEquals("jwt_token", result.getJwtToken());
 		assertFalse(result.getResponseDto().isExistingEmail());
+		assertFalse(result.getResponseDto().isNewUser());
 		verify(oAuthClient).getAccessToken(anyString(), any(OAuthProvider.class));
 		verify(oAuthClient).getUserInfo(anyString(), any(OAuthProvider.class));
 		verify(oAuthMapper).findByProviderAndProviderId(anyString(), anyString());
@@ -217,6 +221,7 @@ class OAuthServiceTest {
 		assertNotNull(result);
 		assertEquals("jwt_token", result.getJwtToken());
 		assertFalse(result.getResponseDto().isExistingEmail());
+		assertTrue(result.getResponseDto().isNewUser());
 		verify(oAuthClient).getAccessToken(anyString(), any(OAuthProvider.class));
 		verify(oAuthClient).getUserInfo(anyString(),any(OAuthProvider.class));
 		verify(oAuthMapper).findByProviderAndProviderId(anyString(), anyString());
@@ -254,6 +259,7 @@ class OAuthServiceTest {
 		assertNotNull(result);
 		assertEquals("jwt_token", result.getJwtToken());
 		assertFalse(result.getResponseDto().isExistingEmail());
+		assertFalse(result.getResponseDto().isNewUser());
 		verify(oAuthClient).getAccessToken(anyString(), any(OAuthProvider.class));
 		verify(oAuthClient).getUserInfo(anyString(), any(OAuthProvider.class));
 		verify(oAuthMapper).findByProviderAndProviderId(anyString(), anyString());
@@ -372,6 +378,7 @@ class OAuthServiceTest {
 		assertNotNull(result);
 		assertEquals("jwt_token", result.getJwtToken());
 		assertFalse(result.getResponseDto().isExistingEmail());
+		assertFalse(result.getResponseDto().isNewUser());
 		verify(oAuthClient).getAccessToken(anyString(), any(OAuthProvider.class));
 		verify(oAuthClient).getUserInfo(anyString(), any(OAuthProvider.class));
 		verify(oAuthMapper).findByProviderAndProviderId(anyString(), anyString());


### PR DESCRIPTION
기존에 이메일이 등록되어 있지않은 신규 간편로그인 유저는 isNewUser=true로
기존 유저가 연동시나 이미 있는 이메일에 간편로그인 연동시 isNewUser=false로 파라미터 추가했습니다.
기존 링크토큰으로도 기능상 문제는 없지만 프론트에서 신규회원과 기존회원의 연동시 모달에서 구분하여 안내하기위한 변경점입니다.

변경점
  - OAuthService: 신규 사용자 회원가입 시 `isNewUser=true` 설정하는 `generateNewUserLoginResult()` 메서드 추가
  - OAuthControllerTest: 신규 사용자 테스트 케이스 추가 및 모든 기존 테스트에 `isNewUser` 검증 로직 추가
  - OAuthServiceTest: 신규 사용자 가입 테스트에 `isNewUser=true` 검증 추가
