### PR TITLE
리프레시 토큰으로 액세스토큰이 자동으로 재발급 되지 않는 문제 수정

### DIFF
--- a/src/main/java/com/trackery/trackerybackapiserver/config/RedisConfig.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/config/RedisConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 /**
@@ -32,7 +33,10 @@ public class RedisConfig {
 		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
 		redisTemplate.setConnectionFactory(redisConnectionFactory);
 
-		redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+		redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+		redisTemplate.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
 
 		return redisTemplate;
 	}

--- a/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtResolverFilter.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtResolverFilter.java
@@ -8,6 +8,7 @@ import org.springframework.lang.NonNull;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.trackery.trackerybackapiserver.domain.common.enums.CookieName;
+import com.trackery.trackerybackapiserver.domain.common.enums.SameSitePolicy;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
 import com.trackery.trackerybackapiserver.domain.common.util.CookieUtil;
@@ -71,17 +72,37 @@ public class JwtResolverFilter extends OncePerRequestFilter {
 				throw new ApiException(ErrorCode.UNAUTHORIZED);
 			});
 
-		Long userId = jwtService.parseAndVerifyRefreshToken(refreshToken);
+		try {
+			Long userId = jwtService.parseAndVerifyRefreshToken(refreshToken);
 
-		JwtUserInfoDto jwtUserInfoDto = userService.getUserInfoById(userId);
+			JwtUserInfoDto jwtUserInfoDto = userService.getUserInfoById(userId);
 
+			AuthTokenDto authTokenDto = jwtService.generateAccessTokenAndRefreshToken(jwtUserInfoDto.userId(),
+				jwtUserInfoDto.username(), jwtUserInfoDto.roleId());
 
-		AuthTokenDto authTokenDto = jwtService.generateAccessTokenAndRefreshToken(jwtUserInfoDto.userId(),
-			jwtUserInfoDto.username(), jwtUserInfoDto.roleId());
+			addAuthCookiesToHeader(authTokenDto, response);
 
-		addAuthCookiesToHeader(authTokenDto, response);
+			return authTokenDto.accessToken();
 
-		return authTokenDto.accessToken();
+		} catch (ApiException e) {
+			log.error("액세스토큰 재발급 실패, ErrorCode: {}, Message: {}",
+				e.getErrorCode(), e.getMessage());
+
+			if (e.getErrorCode() == ErrorCode.UNAUTHORIZED
+				|| e.getErrorCode() == ErrorCode.INTERNAL_SERVER_ERROR) {
+				ResponseCookie clearCookie = CookieUtil.deleteCookie(
+					CookieName.REFRESH_TOKEN.getValue(), SameSitePolicy.STRICT.getValue());
+				response.addHeader("Set-Cookie", clearCookie.toString());
+			}
+
+			throw e;
+		} catch (Exception e) {
+			log.error("토큰 재발행 중 에러 발생", e);
+			ResponseCookie clearCookie = CookieUtil.deleteCookie(
+				CookieName.REFRESH_TOKEN.getValue(), SameSitePolicy.STRICT.getValue());
+			response.addHeader("Set-Cookie", clearCookie.toString());
+			throw new ApiException(ErrorCode.INTERNAL_SERVER_ERROR);
+		}
 	}
 
 	/**

--- a/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtResolverFilter.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtResolverFilter.java
@@ -47,17 +47,44 @@ public class JwtResolverFilter extends OncePerRequestFilter {
 	 * 필터 흐름
 	 *  1. 쿠키에서 액세스 토큰을 가져옵니다.
 	 *   1.1. 액세스 토큰이 없고 리프레시 토큰은 있다면 액세스 토큰을 재발급합니다.
-	 *   1.2. 액세스 토큰과 리프레시 토큰이 모두 없다면 401 에러를 반환합니다.
+	 *   1.2. 액세스 토큰이 있지만 만료되었다면 리프레시 토큰으로 재발급합니다.
+	 *   1.3. 액세스 토큰과 리프레시 토큰이 모두 없다면 401 에러를 반환합니다.
 	 *  2. 액세스 토큰을 Attribute에 담아서 필터체인을 진행합니다.
 	 */
 	@Override
 	protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response,
 		@NonNull FilterChain filterChain) throws ServletException, IOException {
-		String accessToken = CookieUtil.extractCookieValue(request, CookieName.ACCESS_TOKEN.getValue(),
-			() -> reissueAccessTokenByRefreshToken(request, response));
+		String accessToken = getValidAccessToken(request, response);
 
 		request.setAttribute(CookieName.ACCESS_TOKEN.getValue(), accessToken);
 		filterChain.doFilter(request, response);
+	}
+
+	/**
+	 * 유효한 액세스 토큰을 가져오는 메서드
+	 * 액세스 토큰이 없거나 만료된 경우 리프레시 토큰으로 재발급합니다.
+	 *
+	 * @param request : HttpServletRequest 요청 객체
+	 * @param response : HttpServletResponse 응답 객체
+	 * @return : 유효한 액세스 토큰
+	 */
+	private String getValidAccessToken(HttpServletRequest request, HttpServletResponse response) {
+		String accessToken = CookieUtil.extractCookieValue(request, CookieName.ACCESS_TOKEN.getValue(), () -> null);
+
+		if (accessToken != null) {
+			try {
+				jwtService.verifyJwt(accessToken);
+				return accessToken;
+			} catch (ApiException e) {
+				if (e.getErrorCode() == ErrorCode.BAD_REQUEST || e.getErrorCode() == ErrorCode.UNAUTHORIZED) {
+					log.debug("액세스 토큰이 만료되었습니다. 리프레시 토큰으로 재발급을 시도합니다.");
+					return reissueAccessTokenByRefreshToken(request, response);
+				}
+				throw e;
+			}
+		}
+
+		return reissueAccessTokenByRefreshToken(request, response);
 	}
 
 	/**

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtRedisService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtRedisService.java
@@ -1,6 +1,6 @@
 package com.trackery.trackerybackapiserver.domain.jwt.service;
 
-import java.util.Optional;
+import java.time.Duration;
 
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
@@ -35,8 +35,8 @@ public class JwtRedisService {
 	private final StringRedisTemplate redisTemplate;
 	private final ObjectMapper objectMapper;
 
-	private static final String REFRESH_TOKEN_REDIS_KEY = "jwtRefreshToken:";
-	private static final String ACCESS_TOKEN_BLACKLIST_KEY = "jwtBlacklist:";
+	private static final String REFRESH_TOKEN_KEY_PREFIX = "jwtRefreshToken:";
+	private static final String ACCESS_TOKEN_BLACKLIST_KEY_PREFIX = "jwtBlacklist:";
 
 	/**
 	 * 리프레시 토큰 정보를 Redis에 저장합니다.
@@ -45,14 +45,26 @@ public class JwtRedisService {
 	 * @param refreshTokenDto 리프레시 토큰, JwtId, 유저ID를 가지고 있는 DTO
 	 */
 	public void saveRefreshToken(RefreshTokenDto refreshTokenDto) {
+		if (refreshTokenDto == null || refreshTokenDto.refreshToken() == null) {
+			log.error("RefreshTokenDto 혹은 dto.refreshToken null");
+			throw new ApiException(ErrorCode.BAD_REQUEST);
+		}
+
 		try {
-			String redisKey = REFRESH_TOKEN_REDIS_KEY + refreshTokenDto.refreshToken();
+			String redisKey = REFRESH_TOKEN_KEY_PREFIX + refreshTokenDto.refreshToken();
 			String jsonRefreshTokenDto = objectMapper.writeValueAsString(refreshTokenDto);
 
-			redisTemplate.opsForValue()
-				.set(redisKey, jsonRefreshTokenDto, JwtExpirationTime.REFRESH_TOKEN.getExpirationTime());
+			Duration ttl = Duration.ofSeconds(JwtExpirationTime.REFRESH_TOKEN.getExpirationTime());
+			redisTemplate.opsForValue().set(redisKey, jsonRefreshTokenDto, ttl);
+
+			String savedValue = redisTemplate.opsForValue().get(redisKey);
+			if (savedValue == null) {
+				log.error("리프레시 토큰 저장 실패. Key: {}", redisKey);
+				throw new ApiException(ErrorCode.INTERNAL_SERVER_ERROR);
+			}
+
 		} catch (JsonProcessingException e) {
-			log.error("Json 파싱 중 에러 발생 : ", e);
+			log.error("리프레시 토큰 Redis에 저장 중 직렬화 오류 발생", e);
 			throw new ApiException(ErrorCode.INTERNAL_SERVER_ERROR);
 		}
 	}
