### PR TITLE
Issue/#74

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ build/
 ### VS Code ###
 .vscode/
 .env
+
+test/resources/application-test.yml

--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,3 @@ build/
 ### VS Code ###
 .vscode/
 .env
-
-test/resources/application-test.yml

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/album/service/AlbumService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/album/service/AlbumService.java
@@ -2,6 +2,7 @@ package com.trackery.trackerybackapiserver.domain.album.service;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -48,6 +49,7 @@ import lombok.extern.slf4j.Slf4j;
  * DATE              AUTHOR             NOTE
  * -----------------------------------------------------------
  * 25. 5. 14.		durururuk		최초 생성
+ * 25. 7. 11.		durururuk		앨범 조회 시에도 S3에서 조회 실패한 이미지는 제외한 결과 응답하게 수정
  */
 @Slf4j
 @Service
@@ -243,7 +245,15 @@ public class AlbumService {
 
 		PageInfo<ImageInfoForThumbnailDto> pageInfo = new PageInfo<>(imageInfoForThumbnailDtos);
 
-		return PageUtil.convert(pageInfo, imageInfo -> imageService.convertToThumbnail(imageInfo, userId));
+		List<ImageThumbnailDto> thumbnailList = new ArrayList<>();
+		for (ImageInfoForThumbnailDto imageInfoForThumbnailDto : imageInfoForThumbnailDtos) {
+			ImageThumbnailDto thumbnailDto = imageService.convertToThumbnail(imageInfoForThumbnailDto, userId);
+			if (thumbnailDto != null) {
+				thumbnailList.add(thumbnailDto);
+			}
+		}
+
+		return PageUtil.convert(pageInfo, thumbnailList);
 	}
 
 	/**

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/album/service/AlbumService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/album/service/AlbumService.java
@@ -2,7 +2,6 @@ package com.trackery.trackerybackapiserver.domain.album.service;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -29,7 +28,6 @@ import com.trackery.trackerybackapiserver.domain.album.event.AlbumImageEditEvent
 import com.trackery.trackerybackapiserver.domain.album.mapper.AlbumMapper;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
-import com.trackery.trackerybackapiserver.domain.common.util.PageUtil;
 import com.trackery.trackerybackapiserver.domain.image.dto.ImageThumbnailDto;
 import com.trackery.trackerybackapiserver.domain.image.dto.internal.ImageInfoForThumbnailDto;
 import com.trackery.trackerybackapiserver.domain.image.entity.Image;
@@ -245,15 +243,7 @@ public class AlbumService {
 
 		PageInfo<ImageInfoForThumbnailDto> pageInfo = new PageInfo<>(imageInfoForThumbnailDtos);
 
-		List<ImageThumbnailDto> thumbnailList = new ArrayList<>();
-		for (ImageInfoForThumbnailDto imageInfoForThumbnailDto : imageInfoForThumbnailDtos) {
-			ImageThumbnailDto thumbnailDto = imageService.convertToThumbnail(imageInfoForThumbnailDto, userId);
-			if (thumbnailDto != null) {
-				thumbnailList.add(thumbnailDto);
-			}
-		}
-
-		return PageUtil.convert(pageInfo, thumbnailList);
+		return imageService.convertToThumbnailPageInfo(pageInfo, userId);
 	}
 
 	/**

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageS3Service.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageS3Service.java
@@ -11,6 +11,9 @@ import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiEx
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
@@ -27,6 +30,7 @@ import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignReques
  * DATE              AUTHOR             NOTE
  * -----------------------------------------------------------
  * 25. 4. 21.		durururuk		최초 생성
+ * 25. 7. 11.		durururuk		PresignedUrl 생성 전에 Head 메서드로 해당 key가 존재하는지 예외 처리 추가
  */
 @Slf4j
 @Service
@@ -59,6 +63,19 @@ public class ImageS3Service {
 			}
 			default -> throw new ApiException(ErrorCode.INTERNAL_SERVER_ERROR);
 		};