@@ -64,13 +76,40 @@ public class JwtRedisService {
 	 * @return : redis에 저장된 리프레시 토큰 정보 (리프레시 토큰 자체를 파싱한 것이 아닙니다.)
 	 */
 	public RefreshTokenDto getRefreshTokenInfo(String refreshToken) {
-		String redisKey = REFRESH_TOKEN_REDIS_KEY + refreshToken;
-		String jsonRefreshTokenDto = Optional.ofNullable(redisTemplate.opsForValue().get(redisKey))
-			.orElseThrow(() -> new ApiException(ErrorCode.UNAUTHORIZED));
+		if (refreshToken == null || refreshToken.trim().isEmpty()) {
+			log.warn("리프레시 토큰 비어있음");
+			throw new ApiException(ErrorCode.BAD_REQUEST);
+		}
+
+		String redisKey = REFRESH_TOKEN_KEY_PREFIX + refreshToken;
+
 		try {
+			boolean keyExists = redisTemplate.hasKey(redisKey);
+
+			if (!keyExists) {
+				log.warn("Redis에서 리프레시 토큰 조회 실패: {}", redisKey);
+				throw new ApiException(ErrorCode.UNAUTHORIZED);
+			}
+
+			String jsonRefreshTokenDto = redisTemplate.opsForValue().get(redisKey);
+
+			if (jsonRefreshTokenDto == null) {
+				log.error("리프레시 토큰 Key는 있는데 값이 null, Key: {}", redisKey);
+				redisTemplate.unlink(redisKey);
+				throw new ApiException(ErrorCode.UNAUTHORIZED);
+			}
+
+			if (jsonRefreshTokenDto.contains("\0") || !isValidJson(jsonRefreshTokenDto)) {
+				log.error("리프레시 토큰 깨짐. Key: {}, Data: {}",
+					redisKey, jsonRefreshTokenDto.replaceAll("\\p{Cntrl}", "?"));
+				redisTemplate.unlink(redisKey);
+				throw new ApiException(ErrorCode.UNAUTHORIZED);
+			}
+
 			return objectMapper.readValue(jsonRefreshTokenDto, RefreshTokenDto.class);
+
 		} catch (JsonProcessingException e) {
-			log.error("Json 매핑 중 에러 발생 : ", e);
+			log.error("리프레시 토큰 조회 후 역직렬화 중 에러 발생", e);
 			throw new ApiException(ErrorCode.INTERNAL_SERVER_ERROR);
 		}
 	}
@@ -80,8 +119,15 @@ public class JwtRedisService {
 	 * @param refreshToken : 사용된 리프레시 토큰
 	 */
 	public void deleteRefreshToken(String refreshToken) {
-		String redisKey = REFRESH_TOKEN_REDIS_KEY + refreshToken;
-		redisTemplate.unlink(redisKey);
+		if (refreshToken == null || refreshToken.trim().isEmpty()) {
+			log.warn("Attempted to delete null or empty refresh token");
+			return;
+		}
+
+		String redisKey = REFRESH_TOKEN_KEY_PREFIX + refreshToken;
+
+		Boolean deleted = redisTemplate.delete(redisKey);
+		log.info("Refresh token deletion result: {}, Key: {}", deleted, redisKey);
 	}
 
 	/**
@@ -90,9 +136,14 @@ public class JwtRedisService {
 	 * @param expirationTime 토큰 만료까지 남은 시간 (초)
 	 */
 	public void addAccessTokenToBlacklist(String jti, long expirationTime) {
-		String redisKey = ACCESS_TOKEN_BLACKLIST_KEY + jti;
-		redisTemplate.opsForValue().set(redisKey, "blacklisted",
-			java.time.Duration.ofSeconds(expirationTime));
+		if (jti == null || jti.trim().isEmpty()) {
+			log.error("JTI null이거나 비어있음");
+			throw new ApiException(ErrorCode.BAD_REQUEST);
+		}
+
+		String redisKey = ACCESS_TOKEN_BLACKLIST_KEY_PREFIX + jti;
+
+		redisTemplate.opsForValue().set(redisKey, "blacklisted", Duration.ofSeconds(expirationTime));
 	}
 
 	/**
@@ -101,8 +152,24 @@ public class JwtRedisService {
 	 * @return 블랙리스트에 있으면 true, 없으면 false
 	 */
 	public boolean isAccessTokenBlacklisted(String jti) {
-		String redisKey = ACCESS_TOKEN_BLACKLIST_KEY + jti;
-		return Boolean.TRUE.equals(redisTemplate.hasKey(redisKey));
+		if (jti == null || jti.trim().isEmpty()) {
+			return false;
+		}
+
+		String redisKey = ACCESS_TOKEN_BLACKLIST_KEY_PREFIX + jti;
+
+		return redisTemplate.hasKey(redisKey);
 	}
 
+	/**
+	 * JSON 문자열 유효성 검사 헬퍼 메서드
+	 */
+	private boolean isValidJson(String jsonString) {
+		try {
+			objectMapper.readTree(jsonString);
+			return true;
+		} catch (Exception e) {
+			return false;
+		}
+	}
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtRedisService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtRedisService.java
@@ -126,7 +126,7 @@ public class JwtRedisService {
 
 		String redisKey = REFRESH_TOKEN_KEY_PREFIX + refreshToken;
 
-		Boolean deleted = redisTemplate.delete(redisKey);
+		Boolean deleted = redisTemplate.unlink(redisKey);
 		log.info("Refresh token deletion result: {}", deleted);
 	}
 

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtRedisService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtRedisService.java
@@ -120,14 +120,14 @@ public class JwtRedisService {
 	 */
 	public void deleteRefreshToken(String refreshToken) {
 		if (refreshToken == null || refreshToken.trim().isEmpty()) {
-			log.warn("Attempted to delete null or empty refresh token");
+			log.warn("리프레시 토큰 레디스에서 삭제 실패 : key 없음");
 			return;
 		}
 
 		String redisKey = REFRESH_TOKEN_KEY_PREFIX + refreshToken;
 
 		Boolean deleted = redisTemplate.delete(redisKey);
-		log.info("Refresh token deletion result: {}, Key: {}", deleted, redisKey);
+		log.info("Refresh token deletion result: {}", deleted);
 	}
 
 	/**

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtRedisServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/jwt/service/JwtRedisServiceTest.java
@@ -59,20 +59,21 @@ class JwtRedisServiceTest {
 			when(redisTemplate.opsForValue()).thenReturn(valueOperations);
 			String expectedJson = "refreshTokenDtoJson";
 			when(objectMapper.writeValueAsString(refreshTokenDto)).thenReturn(expectedJson);
+			when(valueOperations.get(redisKey)).thenReturn(expectedJson);
 			doNothing().when(valueOperations)
-				.set(redisKey, expectedJson, JwtExpirationTime.REFRESH_TOKEN.getExpirationTime());
+				.set(eq(redisKey), eq(expectedJson), any(java.time.Duration.class));
 
 			jwtRedisService.saveRefreshToken(refreshTokenDto);
 
 			verify(objectMapper, times(1)).writeValueAsString(refreshTokenDto);
-			verify(redisTemplate.opsForValue(), times(1)).set(redisKey, expectedJson,
-				JwtExpirationTime.REFRESH_TOKEN.getExpirationTime());
+			verify(redisTemplate.opsForValue(), times(1)).set(eq(redisKey), eq(expectedJson),
+				any(java.time.Duration.class));
 		}
 
 		@Test
 		@DisplayName("실패 - json 파싱 에러")
 		void failure_1() throws JsonProcessingException {
-			when(objectMapper.writeValueAsString(refreshTokenDto)).thenThrow(JsonProcessingException.class);
+			when(objectMapper.writeValueAsString(refreshTokenDto)).thenThrow(new JsonProcessingException("JSON processing error") {});
 
 			assertThrows(ApiException.class, () -> jwtRedisService.saveRefreshToken(refreshTokenDto));
 		}
@@ -85,17 +86,14 @@ class JwtRedisServiceTest {
 		private final String refreshToken = "<PASSWORD>";
 		private final String expectedJson = "refreshTokenDtoJson";
 		private final RefreshTokenDto refreshTokenDto = new RefreshTokenDto(refreshToken, "jid", "subject");
-
-		@BeforeEach
-		void setUp() {
-			when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-			String redisKey = "jwtRefreshToken:" + refreshToken;
-			when(valueOperations.get(redisKey)).thenReturn(expectedJson);
-		}
+		private final String redisKey = "jwtRefreshToken:" + refreshToken;
 
 		@Test
 		@DisplayName("성공")
 		void success() throws JsonProcessingException {
+			when(redisTemplate.hasKey(redisKey)).thenReturn(true);
+			when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+			when(valueOperations.get(redisKey)).thenReturn(expectedJson);
 			when(objectMapper.readValue(expectedJson, RefreshTokenDto.class)).thenReturn(refreshTokenDto);
 
 			RefreshTokenDto result = jwtRedisService.getRefreshTokenInfo(refreshToken);
@@ -106,7 +104,10 @@ class JwtRedisServiceTest {
 		@Test
 		@DisplayName("실패 - Json 매핑 에러")
 		void failure_1() throws JsonProcessingException {
-			when(objectMapper.readValue(expectedJson, RefreshTokenDto.class)).thenThrow(JsonProcessingException.class);
+			when(redisTemplate.hasKey(redisKey)).thenReturn(true);
+			when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+			when(valueOperations.get(redisKey)).thenReturn(expectedJson);
+			when(objectMapper.readValue(expectedJson, RefreshTokenDto.class)).thenThrow(new JsonProcessingException("JSON parsing error") {});
 			assertThrows(ApiException.class, () -> jwtRedisService.getRefreshTokenInfo(refreshToken));
 		}
 	}


### PR DESCRIPTION
Fix #60

1. Key는 계속 StringSerializer를 사용하지만 Value는 Jackson2JsonSerializer를 사용해서 직렬화 문제를 해결했습니다.
2. 브라우저에서 액세스토큰 쿠키가 남아있으나 그게 만료됐을 경우 리프레시 토큰에 접근할 수 있게 예외 처리를 추가했습니다.
3. 로깅을 추가해서 리프레시 토큰이 재발급 되지 않았을 때 원인을 파악하기 편하게 했습니다. 

테스트 해봤을 때 기존 1시간이 지나면 리프레시 토큰이 재발급 되지 않았던 게 2시간이 지나도 제대로 재발급 처리를 해줬습니다. 

TTL이 7일이라 그 사이에 Redis의 메모리가 부족하거나 어떤 이유로 재시작됐을 때 사라지는 경우에 대해서는 영속성 관련 작업을 해보고 문서화 하겠습니다. 