+
+		try {
+			HeadObjectRequest headObjectRequest = HeadObjectRequest.builder()
+				.bucket(imageBucket)
+				.key(actualKey)
+				.build();
+			
+			s3Client.headObject(headObjectRequest);
+		} catch (NoSuchKeyException e) {
+			throw new ApiException(ErrorCode.NOT_FOUND_IMAGE_OBJECT_KEY);
+		} catch (S3Exception e) {
+			throw new ApiException(ErrorCode.INTERNAL_SERVER_ERROR);
+		}
 
 		GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
 			.signatureDuration(Duration.ofMinutes(10))

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageService.java
@@ -99,6 +99,12 @@ public class ImageService {
 		return convertImageToImageDto(image, userId);
 	}
 
+	/**
+	 * 이미지 엔티티를 이미지 썸네일 DTO로 변환합니다.
+	 * @param image 변환할 이미지 엔티티
+	 * @param userId 사용자 ID
+	 * @return 썸네일 URL과 이미지 ID를 포함한 썸네일 DTO
+	 */
 	public ImageThumbnailDto convertImageToImageThumbnailDto(Image image, Long userId) {
 		String imagePresignedUrl = imageS3Service.generatePreSignedGetUrl(image.getImageName(), userId, "thumbnail");
 		return ImageThumbnailDto
@@ -108,6 +114,12 @@ public class ImageService {
 			.build();
 	}
 
+	/**
+	 * 사용자 ID로 이미지 목록을 페이지네이션하여 조회합니다.
+	 * S3에서 썸네일 조회 실패한 이미지는 결과에서 제외됩니다.
+	 * @param imageSearchByUserIdDto 사용자 이미지 검색 조건 (사용자 ID, 페이지 번호, 페이지 크기 등)
+	 * @return 썸네일 DTO 목록을 포함한 페이지네이션 정보
+	 */
 	@SuppressWarnings("squid:S3252")
 	public PageInfo<ImageThumbnailDto> getImageListByUserId(ImageSearchByUserIdDto imageSearchByUserIdDto) {
 		PageHelper.startPage(imageSearchByUserIdDto.getPageNum(), imageSearchByUserIdDto.getPageSize());

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageService.java
@@ -48,6 +48,7 @@ import lombok.extern.slf4j.Slf4j;
  * 25. 7. 7.		 inari		 이미지 좌표 인서트시 태그 추가
  * 25. 7. 9.		 inari		 removeAllTagsFromImage로 메서드 분리
  * 25. 7. 11.		durururuk	 내 이미지 리스트 조회 시 S3에서 이미지 조회 실패한 이미지는 제외하고 결과를 반환하게 수정
+ * 25. 7. 11.		durururuk	 중복되는 리스팅 메서드 추출
  */
 @Slf4j
 @Service
@@ -129,15 +130,7 @@ public class ImageService {
 
 		PageInfo<ImageInfoForThumbnailDto> sourcePageInfo = new PageInfo<>(imageInfoForThumbnailDtos);
 
-		List<ImageThumbnailDto> thumbnailList = new ArrayList<>();
-		for (ImageInfoForThumbnailDto imageInfo : sourcePageInfo.getList()) {
-			ImageThumbnailDto thumbnail = convertToThumbnail(imageInfo, imageSearchByUserIdDto.getUserId());
-			if (thumbnail != null) {
-				thumbnailList.add(thumbnail);
-			}
-		}
-
-		return PageUtil.convert(sourcePageInfo, thumbnailList);
+		return convertToThumbnailPageInfo(sourcePageInfo, imageSearchByUserIdDto.getUserId());
 	}
 
 	/**
@@ -280,6 +273,26 @@ public class ImageService {
 			() -> new ApiException(ErrorCode.NOT_FOUND_IMAGE));
 
 		return imageS3Service.generatePreSignedGetUrl(image.getImageName(), image.getUserId(), "original");
+	}
+
+	/**
+	 * PageInfo<ImageInfoForThumbnailDto>를 PageInfo<ImageThumbnailDto>로 변환합니다.
+	 * S3에서 썸네일 조회 실패한 이미지는 결과에서 제외됩니다.
+	 * @param sourcePageInfo 원본 페이지 정보
+	 * @param userId 사용자 ID
+	 * @return 썸네일 DTO 목록을 포함한 페이지네이션 정보
+	 */
+	public PageInfo<ImageThumbnailDto> convertToThumbnailPageInfo(
+		PageInfo<ImageInfoForThumbnailDto> sourcePageInfo, Long userId) {
+		
+		List<ImageThumbnailDto> thumbnailList = new ArrayList<>();
+		for (ImageInfoForThumbnailDto imageInfo : sourcePageInfo.getList()) {
+			ImageThumbnailDto thumbnail = convertToThumbnail(imageInfo, userId);
+			if (thumbnail != null) {
+				thumbnailList.add(thumbnail);
+			}
+		}
+		return PageUtil.convert(sourcePageInfo, thumbnailList);
 	}
 
 	/**

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageService.java
@@ -1,5 +1,6 @@
 package com.trackery.trackerybackapiserver.domain.image.service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.cache.annotation.CacheEvict;
@@ -46,6 +47,7 @@ import lombok.extern.slf4j.Slf4j;
  * 25. 6. 22.		 inari		 이미지 수정시 좌표 인서트가 아닌 업데이트로 변경
  * 25. 7. 7.		 inari		 이미지 좌표 인서트시 태그 추가
  * 25. 7. 9.		 inari		 removeAllTagsFromImage로 메서드 분리
+ * 25. 7. 11.		durururuk	 내 이미지 리스트 조회 시 S3에서 이미지 조회 실패한 이미지는 제외하고 결과를 반환하게 수정
  */
 @Slf4j
 @Service
@@ -113,10 +115,17 @@ public class ImageService {
 		List<ImageInfoForThumbnailDto> imageInfoForThumbnailDtos = imageMapper.findImageThumbnailsByUserId(
 			imageSearchByUserIdDto);
 
-		PageInfo<ImageInfoForThumbnailDto> pageInfo = new PageInfo<>(imageInfoForThumbnailDtos);
+		PageInfo<ImageInfoForThumbnailDto> sourcePageInfo = new PageInfo<>(imageInfoForThumbnailDtos);
 
-		return PageUtil.convert(pageInfo,
-			imageThumbnailDtoList -> convertToThumbnail(imageThumbnailDtoList, imageSearchByUserIdDto.getUserId()));
+		List<ImageThumbnailDto> thumbnailList = new ArrayList<>();
+		for (ImageInfoForThumbnailDto imageInfo : sourcePageInfo.getList()) {
+			ImageThumbnailDto thumbnail = convertToThumbnail(imageInfo, imageSearchByUserIdDto.getUserId());
+			if (thumbnail != null) {
+				thumbnailList.add(thumbnail);
+			}
+		}
+
+		return PageUtil.convert(sourcePageInfo, thumbnailList);
 	}
 
 	/**
@@ -268,11 +277,19 @@ public class ImageService {
 	 * @return 썸네일 DTO
 	 */
 	public ImageThumbnailDto convertToThumbnail(ImageInfoForThumbnailDto imageInfo, Long userId) {
-		String thumbnailUrl = imageS3Service.generatePreSignedGetUrl(imageInfo.getImageName(), userId, "thumbnail");
+		try {
+			String thumbnailUrl = imageS3Service.generatePreSignedGetUrl(imageInfo.getImageName(), userId, "thumbnail");
 
-		return ImageThumbnailDto.builder()
-			.imageId(imageInfo.getImageId())
-			.thumbnailUrl(thumbnailUrl)
-			.build();
+			return ImageThumbnailDto.builder()
+				.imageId(imageInfo.getImageId())
+				.thumbnailUrl(thumbnailUrl)
+				.build();
+		} catch (ApiException e) {
+			if (e.getErrorCode() == ErrorCode.NOT_FOUND_IMAGE_OBJECT_KEY) {
+				log.warn("S3에서 이미지 조회 실패, 이미지: {} (user: {})", imageInfo.getImageName(), userId);
+				return null;
+			}
+			throw e;
+		}
 	}
 }

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/album/service/AlbumServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/album/service/AlbumServiceTest.java
@@ -2,6 +2,7 @@ package com.trackery.trackerybackapiserver.domain.album.service;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.*;
 
 import java.util.HashSet;
 import java.util.List;
@@ -458,24 +459,24 @@ class AlbumServiceTest {
 
 			when(albumMapper.findImagesForThumbnailByAlbumId(ALBUM_ID)).thenReturn(imageInfoList);
 
-			when(imageService.convertToThumbnail(imageInfo1, USER_ID)).thenReturn(
+			PageInfo<ImageThumbnailDto> expectedPageInfo = new PageInfo<>();
+			List<ImageThumbnailDto> thumbnailList = List.of(
 				ImageThumbnailDto.builder()
 					.imageId(1L)
 					.thumbnailUrl("thumbnail1.jpg")
-					.build()
-			);
-			when(imageService.convertToThumbnail(imageInfo2, USER_ID)).thenReturn(
+					.build(),
 				ImageThumbnailDto.builder()
 					.imageId(2L)
 					.thumbnailUrl("thumbnail2.jpg")
-					.build()
-			);
-			when(imageService.convertToThumbnail(imageInfo3, USER_ID)).thenReturn(
+					.build(),
 				ImageThumbnailDto.builder()
 					.imageId(3L)
 					.thumbnailUrl("thumbnail3.jpg")
 					.build()
 			);
+			expectedPageInfo.setList(thumbnailList);
+			
+			when(imageService.convertToThumbnailPageInfo(any(), eq(USER_ID))).thenReturn(expectedPageInfo);
 
 			PageInfo<ImageThumbnailDto> result =
 				albumService.getAlbumImages(ALBUM_ID, USER_ID, pageNum, pageSize);
@@ -488,9 +489,7 @@ class AlbumServiceTest {
 			assertEquals(3L, result.getList().get(2).getImageId());
 
 			verify(albumMapper).findImagesForThumbnailByAlbumId(ALBUM_ID);
-			verify(imageService).convertToThumbnail(imageInfo1, USER_ID);
-			verify(imageService).convertToThumbnail(imageInfo2, USER_ID);
-			verify(imageService).convertToThumbnail(imageInfo3, USER_ID);
+			verify(imageService).convertToThumbnailPageInfo(any(), eq(USER_ID));
 		}
 
 		@Test
@@ -513,13 +512,8 @@ class AlbumServiceTest {
 			List<ImageInfoForThumbnailDto> imageInfoList = List.of(imageInfo1, imageInfo2);
 
 			when(albumMapper.findImagesForThumbnailByAlbumId(ALBUM_ID)).thenReturn(imageInfoList);
-			when(imageService.convertToThumbnail(imageInfo1, USER_ID)).thenReturn(
-				ImageThumbnailDto.builder()
-					.imageId(1L)
-					.thumbnailUrl("thumbnail1.jpg")
-					.build()
-			);
-			when(imageService.convertToThumbnail(imageInfo2, USER_ID)).thenThrow(new ApiException(ErrorCode.NOT_FOUND_IMAGE));
+			when(imageService.convertToThumbnailPageInfo(any(), eq(USER_ID)))
+				.thenThrow(new ApiException(ErrorCode.NOT_FOUND_IMAGE));
 
 			// When & Then
 			ApiException exception = assertThrows(ApiException.class,
@@ -528,8 +522,7 @@ class AlbumServiceTest {
 			assertEquals(ErrorCode.NOT_FOUND_IMAGE, exception.getErrorCode());
 
 			verify(albumMapper).findImagesForThumbnailByAlbumId(ALBUM_ID);
-			verify(imageService).convertToThumbnail(imageInfo1, USER_ID);
-			verify(imageService).convertToThumbnail(imageInfo2, USER_ID);
+			verify(imageService).convertToThumbnailPageInfo(any(), eq(USER_ID));
 		}
 
 		@Test
@@ -540,6 +533,10 @@ class AlbumServiceTest {
 			int pageSize = 10;
 
 			when(albumMapper.findImagesForThumbnailByAlbumId(ALBUM_ID)).thenReturn(List.of());
+			
+			PageInfo<ImageThumbnailDto> emptyPageInfo = new PageInfo<>();
+			emptyPageInfo.setList(List.of());
+			when(imageService.convertToThumbnailPageInfo(any(), eq(USER_ID))).thenReturn(emptyPageInfo);
 
 			// When
 			PageInfo<ImageThumbnailDto> result =


### PR DESCRIPTION
1. S3에서 PresignedGetUrl을 생성하기 전에 Head 메서드로 key에 대한 object가 존재하는지 확인하고 없을 경우 예외를 발생하게 수정했습니다.

2. 예외가 발생한 이미지는 조회 결과에서 제외되게 수정해서 이미지 하나가 오류가 나도 앨범이나 내 이미지를 불러오는 데에는 문제가 없게 수정했습니다.