### PR TITLE
Feature/태그 수정

### DIFF
--- a/src/docs/asciidoc/tag-api.adoc
+++ b/src/docs/asciidoc/tag-api.adoc
@@ -61,16 +61,16 @@ include::{snippets}/tag-delete-by-admin/http-response.adoc[]
 include::{snippets}/tag-delete-by-admin/response-fields.adoc[]
 '''
 
-=== 기본 태그 생성 API
-==== POST /api/tags/default
+=== 계절 태그 생성 API
+==== POST /api/tags/season
 
 날짜/시간 정보를 기반으로 계절 및 시간대 태그를 자동 생성합니다.
 
 ===== 요청
-include::{snippets}/tag-create-default/http-request.adoc[]
-include::{snippets}/tag-create-default/request-fields.adoc[]
+include::{snippets}/tag-create-season/http-request.adoc[]
+include::{snippets}/tag-create-season/request-fields.adoc[]
 
 ===== 응답
-include::{snippets}/tag-create-default/http-response.adoc[]
-include::{snippets}/tag-create-default/response-fields.adoc[]
+include::{snippets}/tag-create-season/http-response.adoc[]
+include::{snippets}/tag-create-season/response-fields.adoc[]
 '''

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/dto/ImageDto.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/dto/ImageDto.java
@@ -3,7 +3,7 @@ package com.trackery.trackerybackapiserver.domain.image.dto;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import com.trackery.trackerybackapiserver.domain.tag.dto.TagNameResponseDto;
+import com.trackery.trackerybackapiserver.domain.tag.dto.TagForImageResponseDto;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -19,6 +19,7 @@ import lombok.Getter;
  * -----------------------------------------------------------
  * 25. 5. 14.		durururuk		최초 생성
  * 25. 7. 10.       inari       	이미지 단건 조회시 태그 추가
+ * 25. 7. 12.       inari       	태그 id 추가
  */
 @Getter
 @Builder
@@ -35,5 +36,5 @@ public class ImageDto {
 	private LocalDateTime imageDate;
 	private Integer isPublic;
 	private String imageUrl;
-	private List<TagNameResponseDto> tags;
+	private List<TagForImageResponseDto> tags;
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/dto/ImageUpdateRequestDto.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/dto/ImageUpdateRequestDto.java
@@ -1,6 +1,7 @@
 package com.trackery.trackerybackapiserver.domain.image.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
@@ -18,6 +19,7 @@ import lombok.Builder;
  * -----------------------------------------------------------
  * 25. 6. 20.        inari       최초 생성
  * 25. 7. 11.        inari       주석 추가 및 체크스타일 수정
+ * 25. 7. 12.        inari       삭제할 태그 리스트 추가
  *
  * @param imageName 이미지 이름 (최대 100자)
  * @param imageContent 이미지 설명 (최대 500자)
@@ -25,6 +27,7 @@ import lombok.Builder;
  * @param isPublic 공개 여부 (0: 비공개, 1: 공개)
  * @param latitude 위도 (33.0 ~ 43.0, 한국 영토 범위)
  * @param longitude 경도 (124.0 ~ 132.0, 한국 영토 범위)
+ * @param tagsToRemove 삭제할 태그 ID 목록
  */
 @Builder
 public record ImageUpdateRequestDto(
@@ -39,6 +42,7 @@ public record ImageUpdateRequestDto(
 	Double latitude,
 	@DecimalMin(value = "124.0", message = "경도는 124.0 이상이어야 합니다.")
 	@DecimalMax(value = "132.0", message = "경도는 132.0 이하여야 합니다.")
-	Double longitude
+	Double longitude,
+	List<Long> tagsToRemove
 ) {
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/dto/ImageUpdateRequestDto.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/dto/ImageUpdateRequestDto.java
@@ -20,6 +20,7 @@ import lombok.Builder;
  * 25. 6. 20.        inari       최초 생성
  * 25. 7. 11.        inari       주석 추가 및 체크스타일 수정
  * 25. 7. 12.        inari       삭제할 태그 리스트 추가
+ * 25. 7. 13.        inari       수정할 태그 리스트 추가
  *
  * @param imageName 이미지 이름 (최대 100자)
  * @param imageContent 이미지 설명 (최대 500자)
@@ -28,6 +29,7 @@ import lombok.Builder;
  * @param latitude 위도 (33.0 ~ 43.0, 한국 영토 범위)
  * @param longitude 경도 (124.0 ~ 132.0, 한국 영토 범위)
  * @param tagsToRemove 삭제할 태그 ID 목록
+ * @param tagsToAdd 추가할 태그명 목록
  */
 @Builder
 public record ImageUpdateRequestDto(
@@ -43,6 +45,7 @@ public record ImageUpdateRequestDto(
 	@DecimalMin(value = "124.0", message = "경도는 124.0 이상이어야 합니다.")
 	@DecimalMax(value = "132.0", message = "경도는 132.0 이하여야 합니다.")
 	Double longitude,
-	List<Long> tagsToRemove
+	List<Long> tagsToRemove,
+	List<String> tagsToAdd
 ) {
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/dto/LandingImagesResponse.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/dto/LandingImagesResponse.java
@@ -2,9 +2,6 @@ package com.trackery.trackerybackapiserver.domain.image.dto;
 
 import java.util.List;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
 /**
  * packageName    : com.trackery.trackerybackapiserver.domain.image.dto
  * fileName       : LandingImagesResponse
@@ -15,9 +12,9 @@ import lombok.Getter;
  * DATE              AUTHOR             NOTE
  * -----------------------------------------------------------
  * 25. 2. 14.        inari       최초 생성
+ * 25. 7. 14.        inari       레코드로 변경
+ *
+ * @param imageUrls 랜딩 페이지에 표시될 이미지 URL 목록
  */
-@Getter
-@AllArgsConstructor
-public class LandingImagesResponse {
-	private final List<String> imageUrls;
+public record LandingImagesResponse(List<String> imageUrls) {
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageService.java
@@ -48,10 +48,12 @@ import lombok.extern.slf4j.Slf4j;
  * 25. 6. 22.		 inari		 이미지 수정시 좌표 인서트가 아닌 업데이트로 변경
  * 25. 7. 7.		 inari		 이미지 좌표 인서트시 태그 추가
  * 25. 7. 9.		 inari		 removeAllTagsFromImage로 메서드 분리
- * 25. 7. 10.       inari       	이미지 단건 조회시 태그 추가
+ * 25. 7. 10.        inari       	이미지 단건 조회시 태그 추가
  * 25. 7. 11.		durururuk	 내 이미지 리스트 조회 시 S3에서 이미지 조회 실패한 이미지는 제외하고 결과를 반환하게 수정
  * 25. 7. 11.		durururuk	 중복되는 리스팅 메서드 추출
  * 25. 7. 12.		inari		이미지 수정시 태그 삭제 추가
+ * 25. 7. 13.		inari		이미지 수정시 태그 수정 추가
+ * 25. 7. 14.		inari		updateImageMetadata 코드 복잡도 수정
  */
 @Slf4j
 @Service
@@ -212,6 +214,24 @@ public class ImageService {
 	 */
 	@CacheEvict(value = "publicImageUrls", allEntries = true)
 	public ImageDto updateImageMetadata(Long imageId, Long userId, ImageUpdateRequestDto updateRequest) {
+		Image existingImage = validateImageUpdatePermission(imageId, userId);
+
+		updateBasicImageMetadata(imageId, updateRequest);
+		updateLocationIfProvided(imageId, existingImage, updateRequest);
+		processTagRemoval(imageId, updateRequest);
+		processTagAddition(imageId, updateRequest);
+
+		return getOriginalImageByImageId(userId, imageId);
+	}
+
+	/**
+	 * 이미지 수정 권한을 검증합니다.
+	 * @param imageId 이미지 ID
+	 * @param userId 사용자 ID
+	 * @return 검증된 이미지 엔티티
+	 * @throws ApiException 이미지를 찾을 수 없거나 권한이 없는 경우
+	 */
+	private Image validateImageUpdatePermission(Long imageId, Long userId) {
 		Image existingImage = imageMapper.findImageByImageId(imageId)
 			.orElseThrow(() -> new ApiException(ErrorCode.NOT_FOUND_IMAGE));
 
@@ -219,7 +239,15 @@ public class ImageService {
 			throw new ApiException(ErrorCode.FORBIDDEN);
 		}
 
-		// 기본 메타데이터 수정
+		return existingImage;
+	}
+
+	/**
+	 * 기본 이미지 메타데이터를 수정합니다.
+	 * @param imageId 이미지 ID
+	 * @param updateRequest 수정 요청 데이터
+	 */
+	private void updateBasicImageMetadata(Long imageId, ImageUpdateRequestDto updateRequest) {
 		imageMapper.updateImageMetadata(
 			imageId,
 			updateRequest.imageName(),
@@ -227,42 +255,78 @@ public class ImageService {
 			updateRequest.imageDate(),
 			updateRequest.isPublic()
 		);
+	}
 
-		// 위치 정보가 제공된 경우 위치 정보도 수정
-		if (updateRequest.latitude() != null && updateRequest.longitude() != null) {
-			try {
-				CoordinateDto coordinateDto = new CoordinateDto(
-					updateRequest.latitude(),
-					updateRequest.longitude()
-				);
-
-				// 기존 이미지의 coord_point_id를 사용하여 업데이트
-				Long existingCoordPointId = existingImage.getCoordPoint().getCoordinatePointId();
-				locationService.updateCoordinatePoint(existingCoordPointId, coordinateDto);
-
-				log.info("이미지 위치 정보 수정 완료 - imageId: {}, coord_point_id: {}, 새로운 위치: {}, {}",
-					imageId, existingCoordPointId, updateRequest.latitude(), updateRequest.longitude());
-			} catch (Exception e) {
-				log.error("이미지 위치 정보 수정 실패 - imageId: {}, 에러: {}", imageId, e.getMessage());
-				throw new ApiException(ErrorCode.UPDATE_FAILED_LOCATION);
-			}
+	/**
+	 * 위치 정보가 제공된 경우 위치 정보를 수정합니다.
+	 * @param imageId 이미지 ID
+	 * @param existingImage 기존 이미지 정보
+	 * @param updateRequest 수정 요청 데이터
+	 */
+	private void updateLocationIfProvided(Long imageId, Image existingImage, ImageUpdateRequestDto updateRequest) {
+		if (updateRequest.latitude() == null || updateRequest.longitude() == null) {
+			return;
 		}
 
-		// 태그 삭제 처리
-		if (updateRequest.tagsToRemove() != null && !updateRequest.tagsToRemove().isEmpty()) {
-			for (Long tagId : updateRequest.tagsToRemove()) {
+		try {
+			CoordinateDto coordinateDto = new CoordinateDto(
+				updateRequest.latitude(),
+				updateRequest.longitude()
+			);
+
+			Long existingCoordPointId = existingImage.getCoordPoint().getCoordinatePointId();
+			locationService.updateCoordinatePoint(existingCoordPointId, coordinateDto);
+
+			log.info("이미지 위치 정보 수정 완료 - imageId: {}, coord_point_id: {}, 새로운 위치: {}, {}",
+				imageId, existingCoordPointId, updateRequest.latitude(), updateRequest.longitude());
+		} catch (Exception e) {
+			log.error("이미지 위치 정보 수정 실패 - imageId: {}, 에러: {}", imageId, e.getMessage());
+			throw new ApiException(ErrorCode.UPDATE_FAILED_LOCATION);
+		}
+	}
+
+	/**
+	 * 삭제할 태그들을 처리합니다.
+	 * @param imageId 이미지 ID
+	 * @param updateRequest 수정 요청 데이터
+	 */
+	private void processTagRemoval(Long imageId, ImageUpdateRequestDto updateRequest) {
+		if (updateRequest.tagsToRemove() == null || updateRequest.tagsToRemove().isEmpty()) {
+			return;
+		}
+
+		for (Long tagId : updateRequest.tagsToRemove()) {
+			try {
+				tagService.removeTagFromImage(imageId, tagId);
+				log.info("이미지에서 태그 삭제 완료 - imageId: {}, tagId: {}", imageId, tagId);
+			} catch (Exception e) {
+				log.warn("이미지에서 태그 삭제 실패 - imageId: {}, tagId: {}, 오류: {}",
+					imageId, tagId, e.getMessage());
+			}
+		}
+	}
+
+	/**
+	 * 추가할 태그들을 처리합니다.
+	 * @param imageId 이미지 ID
+	 * @param updateRequest 수정 요청 데이터
+	 */
+	private void processTagAddition(Long imageId, ImageUpdateRequestDto updateRequest) {
+		if (updateRequest.tagsToAdd() == null || updateRequest.tagsToAdd().isEmpty()) {
+			return;
+		}
+
+		for (String tagName : updateRequest.tagsToAdd()) {
+			if (tagName != null && !tagName.trim().isEmpty()) {
 				try {
-					tagService.removeTagFromImage(imageId, tagId);
-					log.info("이미지에서 태그 삭제 완료 - imageId: {}, tagId: {}", imageId, tagId);
+					tagService.addTagToImageByName(imageId, tagName.trim());
+					log.info("이미지에 태그 추가 완료 - imageId: {}, tagName: {}", imageId, tagName.trim());
 				} catch (Exception e) {
-					log.warn("이미지에서 태그 삭제 실패 - imageId: {}, tagId: {}, 오류: {}",
-						imageId, tagId, e.getMessage());
-					// 태그 삭제 실패해도 다른 수정 작업은 계속 진행
+					log.warn("이미지에 태그 추가 실패 - imageId: {}, tagName: {}, 오류: {}",
+						imageId, tagName.trim(), e.getMessage());
 				}
 			}
 		}
-
-		return getOriginalImageByImageId(userId, imageId);
 	}
 
 	/**

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageService.java
@@ -25,6 +25,7 @@ import com.trackery.trackerybackapiserver.domain.location.dto.LocationInfoDto;
 import com.trackery.trackerybackapiserver.domain.location.entity.CoordinatePoint;
 import com.trackery.trackerybackapiserver.domain.location.service.LocationService;
 import com.trackery.trackerybackapiserver.domain.location.service.LocationUtil;
+import com.trackery.trackerybackapiserver.domain.tag.dto.TagForImageResponseDto;
 import com.trackery.trackerybackapiserver.domain.tag.service.TagService;
 
 import lombok.RequiredArgsConstructor;
@@ -50,6 +51,7 @@ import lombok.extern.slf4j.Slf4j;
  * 25. 7. 10.       inari       	이미지 단건 조회시 태그 추가
  * 25. 7. 11.		durururuk	 내 이미지 리스트 조회 시 S3에서 이미지 조회 실패한 이미지는 제외하고 결과를 반환하게 수정
  * 25. 7. 11.		durururuk	 중복되는 리스팅 메서드 추출
+ * 25. 7. 12.		inari		이미지 수정시 태그 삭제 추가
  */
 @Slf4j
 @Service
@@ -153,6 +155,7 @@ public class ImageService {
 		CoordinatePoint coordPoint = image.getCoordPoint();
 		LocationInfoDto locationInfoDto = LocationUtil.getLocationInfoByCoordinatePoint(coordPoint);
 
+		List<TagForImageResponseDto> imageTags = tagService.getTagsForImageDisplay(image.getImageId());
 		return ImageDto.builder()
 			.imageId(image.getImageId())
 			.userId(image.getUserId())
@@ -166,7 +169,7 @@ public class ImageService {
 			.imageDate(image.getImageDate())
 			.isPublic(image.getIsPublic())
 			.imageUrl(imagePresignedUrl)
-			.tags(tagService.getTagNamesByImageId(image.getImageId()))
+			.tags(imageTags)
 			.build();
 	}
 
@@ -242,6 +245,20 @@ public class ImageService {
 			} catch (Exception e) {
 				log.error("이미지 위치 정보 수정 실패 - imageId: {}, 에러: {}", imageId, e.getMessage());
 				throw new ApiException(ErrorCode.UPDATE_FAILED_LOCATION);
+			}
+		}
+
+		// 태그 삭제 처리
+		if (updateRequest.tagsToRemove() != null && !updateRequest.tagsToRemove().isEmpty()) {
+			for (Long tagId : updateRequest.tagsToRemove()) {
+				try {
+					tagService.removeTagFromImage(imageId, tagId);
+					log.info("이미지에서 태그 삭제 완료 - imageId: {}, tagId: {}", imageId, tagId);
+				} catch (Exception e) {
+					log.warn("이미지에서 태그 삭제 실패 - imageId: {}, tagId: {}, 오류: {}",
+						imageId, tagId, e.getMessage());
+					// 태그 삭제 실패해도 다른 수정 작업은 계속 진행
+				}
 			}
 		}
 

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/location/dto/LocationNameResponseDto.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/location/dto/LocationNameResponseDto.java
@@ -14,12 +14,18 @@ import lombok.Getter;
  * -----------------------------------------------------------
  * 25. 7. 7.        inari       최초 생성
  * 25. 7. 11.       inari       태그 리스트 삭제
+ * 25. 7. 14.       inari       locationName을 sdName과 sggName으로 분리
  */
 @Getter
 @Builder
 public class LocationNameResponseDto {
 	/**
-	 * 위치명.
+	 * 시도명.
 	 */
-	private String locationName;
+	private String sdName;
+
+	/**
+	 * 시군구명.
+	 */
+	private String sggName;
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/location/service/LocationService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/location/service/LocationService.java
@@ -55,19 +55,18 @@ public class LocationService {
 	private static final String SIDO_SIGUNGU_FORMAT = "%s %s";
 
 	/**
-	 * 좌표로 시도 + 시군구 주소를 조회하는 메서드입니다.
+	 * 좌표로 시도명과 시군구명을 분리하여 조회하는 메서드입니다.
 	 * @param coordinateDto 좌표 DTO : latitude(위도), longitude(경도) 둘 다 double 타입입니다.
-	 * @return : 시도 + 시군구 주소를 포함한 응답 DTO
+	 * @return : 시도명과 시군구명을 분리한 응답 DTO
 	 */
 	public LocationNameResponseDto getLocationNameByCoord(CoordinateDto coordinateDto) {
 		JusoSigungu sigungu = locationMapper.findSigunguByCoordinate(coordinateDto).orElseThrow(
 			() -> new ApiException(ErrorCode.NOT_FOUND)
 		);
 
-		String locationName = String.format(SIDO_SIGUNGU_FORMAT, sigungu.getSido().getSidoName(),
-			sigungu.getSigunguName());
 		return LocationNameResponseDto.builder()
-			.locationName(locationName)
+			.sdName(sigungu.getSido().getSidoName())
+			.sggName(sigungu.getSigunguName())
 			.build();
 	}
 

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/tag/controller/TagController.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/tag/controller/TagController.java
@@ -15,9 +15,9 @@ import com.trackery.trackerybackapiserver.domain.common.response.ApiResponse;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.SuccessCode;
 import com.trackery.trackerybackapiserver.domain.tag.dto.TagCreateRequestDto;
-import com.trackery.trackerybackapiserver.domain.tag.dto.TagDefaultRequestDto;
 import com.trackery.trackerybackapiserver.domain.tag.dto.TagNameResponseDto;
 import com.trackery.trackerybackapiserver.domain.tag.dto.TagResponseDto;
+import com.trackery.trackerybackapiserver.domain.tag.dto.TagSeasonRequestDto;
 import com.trackery.trackerybackapiserver.domain.tag.service.TagService;
 
 import jakarta.validation.Valid;
@@ -96,16 +96,15 @@ public class TagController {
 	}
 
 	/**
-	 * 날짜 정보와 좌표 정보를 기반으로 기본 태그명 목록을 반환합니다.
-	 * @param request 날짜 및 좌표 정보 요청 데이터
-	 * @return 계절 태그명 목록 + 지역 태그명 목록 (좌표 제공시)
+	 * 날짜 정보를 기반으로 계절 태그명 목록을 반환합니다.
+	 * @param request 날짜 정보 요청 데이터
+	 * @return 계절 태그명 목록
 	 */
-	@PostMapping("/default")
-	public ResponseEntity<ApiResponse<List<TagNameResponseDto>>> getDefaultTags(
-			@RequestBody @Valid TagDefaultRequestDto request) {
+	@PostMapping("/season")
+	public ResponseEntity<ApiResponse<List<TagNameResponseDto>>> getSeasonTags(
+			@RequestBody @Valid TagSeasonRequestDto request) {
 
-		List<TagNameResponseDto> response = tagService.createDefaultTags(
-				request.getDate(), request.getCoordinate().latitude(), request.getCoordinate().longitude());
+		List<TagNameResponseDto> response = tagService.createSeasonTags(request.getDate());
 		return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
 	}
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/tag/dto/TagForImageResponseDto.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/tag/dto/TagForImageResponseDto.java
@@ -1,0 +1,33 @@
+package com.trackery.trackerybackapiserver.domain.tag.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * packageName    : com.trackery.trackerybackapiserver.domain.tag.dto
+ * fileName       : TagForImageResponseDto
+ * author         : inari
+ * date           : 25. 7. 12.
+ * description    : 이미지 조회 시 태그 정보를 위한 간소화된 응답 DTO 클래스입니다.
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 25. 7. 12.        inari        최초 생성
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TagForImageResponseDto {
+	/**
+	 * 태그 ID.
+	 */
+	private Long tagId;
+	
+	/**
+	 * 태그명.
+	 */
+	private String tagName;
+}

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/tag/dto/TagForImageResponseDto.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/tag/dto/TagForImageResponseDto.java
@@ -25,7 +25,6 @@ public class TagForImageResponseDto {
 	 * 태그 ID.
 	 */
 	private Long tagId;
-	
 	/**
 	 * 태그명.
 	 */

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/tag/dto/TagSeasonRequestDto.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/tag/dto/TagSeasonRequestDto.java
@@ -1,10 +1,6 @@
 package com.trackery.trackerybackapiserver.domain.tag.dto;
 
-import com.trackery.trackerybackapiserver.domain.location.dto.CoordinateDto;
-
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,24 +8,21 @@ import lombok.NoArgsConstructor;
 
 /**
  * packageName    : com.trackery.trackerybackapiserver.domain.tag.dto
- * fileName       : TagDefaultRequestDto
+ * fileName       : TagSeasonRequestDto
  * author         : inari
  * date           : 25. 7. 10.
- * description    : 기본 태그 생성 요청 DTO 클래스입니다. 날짜 기반 계절 태그와 좌표 기반 지역 태그를 통합 처리합니다.
+ * description    : 기본 태그 생성 요청 DTO 클래스입니다. 날짜 기반 계절 태그 처리합니다.
  * ===========================================================
  * DATE              AUTHOR             NOTE
  * -----------------------------------------------------------
  * 25. 7. 10.        inari       최초 생성
+ * 25. 7. 10.        inari       좌표 제거
  */
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class TagDefaultRequestDto {
+public class TagSeasonRequestDto {
 
 	@NotBlank(message = "날짜는 필수입니다.")
 	private String date;
-
-	@Valid
-	@NotNull(message = "좌표는 필수입니다.")
-	private CoordinateDto coordinate;
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/tag/enums/TagType.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/tag/enums/TagType.java
@@ -16,15 +16,17 @@ import lombok.RequiredArgsConstructor;
  * -----------------------------------------------------------
  * 25. 7. 2.        narilee       	최초 생성
  * 25. 7. 8.        narilee      	@JsonValue 제거
+ * 25. 7. 14.       narilee      	LOCATION태그 시도와 시군구로 분리
  */
 @Getter
 @RequiredArgsConstructor
 public enum TagType {
 	CUSTOM(0, "사용자 정의"),
-	LOCATION(1, "위치"),
-	SEASON(2, "계절"),
-	TIME(3, "시간대"),
-	WEATHER(4, "날씨");
+	SIDO(1, "시도"),
+	SIGUNGU(2, "시군구"),
+	SEASON(3, "계절"),
+	TIME(4, "시간"),
+	WEATHER(5, "날씨");
 
 	/**
 	 * 태그 타입의 고유 코드 (데이터베이스 저장용)
@@ -39,7 +41,7 @@ public enum TagType {
 	/**
 	 * 정수 코드를 사용해 해당하는 TagType enum을 반환합니다.
 	 * 
-	 * @param code 태그 타입 코드 (0: CUSTOM, 1: LOCATION, 2: SEASON, 3: TIME, 4: WEATHER)
+	 * @param code 태그 타입 코드 (0: CUSTOM, 1: SIDO, 2: SIGUNGU, 3: SEASON, 4: TIME, 5: WEATHER)
 	 * @return 해당하는 TagType enum 값
 	 * @throws IllegalArgumentException 유효하지 않은 코드인 경우
 	 */

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/tag/service/TagService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/tag/service/TagService.java
@@ -40,6 +40,7 @@ import lombok.extern.slf4j.Slf4j;
  * 25. 7. 10.       inari       이미지 단건 조회시 태그 추가, 날짜 제거
  * 25. 7. 10.		inari		기본 태그 api 추가
  * 25. 7. 11.		inari		태그 일괄 삭제 구현
+ * 25. 7. 12.		inari		태그 수정 구현
  */
 @Slf4j
 @Service
@@ -161,6 +162,17 @@ public class TagService {
 
 		tagMapper.insertImageTag(imageTag);
 		tagMapper.incrementTagUseCount(tagId);
+	}
+
+	/**
+	 * 태그명으로 태그를 찾거나 생성한 후 이미지에 연결합니다.
+	 * @param imageId 이미지 ID
+	 * @param tagName 태그명
+	 */
+	@Transactional
+	public void addTagToImageByName(Long imageId, String tagName) {
+		Tag tag = findOrCreateTagByName(tagName);
+		addTagToImage(imageId, tag.getTagId());
 	}
 
 	/**

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/tag/service/TagService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/tag/service/TagService.java
@@ -42,6 +42,7 @@ import lombok.extern.slf4j.Slf4j;
  * 25. 7. 11.		inari		태그 일괄 삭제 구현
  * 25. 7. 12.		inari		태그 수정 구현
  * 25. 7. 14.       inari      	LOCATION태그 시도와 시군구로 분리
+ * 25. 7. 14.       inari       프론트에서 태그 요청시 정렬해서 보내게 수정
  */
 @Slf4j
 @Service
@@ -134,6 +135,8 @@ public class TagService {
 
 	/**
 	 * 이미지 조회용 태그 목록을 반환합니다 (ID와 이름만 포함).
+	 * 태그 타입(TagType)에 따라 정렬됩니다. (SIDO, SIGUNGU, SEASON, TIME, WEATHER, CUSTOM 순서)
+	 *
 	 * @param imageId 이미지 ID
 	 * @return 이미지에 연결된 간소화된 태그 목록
 	 */
@@ -141,11 +144,37 @@ public class TagService {
 	public List<TagForImageResponseDto> getTagsForImageDisplay(Long imageId) {
 		List<Tag> tags = tagMapper.findTagsByImageId(imageId);
 		return tags.stream()
+			.sorted((tag1, tag2) -> {
+				// 태그 타입에 따른 사용자 정의 정렬 순서 정의
+				int order1 = getTagTypeOrder(tag1.getTagType());
+				int order2 = getTagTypeOrder(tag2.getTagType());
+				return Integer.compare(order1, order2);
+			})
 			.map(tag -> TagForImageResponseDto.builder()
 				.tagId(tag.getTagId())
 				.tagName(tag.getTagName())
 				.build())
 			.toList();
+	}
+
+	/**
+	 * 태그 타입에 따른 정렬 순서를 반환합니다.
+	 * SIDO(1), SIGUNGU(2), SEASON(3), TIME(4), WEATHER(5) 순서로 우선순위를 가지며,
+	 * CUSTOM(0)은 가장 마지막에 정렬됩니다.
+	 *
+	 * @param tagType 태그 타입
+	 * @return 정렬 순서 (낮은 숫자가 우선)
+	 */
+	private int getTagTypeOrder(TagType tagType) {
+		return switch (tagType) {
+			case SIDO -> 1;
+			case SIGUNGU -> 2;
+			case SEASON -> 3;
+			case TIME -> 4;
+			case WEATHER -> 5;
+			case CUSTOM -> 6; // CUSTOM (0)은 가장 마지막에 정렬
+			default -> Integer.MAX_VALUE; // 정의되지 않은 타입은 마지막으로
+		};
 	}
 
 	/**

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/tag/service/TagService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/tag/service/TagService.java
@@ -15,6 +15,7 @@ import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiEx
 import com.trackery.trackerybackapiserver.domain.location.entity.JusoSigungu;
 import com.trackery.trackerybackapiserver.domain.location.service.LocationService;
 import com.trackery.trackerybackapiserver.domain.tag.dto.TagCreateRequestDto;
+import com.trackery.trackerybackapiserver.domain.tag.dto.TagForImageResponseDto;
 import com.trackery.trackerybackapiserver.domain.tag.dto.TagNameResponseDto;
 import com.trackery.trackerybackapiserver.domain.tag.dto.TagResponseDto;
 import com.trackery.trackerybackapiserver.domain.tag.entity.ImageTag;
@@ -124,6 +125,22 @@ public class TagService {
 		List<Tag> tags = tagMapper.findTagsByImageId(imageId);
 		return tags.stream()
 			.map(tag -> TagNameResponseDto.builder()
+				.tagName(tag.getTagName())
+				.build())
+			.toList();
+	}
+
+	/**
+	 * 이미지 조회용 태그 목록을 반환합니다 (ID와 이름만 포함).
+	 * @param imageId 이미지 ID
+	 * @return 이미지에 연결된 간소화된 태그 목록
+	 */
+	@Transactional(readOnly = true)
+	public List<TagForImageResponseDto> getTagsForImageDisplay(Long imageId) {
+		List<Tag> tags = tagMapper.findTagsByImageId(imageId);
+		return tags.stream()
+			.map(tag -> TagForImageResponseDto.builder()
+				.tagId(tag.getTagId())
 				.tagName(tag.getTagName())
 				.build())
 			.toList();

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/tag/service/TagService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/tag/service/TagService.java
@@ -41,6 +41,7 @@ import lombok.extern.slf4j.Slf4j;
  * 25. 7. 10.		inari		기본 태그 api 추가
  * 25. 7. 11.		inari		태그 일괄 삭제 구현
  * 25. 7. 12.		inari		태그 수정 구현
+ * 25. 7. 14.       inari      	LOCATION태그 시도와 시군구로 분리
  */
 @Slf4j
 @Service
@@ -213,8 +214,8 @@ public class TagService {
 		String sidoName = sigungu.getSido().getSidoName();
 		String sigunguName = sigungu.getSigunguName();
 
-		Tag sidoTag = findOrCreateLocationTag(sidoName);
-		Tag sigunguTag = findOrCreateLocationTag(sigunguName);
+		Tag sidoTag = findOrCreateSidoTag(sidoName);
+		Tag sigunguTag = findOrCreateSigunguTag(sigunguName);
 
 		return List.of(sidoTag, sigunguTag);
 	}
@@ -288,20 +289,43 @@ public class TagService {
 
 
 	/**
-	 * 위치 이름으로 기존 태그를 찾거나 새로 생성합니다.
-	 * @param locationName 위치 이름
-	 * @return 찾았거나 생성된 위치 태그
+	 * 시도 이름으로 기존 태그를 찾거나 새로 생성합니다.
+	 * @param sidoName 시도 이름
+	 * @return 찾았거나 생성된 시도 태그
 	 */
-	private Tag findOrCreateLocationTag(String locationName) {
-		Tag existingTag = tagMapper.findTagByNameAndType(locationName, TagType.LOCATION);
+	private Tag findOrCreateSidoTag(String sidoName) {
+		Tag existingTag = tagMapper.findTagByNameAndType(sidoName, TagType.SIDO);
 
 		if (existingTag != null) {
 			return existingTag;
 		}
 
 		Tag newTag = Tag.builder()
-			.tagName(locationName)
-			.tagType(TagType.LOCATION)
+			.tagName(sidoName)
+			.tagType(TagType.SIDO)
+			.tagUseCount(1L)
+			.createdAt(LocalDateTime.now(ZoneId.of(ASIA_SEOUL)))
+			.build();
+
+		tagMapper.insertTag(newTag);
+		return newTag;
+	}
+
+	/**
+	 * 시군구 이름으로 기존 태그를 찾거나 새로 생성합니다.
+	 * @param sigunguName 시군구 이름
+	 * @return 찾았거나 생성된 시군구 태그
+	 */
+	private Tag findOrCreateSigunguTag(String sigunguName) {
+		Tag existingTag = tagMapper.findTagByNameAndType(sigunguName, TagType.SIGUNGU);
+
+		if (existingTag != null) {
+			return existingTag;
+		}
+
+		Tag newTag = Tag.builder()
+			.tagName(sigunguName)
+			.tagType(TagType.SIGUNGU)
 			.tagUseCount(1L)
 			.createdAt(LocalDateTime.now(ZoneId.of(ASIA_SEOUL)))
 			.build();

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/tag/service/TagService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/tag/service/TagService.java
@@ -416,28 +416,13 @@ public class TagService {
 	}
 
 	/**
-	 * 날짜 문자열과 좌표를 기반으로 기본 태그 목록을 생성합니다.
+	 * 날짜 문자열을 기반으로 계절 태그 목록을 생성합니다.
 	 * @param dateStr 날짜 문자열 (예: "2024 / 1 / 15")
-	 * @param latitude 위도 (선택사항)
-	 * @param longitude 경도 (선택사항)
-	 * @return 생성된 태그명 목록 (시도, 시군구, 계절 순)
+	 * @return 생성된 태그명 목록 (계절 태그)
 	 */
 	@Transactional
-	public List<TagNameResponseDto> createDefaultTags(String dateStr, Double latitude, Double longitude) {
+	public List<TagNameResponseDto> createSeasonTags(String dateStr) {
 		List<TagNameResponseDto> tags = new ArrayList<>();
-		// 지역 태그 생성 (시도, 시군구 순)
-		if (latitude != null && longitude != null) {
-			JusoSigungu sigungu = locationService.findSigunguByCoordinate(latitude, longitude);
-			if (sigungu != null) {
-				String sidoName = sigungu.getSido().getSidoName();
-				String sigunguName = sigungu.getSigunguName();
-				findOrCreateLocationTag(sidoName);
-				findOrCreateLocationTag(sigunguName);
-
-				tags.add(TagNameResponseDto.builder().tagName(sidoName).build());
-				tags.add(TagNameResponseDto.builder().tagName(sigunguName).build());
-			}
-		}
 
 		// 날짜 기반 계절 태그 생성
 		LocalDate date = parseDate(dateStr);

--- a/src/main/resources/data/0.2 insert_default/insert_default_data_2025_07_01.sql
+++ b/src/main/resources/data/0.2 insert_default/insert_default_data_2025_07_01.sql
@@ -13,7 +13,7 @@ INSERT INTO role (role_id, role_name) VALUES
                                           (2, 'MANAGER'),
                                           (3, 'ADMIN');
 
--- tag_type: 1 (위치)
+-- tag_type: 1 (시도)
 
 -- 시도 기본 태그 인서트 (juso_sido 테이블에서 자동 생성)
 INSERT INTO tag (tag_name, tag_type, tag_use_count, created_at)
@@ -21,29 +21,31 @@ SELECT sd_name, 1, 0, NOW()
 FROM juso_sido
 ORDER BY sd_id;
 
+-- tag_type: 2 (시군구)
+
 -- 시군구 기본 태그 인서트 (juso_sigungu 테이블에서 자동 생성)
 INSERT INTO tag (tag_name, tag_type, tag_use_count, created_at)
-SELECT sgg_name, 1, 0, NOW()
+SELECT sgg_name, 2, 0, NOW()
 FROM juso_sigungu
 ORDER BY sgg_id;
 
--- tag_type: 2 (계절)
+-- tag_type: 3 (계절)
 INSERT INTO tag (tag_name, tag_type, tag_use_count, created_at) VALUES
-                                                                    ('봄', 2, 0, NOW()),
-                                                                    ('여름', 2, 0, NOW()),
-                                                                    ('가을', 2, 0, NOW()),
-                                                                    ('겨울', 2, 0, NOW());
+                                                                    ('봄', 3, 0, NOW()),
+                                                                    ('여름', 3, 0, NOW()),
+                                                                    ('가을', 3, 0, NOW()),
+                                                                    ('겨울', 3, 0, NOW());
 
--- tag_type: 3 (시간)
+-- tag_type: 4 (시간)
 INSERT INTO tag (tag_name, tag_type, tag_use_count, created_at) VALUES
-                                                                    ('아침', 3, 0, NOW()),
-                                                                    ('점심', 3, 0, NOW()),
-                                                                    ('저녁', 3, 0, NOW()),
-                                                                    ('밤', 3, 0, NOW());
+                                                                    ('아침', 4, 0, NOW()),
+                                                                    ('점심', 4, 0, NOW()),
+                                                                    ('저녁', 4, 0, NOW()),
+                                                                    ('밤', 4, 0, NOW());
 
--- tag_type: 4 (날씨)
+-- tag_type: 5 (날씨)
 INSERT INTO tag (tag_name, tag_type, tag_use_count, created_at) VALUES
-                                                                    ('맑음', 4, 0, NOW()),
-                                                                    ('흐림', 4, 0, NOW()),
-                                                                    ('비', 4, 0, NOW()),
-                                                                    ('눈', 4, 0, NOW());
+                                                                    ('맑음', 5, 0, NOW()),
+                                                                    ('흐림', 5, 0, NOW()),
+                                                                    ('비', 5, 0, NOW()),
+                                                                    ('눈', 5, 0, NOW());

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/image/controller/ImageControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/image/controller/ImageControllerTest.java
@@ -48,6 +48,7 @@ import com.trackery.trackerybackapiserver.domain.user.entity.CustomUserDetails;
  * 25. 6. 18.		inari		    Spring-Rest-Docs api문서 추가
  * 25. 7. 9.        inari       	테스트코드 수정
  * 25. 7. 10.       inari       	이미지 단건 조회시 태그 추가
+ * 25. 7. 14.       inari       	테스트 코드 수정
  */
 @WebMvcTest(ImageController.class)
 class ImageControllerTest extends CommonMockMvcControllerTestSetUp {
@@ -255,7 +256,9 @@ class ImageControllerTest extends CommonMockMvcControllerTestSetUp {
 					fieldWithPath("imageDate").description("수정할 이미지 촬영 날짜 (선택사항)").optional(),
 					fieldWithPath("isPublic").description("수정할 공개 여부 (0: 비공개, 1: 공개, 선택사항)").optional(),
 					fieldWithPath("latitude").description("수정할 위도 (33.0-43.0, 선택사항)").optional(),
-					fieldWithPath("longitude").description("수정할 경도 (124.0-132.0, 선택사항)").optional()
+					fieldWithPath("longitude").description("수정할 경도 (124.0-132.0, 선택사항)").optional(),
+					fieldWithPath("tagsToRemove").description("삭제할 태그 ID 목록 (선택사항)").optional(),
+					fieldWithPath("tagsToAdd").description("추가할 태그명 목록 (선택사항)").optional()
 				),
 				responseFields(
 					fieldWithPath("code").description("상태 코드"),
@@ -335,7 +338,9 @@ class ImageControllerTest extends CommonMockMvcControllerTestSetUp {
 					fieldWithPath("imageDate").description("수정할 이미지 촬영 날짜").optional(),
 					fieldWithPath("isPublic").description("수정할 공개 여부 (0: 비공개, 1: 공개)"),
 					fieldWithPath("latitude").description("수정할 위도 (33.0-43.0)"),
-					fieldWithPath("longitude").description("수정할 경도 (124.0-132.0)")
+					fieldWithPath("longitude").description("수정할 경도 (124.0-132.0)"),
+					fieldWithPath("tagsToRemove").description("삭제할 태그 ID 목록 (선택사항)").optional(),
+					fieldWithPath("tagsToAdd").description("추가할 태그명 목록 (선택사항)").optional()
 				),
 				responseFields(
 					fieldWithPath("code").description("상태 코드"),
@@ -417,7 +422,7 @@ class ImageControllerTest extends CommonMockMvcControllerTestSetUp {
 					fieldWithPath("message").description("응답 메시지"),
 					fieldWithPath("data[].tagId").description("태그 ID"),
 					fieldWithPath("data[].tagName").description("태그명"),
-					fieldWithPath("data[].tagType").description("태그 타입(CUSTOM, LOCATION 등)"),
+					fieldWithPath("data[].tagType").description("태그 타입(CUSTOM, SIDO, SIGUNGU 등)"),
 					fieldWithPath("data[].tagUseCount").description("태그 사용 횟수"),
 					fieldWithPath("data[].createdAt").description("태그 생성 시간")
 				)
@@ -522,7 +527,7 @@ class ImageControllerTest extends CommonMockMvcControllerTestSetUp {
 					fieldWithPath("message").description("응답 메시지"),
 					fieldWithPath("data.tagId").description("새로운 태그 ID"),
 					fieldWithPath("data.tagName").description("새로운 태그명"),
-					fieldWithPath("data.tagType").description("태그 타입(CUSTOM, LOCATION 등)"),
+					fieldWithPath("data.tagType").description("태그 타입(CUSTOM, SIDO, SIGUNGU 등)"),
 					fieldWithPath("data.tagUseCount").description("태그 사용 횟수"),
 					fieldWithPath("data.createdAt").description("태그 생성 시간")
 				)

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/image/service/ImageServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/image/service/ImageServiceTest.java
@@ -51,6 +51,7 @@ import com.trackery.trackerybackapiserver.domain.tag.service.TagService;
  * 25. 5. 19.		durururuk	이미지 조회 단위 테스트 작성
  * 25. 6. 20.		inari		이미지 삭제 및 수정 테스트 작성
  * 25. 7. 10.       inari       	이미지 단건 조회시 태그 추가
+ * 25. 7. 14.       inari       테스트 코드 수정
  */
 @ExtendWith(MockitoExtension.class)
 class ImageServiceTest {
@@ -175,7 +176,6 @@ class ImageServiceTest {
 			when(imageS3Service.generatePreSignedGetUrl(anyString(), eq(testUserId), eq("original"))).thenReturn(
 				testPresignedUrl);
 			when(imageMapper.findImageByImageId(5L)).thenReturn(Optional.of(testImage1));
-			when(tagService.getTagNamesByImageId(testImageId)).thenReturn(List.of());
 
 			ImageDto result = imageService.getOriginalImageByImageId(testUserId, 5L);
 
@@ -303,7 +303,6 @@ class ImageServiceTest {
 			when(imageMapper.findImageByImageId(testImageId)).thenReturn(Optional.of(publicImage));
 			when(imageS3Service.generatePreSignedGetUrl(anyString(), eq(testUserId), eq("original"))).thenReturn(
 				testPresignedUrl);
-			when(tagService.getTagNamesByImageId(testImageId)).thenReturn(List.of());
 
 			ImageDto result = imageService.getOriginalImageByImageId(testUserId, testImageId);
 
@@ -507,7 +506,6 @@ class ImageServiceTest {
 				.thenReturn(1);
 			when(imageS3Service.generatePreSignedGetUrl(anyString(), eq(userId), eq("original"))).thenReturn(
 				"test-url");
-			when(tagService.getTagNamesByImageId(imageId)).thenReturn(List.of());
 
 			ImageDto result = imageService.updateImageMetadata(imageId, userId, updateRequest);
 
@@ -565,9 +563,9 @@ class ImageServiceTest {
 			when(imageMapper.updateImageMetadata(eq(imageId), eq("수정된 이미지"), eq("수정된 설명"), isNull(), eq(1)))
 				.thenReturn(1);
 			when(locationService.updateCoordinatePoint(eq(1L), any())).thenReturn(1);
+			when(tagService.getTagsForImageDisplay(imageId)).thenReturn(List.of());
 			when(imageS3Service.generatePreSignedGetUrl(anyString(), eq(userId), eq("original"))).thenReturn(
 				"test-url");
-			when(tagService.getTagNamesByImageId(imageId)).thenReturn(List.of());
 
 			ImageDto result = imageService.updateImageMetadata(imageId, userId, updateRequest);
 
@@ -575,6 +573,33 @@ class ImageServiceTest {
 			verify(imageMapper, times(2)).findImageByImageId(imageId);
 			verify(imageMapper).updateImageMetadata(eq(imageId), eq("수정된 이미지"), eq("수정된 설명"), isNull(), eq(1));
 			verify(locationService).updateCoordinatePoint(eq(1L), any());
+			verify(tagService, times(1)).getTagsForImageDisplay(imageId);
+		}
+
+		@Test
+		@DisplayName("성공 - 날짜 정보 포함 메타데이터 수정")
+		void updateImageMetadata_withDate_success() {
+			LocalDateTime newDate = LocalDateTime.of(2023, 6, 15, 12, 0);
+			ImageUpdateRequestDto updateRequest = ImageUpdateRequestDto.builder()
+				.imageName("수정된 이미지")
+				.imageContent("수정된 설명")
+				.isPublic(1)
+				.imageDate(newDate)
+				.build();
+
+			when(imageMapper.findImageByImageId(imageId)).thenReturn(Optional.of(existingImage));
+			when(imageMapper.updateImageMetadata(eq(imageId), eq("수정된 이미지"), eq("수정된 설명"), eq(newDate), eq(1)))
+				.thenReturn(1);
+			when(tagService.getTagsForImageDisplay(imageId)).thenReturn(List.of());
+			when(imageS3Service.generatePreSignedGetUrl(anyString(), eq(userId), eq("original"))).thenReturn(
+				"test-url");
+
+			ImageDto result = imageService.updateImageMetadata(imageId, userId, updateRequest);
+
+			assertNotNull(result);
+			verify(imageMapper, times(2)).findImageByImageId(imageId);
+			verify(imageMapper).updateImageMetadata(eq(imageId), eq("수정된 이미지"), eq("수정된 설명"), eq(newDate), eq(1));
+			verify(tagService, times(1)).getTagsForImageDisplay(imageId);
 		}
 	}
 
@@ -631,6 +656,205 @@ class ImageServiceTest {
 
 			verify(imageMapper).findImageByImageId(imageId);
 			verify(imageMapper, never()).deleteImage(any());
+		}
+
+		@Test
+		@DisplayName("성공 - 태그 연결된 이미지 삭제 시 태그 연결 해제")
+		void deleteImage_WithTagsSuccess() {
+			// given
+			when(imageMapper.findImageByImageId(imageId)).thenReturn(Optional.of(existingImage));
+			when(imageMapper.deleteImage(imageId)).thenReturn(1);
+			doNothing().when(tagService).removeAllTagsFromImage(imageId);
+
+			// when
+			assertDoesNotThrow(() -> imageService.deleteImage(imageId, userId));
+
+			// then
+			verify(imageMapper).findImageByImageId(imageId);
+			verify(tagService).removeAllTagsFromImage(imageId);
+			verify(imageMapper).deleteImage(imageId);
+		}
+	}
+
+	@Nested
+	@DisplayName("이미지 태그 관련 테스트")
+	class ImageTagTest {
+		private final Long imageId = 1L;
+		private final Long userId = 2L;
+		
+		@Test
+		@DisplayName("성공 - 이미지 단건 조회 시 태그 포함")
+		void getOriginalImageByImageId_WithTags() {
+			// given
+			JusoSido sido = new JusoSido();
+			ReflectionTestUtils.setField(sido, "sidoId", 1L);
+			ReflectionTestUtils.setField(sido, "sidoName", "서울특별시");
+
+			JusoSigungu sigungu = new JusoSigungu();
+			ReflectionTestUtils.setField(sigungu, "sigunguId", 1L);
+			ReflectionTestUtils.setField(sigungu, "sigunguName", "강남구");
+			ReflectionTestUtils.setField(sigungu, "sido", sido);
+
+			Coordinate coordinate = new Coordinate(127.0495556, 37.5398056);
+			PrecisionModel precisionModel = new PrecisionModel(PrecisionModel.FLOATING);
+			org.locationtech.jts.geom.GeometryFactory geometryFactory = new org.locationtech.jts.geom.GeometryFactory(precisionModel, 4326);
+			Point testPoint = geometryFactory.createPoint(coordinate);
+
+			CoordinatePoint coordPoint = new CoordinatePoint();
+			ReflectionTestUtils.setField(coordPoint, "coordinatePointId", 1L);
+			ReflectionTestUtils.setField(coordPoint, "coordinatePointName", "테스트 좌표");
+			ReflectionTestUtils.setField(coordPoint, "coordinatePointPoint", testPoint);
+			ReflectionTestUtils.setField(coordPoint, "sigungu", sigungu);
+			
+			Image image = Image.builder()
+				.imageName("테스트 이미지")
+				.userId(userId)
+				.coordPoint(coordPoint)
+				.build();
+			ReflectionTestUtils.setField(image, "imageId", imageId);
+			
+			when(imageMapper.findImageByImageId(imageId)).thenReturn(Optional.of(image));
+			when(tagService.getTagsForImageDisplay(imageId)).thenReturn(List.of());
+			when(imageS3Service.generatePreSignedGetUrl(any(), any(), any())).thenReturn("http://test.url");
+
+			// when
+			ImageDto result = imageService.getOriginalImageByImageId(userId, imageId);
+
+			// then
+			assertNotNull(result);
+			assertEquals(imageId, result.getImageId());
+			assertNotNull(result.getTags());
+			verify(tagService).getTagsForImageDisplay(imageId);
+		}
+		
+		@Test
+		@DisplayName("성공 - 이미지 목록 조회 시 태그 포함")
+		void getImageListByUserId_WithTags() {
+			// given
+			ImageSearchByUserIdDto searchDto = ImageSearchByUserIdDto.builder()
+				.userId(userId)
+				.build();
+			
+			ImageInfoForThumbnailDto thumbnailDto = new ImageInfoForThumbnailDto();
+			ReflectionTestUtils.setField(thumbnailDto, "imageId", 1L);
+			ReflectionTestUtils.setField(thumbnailDto, "userId", userId);
+			ReflectionTestUtils.setField(thumbnailDto, "imageName", "테스트 이미지");
+			
+			when(imageMapper.findImageThumbnailsByUserId(any())).thenReturn(List.of(thumbnailDto));
+			when(imageS3Service.generatePreSignedGetUrl(any(), any(), any())).thenReturn("http://test.url");
+			
+			// when
+			PageInfo<ImageThumbnailDto> result = imageService.getImageListByUserId(searchDto);
+
+			// then
+			assertNotNull(result);
+			assertNotNull(result.getList());
+			verify(imageMapper).findImageThumbnailsByUserId(any());
+		}
+
+		@Test
+		@DisplayName("성공 - 이미지 업데이트 시 태그 추가/삭제")
+		void updateImageMetadata_WithTagOperations() {
+			// given
+			JusoSido sido = new JusoSido();
+			ReflectionTestUtils.setField(sido, "sidoId", 1L);
+			ReflectionTestUtils.setField(sido, "sidoName", "서울특별시");
+
+			JusoSigungu sigungu = new JusoSigungu();
+			ReflectionTestUtils.setField(sigungu, "sigunguId", 1L);
+			ReflectionTestUtils.setField(sigungu, "sigunguName", "강남구");
+			ReflectionTestUtils.setField(sigungu, "sido", sido);
+
+			Coordinate coordinate = new Coordinate(127.0495556, 37.5398056);
+			PrecisionModel precisionModel = new PrecisionModel(PrecisionModel.FLOATING);
+			org.locationtech.jts.geom.GeometryFactory geometryFactory = new org.locationtech.jts.geom.GeometryFactory(precisionModel, 4326);
+			Point testPoint = geometryFactory.createPoint(coordinate);
+
+			CoordinatePoint coordPoint = new CoordinatePoint();
+			ReflectionTestUtils.setField(coordPoint, "coordinatePointId", 1L);
+			ReflectionTestUtils.setField(coordPoint, "coordinatePointName", "테스트 좌표");
+			ReflectionTestUtils.setField(coordPoint, "coordinatePointPoint", testPoint);
+			ReflectionTestUtils.setField(coordPoint, "sigungu", sigungu);
+
+			Image existingImage = Image.builder()
+				.imageName("기존 이미지")
+				.userId(userId)
+				.coordPoint(coordPoint)
+				.build();
+			ReflectionTestUtils.setField(existingImage, "imageId", imageId);
+			
+			ImageUpdateRequestDto updateRequest = ImageUpdateRequestDto.builder()
+				.imageName("수정된 이미지")
+				.tagsToAdd(List.of("새태그1", "새태그2"))
+				.tagsToRemove(List.of(1L, 2L))
+				.build();
+			
+			when(imageMapper.findImageByImageId(imageId)).thenReturn(Optional.of(existingImage));
+			when(imageMapper.updateImageMetadata(any(), any(), any(), any(), any())).thenReturn(1);
+			when(tagService.getTagsForImageDisplay(imageId)).thenReturn(List.of());
+			when(imageS3Service.generatePreSignedGetUrl(any(), any(), any())).thenReturn("http://test.url");
+			doNothing().when(tagService).addTagToImageByName(any(), any());
+			doNothing().when(tagService).removeTagFromImage(any(), any());
+
+			// when
+			ImageDto result = imageService.updateImageMetadata(imageId, userId, updateRequest);
+
+			// then
+			assertNotNull(result);
+			verify(tagService).addTagToImageByName(imageId, "새태그1");
+			verify(tagService).addTagToImageByName(imageId, "새태그2");
+			verify(tagService).removeTagFromImage(imageId, 1L);
+			verify(tagService).removeTagFromImage(imageId, 2L);
+		}
+
+		@Test
+		@DisplayName("성공 - 좌표 변경 시 위치 기반 태그 자동 생성")
+		void updateImageMetadata_WithLocationChange() {
+			// given
+			JusoSido sido = new JusoSido();
+			ReflectionTestUtils.setField(sido, "sidoId", 1L);
+			ReflectionTestUtils.setField(sido, "sidoName", "서울특별시");
+
+			JusoSigungu sigungu = new JusoSigungu();
+			ReflectionTestUtils.setField(sigungu, "sigunguId", 1L);
+			ReflectionTestUtils.setField(sigungu, "sigunguName", "강남구");
+			ReflectionTestUtils.setField(sigungu, "sido", sido);
+
+			Coordinate coordinate = new Coordinate(127.0495556, 37.5398056);
+			PrecisionModel precisionModel = new PrecisionModel(PrecisionModel.FLOATING);
+			org.locationtech.jts.geom.GeometryFactory geometryFactory = new org.locationtech.jts.geom.GeometryFactory(precisionModel, 4326);
+			Point testPoint = geometryFactory.createPoint(coordinate);
+
+			CoordinatePoint coordPoint = new CoordinatePoint();
+			ReflectionTestUtils.setField(coordPoint, "coordinatePointId", 1L);
+			ReflectionTestUtils.setField(coordPoint, "coordinatePointName", "테스트 좌표");
+			ReflectionTestUtils.setField(coordPoint, "coordinatePointPoint", testPoint);
+			ReflectionTestUtils.setField(coordPoint, "sigungu", sigungu);
+			
+			Image existingImage = Image.builder()
+				.imageName("기존 이미지")
+				.userId(userId)
+				.coordPoint(coordPoint)
+				.build();
+			ReflectionTestUtils.setField(existingImage, "imageId", imageId);
+			
+			ImageUpdateRequestDto updateRequest = ImageUpdateRequestDto.builder()
+				.latitude(37.5665)
+				.longitude(126.978)
+				.build();
+			
+			when(imageMapper.findImageByImageId(imageId)).thenReturn(Optional.of(existingImage));
+			when(imageMapper.updateImageMetadata(any(), any(), any(), any(), any())).thenReturn(1);
+			when(locationService.updateCoordinatePoint(eq(1L), any())).thenReturn(1);
+			when(tagService.getTagsForImageDisplay(imageId)).thenReturn(List.of());
+			when(imageS3Service.generatePreSignedGetUrl(any(), any(), any())).thenReturn("http://test.url");
+
+			// when
+			ImageDto result = imageService.updateImageMetadata(imageId, userId, updateRequest);
+
+			// then
+			assertNotNull(result);
+			verify(locationService).updateCoordinatePoint(eq(1L), any());
 		}
 	}
 }

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/location/controller/LocationControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/location/controller/LocationControllerTest.java
@@ -47,6 +47,7 @@ import com.trackery.trackerybackapiserver.domain.user.entity.CustomUserDetails;
  * 25. 6. 13.		inari			테스트 추가
  * 25. 6. 15.		inari			Spring-Rest-Docs api문서 추가
  * 25. 7. 11.		inari			태그 제거
+ * 25. 7. 14.       inari       	테스트 코드 수정
  */
 @WebMvcTest(LocationController.class)
 public class LocationControllerTest extends CommonMockMvcControllerTestSetUp {
@@ -72,7 +73,8 @@ public class LocationControllerTest extends CommonMockMvcControllerTestSetUp {
 			CoordinateDto coordinateDto = new CoordinateDto(37.5665, 126.9780);
 
 			LocationNameResponseDto locationResponse = LocationNameResponseDto.builder()
-				.locationName("서울특별시 동작구")
+				.sdName("서울특별시")
+				.sggName("동작구")
 				.build();
 
 			when(locationService.getLocationNameByCoord(coordinateDto)).thenReturn(locationResponse);
@@ -85,7 +87,8 @@ public class LocationControllerTest extends CommonMockMvcControllerTestSetUp {
 
 			result
 				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.data.locationName").value("서울특별시 동작구"));
+				.andExpect(jsonPath("$.data.sdName").value("서울특별시"))
+				.andExpect(jsonPath("$.data.sggName").value("동작구"));
 
 			result.andDo(document("get-location-name-by-coordinate-success",
 				requestFields(
@@ -95,7 +98,8 @@ public class LocationControllerTest extends CommonMockMvcControllerTestSetUp {
 				responseFields(
 					fieldWithPath("code").description("응답 코드"),
 					fieldWithPath("message").description("응답 메시지"),
-					fieldWithPath("data.locationName").description("주소명")
+					fieldWithPath("data.sdName").description("시도명"),
+					fieldWithPath("data.sggName").description("시군구명")
 				)
 			));
 		}

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/location/service/LocationServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/location/service/LocationServiceTest.java
@@ -44,6 +44,7 @@ import com.trackery.trackerybackapiserver.domain.location.mapper.LocationMapper;
  * 25. 6. 13.		Narilee			최초 생성
  * 25. 6. 22.		Narilee			좌표 업데이트 테스트 추가
  * 25. 7. 11.		inari			태그 제거
+ * 25. 7. 14.       inari       	테스트 코드 수정
  */
 
 @ExtendWith(MockitoExtension.class)
@@ -80,7 +81,8 @@ class LocationServiceTest {
 
 			LocationNameResponseDto result = locationService.getLocationNameByCoord(coordinateDto);
 
-			assertEquals("서울특별시 동작구", result.getLocationName());
+			assertEquals("서울특별시", result.getSdName());
+			assertEquals("동작구", result.getSggName());
 			verify(locationMapper, times(1)).findSigunguByCoordinate(coordinateDto);
 		}
 

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/tag/controller/TagControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/tag/controller/TagControllerTest.java
@@ -21,13 +21,14 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
+import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
 import com.trackery.trackerybackapiserver.domain.config.CommonMockMvcControllerTestSetUp;
 import com.trackery.trackerybackapiserver.domain.image.service.ImageService;
-import com.trackery.trackerybackapiserver.domain.location.dto.CoordinateDto;
 import com.trackery.trackerybackapiserver.domain.tag.dto.TagCreateRequestDto;
-import com.trackery.trackerybackapiserver.domain.tag.dto.TagDefaultRequestDto;
 import com.trackery.trackerybackapiserver.domain.tag.dto.TagNameResponseDto;
 import com.trackery.trackerybackapiserver.domain.tag.dto.TagResponseDto;
+import com.trackery.trackerybackapiserver.domain.tag.dto.TagSeasonRequestDto;
 import com.trackery.trackerybackapiserver.domain.tag.enums.TagType;
 import com.trackery.trackerybackapiserver.domain.tag.service.TagService;
 import com.trackery.trackerybackapiserver.domain.user.entity.CustomUserDetails;
@@ -43,7 +44,7 @@ import com.trackery.trackerybackapiserver.domain.user.entity.CustomUserDetails;
  * -----------------------------------------------------------
  * 25. 7. 8.        inari       최초 생성
  * 25. 7. 9.        inari       테스트코드 수정
- * 25. 7. 9.        inari       테스트코드 수정
+ * 25. 7. 14.       inari       테스트 코드 수정
  */
 @WebMvcTest(TagController.class)
 class TagControllerTest extends CommonMockMvcControllerTestSetUp {
@@ -59,7 +60,7 @@ class TagControllerTest extends CommonMockMvcControllerTestSetUp {
 
 	private TagResponseDto tagResponseDto;
 	private TagCreateRequestDto createRequestDto;
-	private TagDefaultRequestDto defaultRequestDto;
+	private TagSeasonRequestDto defaultRequestDto;
 
 	@BeforeEach
 	void setUp() {
@@ -76,7 +77,7 @@ class TagControllerTest extends CommonMockMvcControllerTestSetUp {
 			.tagType(TagType.CUSTOM.getCode())
 			.build();
 
-		defaultRequestDto = new TagDefaultRequestDto("2024/7/15", new CoordinateDto(37.5665, 126.9780));
+		defaultRequestDto = new TagSeasonRequestDto("2024/7/15");
 	}
 
 	@Nested
@@ -104,14 +105,14 @@ class TagControllerTest extends CommonMockMvcControllerTestSetUp {
 				.andDo(document("tag-create",
 					requestFields(
 						fieldWithPath("tagName").description("생성할 태그명"),
-						fieldWithPath("tagType").description("태그 타입 코드 (0: CUSTOM, 1: LOCATION, 2: SEASON, 3: TIME, 4: WEATHER)")
+						fieldWithPath("tagType").description("태그 타입 코드 (0: CUSTOM, 1: SIDO, 2: SIGUNGU, 3: SEASON, 4: TIME, 5: WEATHER)")
 					),
 					relaxedResponseFields(
 						fieldWithPath("code").description("응답 코드"),
 						fieldWithPath("message").description("응답 메시지"),
 						fieldWithPath("data.tagId").description("태그 ID"),
 						fieldWithPath("data.tagName").description("태그명"),
-						fieldWithPath("data.tagType").description("태그 타입(CUSTOM, LOCATION 등)"),
+						fieldWithPath("data.tagType").description("태그 타입(CUSTOM, SIDO, SIGUNGU 등)"),
 						fieldWithPath("data.tagUseCount").description("태그 사용 횟수"),
 						fieldWithPath("data.createdAt").description("태그 생성 시간")
 					)
@@ -146,7 +147,7 @@ class TagControllerTest extends CommonMockMvcControllerTestSetUp {
 						fieldWithPath("message").description("응답 메시지"),
 						fieldWithPath("data[].tagId").description("태그 ID"),
 						fieldWithPath("data[].tagName").description("태그명"),
-						fieldWithPath("data[].tagType").description("태그 타입(CUSTOM, LOCATION 등)"),
+						fieldWithPath("data[].tagType").description("태그 타입(CUSTOM, SIDO, SIGUNGU 등)"),
 						fieldWithPath("data[].tagUseCount").description("태그 사용 횟수"),
 						fieldWithPath("data[].createdAt").description("태그 생성 시간")
 					)
@@ -175,7 +176,7 @@ class TagControllerTest extends CommonMockMvcControllerTestSetUp {
 						fieldWithPath("message").description("응답 메시지"),
 						fieldWithPath("data[].tagId").description("태그 ID"),
 						fieldWithPath("data[].tagName").description("태그명"),
-						fieldWithPath("data[].tagType").description("태그 타입(CUSTOM, LOCATION 등)"),
+						fieldWithPath("data[].tagType").description("태그 타입(CUSTOM, SIDO, SIGUNGU 등)"),
 						fieldWithPath("data[].tagUseCount").description("태그 사용 횟수"),
 						fieldWithPath("data[].createdAt").description("태그 생성 시간")
 					)
@@ -236,20 +237,20 @@ class TagControllerTest extends CommonMockMvcControllerTestSetUp {
 	}
 
 	@Nested
-	@DisplayName("기본 태그 생성 API 테스트")
-	class DefaultTagTest {
+	@DisplayName("계절 태그 생성 API 테스트")
+	class SeasonTagTest {
 
 		@Test
-		@DisplayName("기본 태그 생성 성공")
-		void getDefaultTags_Success() throws Exception {
+		@DisplayName("계절 태그 생성 성공")
+		void getSeasonTags_Success() throws Exception {
 			// given
 			List<TagNameResponseDto> defaultTags = List.of(
 				TagNameResponseDto.builder().tagName("여름").build()
 			);
-			when(tagService.createDefaultTags("2024/7/15", 37.5665, 126.9780)).thenReturn(defaultTags);
+			when(tagService.createSeasonTags("2024/7/15")).thenReturn(defaultTags);
 
 			// when & then
-			mockMvc.perform(post("/api/tags/default")
+			mockMvc.perform(post("/api/tags/season")
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(defaultRequestDto))
 					.with(csrf())
@@ -258,20 +259,180 @@ class TagControllerTest extends CommonMockMvcControllerTestSetUp {
 				.andExpect(jsonPath("$.code").value(200))
 				.andExpect(jsonPath("$.data").isArray())
 				.andExpect(jsonPath("$.data[0].tagName").value("여름"))
-				.andDo(document("tag-create-default",
+				.andDo(document("tag-create-season",
 					requestFields(
-						fieldWithPath("date").description("날짜 문자열 (예: 2024/7/15)"),
-						fieldWithPath("coordinate.latitude").description("위도"),
-						fieldWithPath("coordinate.longitude").description("경도")
+						fieldWithPath("date").description("날짜 문자열 (예: 2024/7/15)")
 					),
 					relaxedResponseFields(
 						fieldWithPath("code").description("응답 코드"),
 						fieldWithPath("message").description("응답 메시지"),
-						fieldWithPath("data[].tagName").description("생성된 기본 태그명")
+						fieldWithPath("data[].tagName").description("생성된 계절 태그명")
 					)
 				));
 
-			verify(tagService).createDefaultTags("2024/7/15", 37.5665, 126.9780);
+			verify(tagService).createSeasonTags("2024/7/15");
+		}
+
+		@Test
+		@DisplayName("잘못된 날짜 형식으로 계절 태그 생성 요청 실패")
+		void getSeasonTags_InvalidDate() throws Exception {
+			// given
+			TagSeasonRequestDto invalidRequestDto = new TagSeasonRequestDto("invalid-date");
+			when(tagService.createSeasonTags("invalid-date"))
+				.thenThrow(new ApiException(ErrorCode.BAD_REQUEST));
+
+			// when & then
+			mockMvc.perform(post("/api/tags/season")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(invalidRequestDto))
+					.with(csrf())
+					.with(user(createTestUser())))
+				.andExpect(status().isBadRequest());
+		}
+
+		@Test
+		@DisplayName("빈 날짜로 계절 태그 생성 요청 실패")
+		void getSeasonTags_EmptyDate() throws Exception {
+			// given
+			TagSeasonRequestDto emptyRequestDto = new TagSeasonRequestDto("");
+
+			// when & then
+			mockMvc.perform(post("/api/tags/season")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(emptyRequestDto))
+					.with(csrf())
+					.with(user(createTestUser())))
+				.andExpect(status().isBadRequest());
+		}
+	}
+
+	@Nested
+	@DisplayName("태그 생성 검증 테스트")
+	class TagCreateValidationTest {
+
+		@Test
+		@DisplayName("빈 태그명으로 태그 생성 성공")
+		void createTag_EmptyTagName() throws Exception {
+			// given
+			TagCreateRequestDto requestDto = TagCreateRequestDto.builder()
+				.tagName("")
+				.tagType(TagType.CUSTOM.getCode())
+				.build();
+
+			TagResponseDto responseDto = TagResponseDto.builder()
+				.tagId(1L)
+				.tagName("")
+				.tagType(TagType.CUSTOM)
+				.tagUseCount(0L)
+				.build();
+
+			when(tagService.createTag(any(TagCreateRequestDto.class)))
+				.thenReturn(responseDto);
+
+			// when & then
+			mockMvc.perform(post("/api/tags")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(requestDto))
+					.with(csrf())
+					.with(user(createTestUser())))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.tagName").value(""));
+		}
+
+		@Test
+		@DisplayName("null 태그명으로 태그 생성 성공")
+		void createTag_NullTagName() throws Exception {
+			// given
+			TagCreateRequestDto requestDto = TagCreateRequestDto.builder()
+				.tagName(null)
+				.tagType(TagType.CUSTOM.getCode())
+				.build();
+
+			TagResponseDto responseDto = TagResponseDto.builder()
+				.tagId(2L)
+				.tagName(null)
+				.tagType(TagType.CUSTOM)
+				.tagUseCount(0L)
+				.build();
+
+			when(tagService.createTag(any(TagCreateRequestDto.class)))
+				.thenReturn(responseDto);
+
+			// when & then
+			mockMvc.perform(post("/api/tags")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(requestDto))
+					.with(csrf())
+					.with(user(createTestUser())))
+				.andExpect(status().isOk());
+		}
+	}
+
+	@Nested
+	@DisplayName("태그 조회 추가 테스트")
+	class AdditionalTagRetrievalTest {
+
+		@Test
+		@DisplayName("빈 태그 목록 조회 시 빈 배열 반환")
+		void getAllTags_EmptyList() throws Exception {
+			// given
+			when(tagService.getAllTags()).thenReturn(List.of());
+
+			// when & then
+			mockMvc.perform(get("/api/tags")
+					.with(user(createTestUser())))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.code").value(200))
+				.andExpect(jsonPath("$.data").isArray())
+				.andExpect(jsonPath("$.data").isEmpty());
+
+			verify(tagService).getAllTags();
+		}
+
+		@Test
+		@DisplayName("여러 태그 조회 시 올바른 순서로 반환")
+		void getAllTags_MultipleTagsOrdered() throws Exception {
+			// given
+			List<TagResponseDto> tags = List.of(
+				TagResponseDto.builder()
+					.tagId(1L)
+					.tagName("서울특별시")
+					.tagType(TagType.SIDO)
+					.tagUseCount(5L)
+					.createdAt(LocalDateTime.now())
+					.build(),
+				TagResponseDto.builder()
+					.tagId(2L)
+					.tagName("강남구")
+					.tagType(TagType.SIGUNGU)
+					.tagUseCount(3L)
+					.createdAt(LocalDateTime.now())
+					.build(),
+				TagResponseDto.builder()
+					.tagId(3L)
+					.tagName("여름")
+					.tagType(TagType.SEASON)
+					.tagUseCount(10L)
+					.createdAt(LocalDateTime.now())
+					.build()
+			);
+			when(tagService.getAllTags()).thenReturn(tags);
+
+			// when & then
+			mockMvc.perform(get("/api/tags")
+					.with(user(createTestUser())))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.code").value(200))
+				.andExpect(jsonPath("$.data").isArray())
+				.andExpect(jsonPath("$.data").hasJsonPath())
+				.andExpect(jsonPath("$.data[0].tagName").value("서울특별시"))
+				.andExpect(jsonPath("$.data[0].tagType").value("SIDO"))
+				.andExpect(jsonPath("$.data[1].tagName").value("강남구"))
+				.andExpect(jsonPath("$.data[1].tagType").value("SIGUNGU"))
+				.andExpect(jsonPath("$.data[2].tagName").value("여름"))
+				.andExpect(jsonPath("$.data[2].tagType").value("SEASON"));
+
+			verify(tagService).getAllTags();
 		}
 	}
 

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/tag/service/TagServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/tag/service/TagServiceTest.java
@@ -38,6 +38,7 @@ import com.trackery.trackerybackapiserver.domain.tag.mapper.TagMapper;
  * -----------------------------------------------------------
  * 25. 7. 8.        inari       최초 생성
  * 25. 7. 11.        inari       최초 생성
+ * 25. 7. 14.        inari       테스트 코드 수정
  */
 @ExtendWith(MockitoExtension.class)
 class TagServiceTest {
@@ -220,8 +221,8 @@ class TagServiceTest {
 			sigungu.setSido(sido);
 
 			when(locationService.findSigunguByCoordinate(latitude, longitude)).thenReturn(sigungu);
-			when(tagMapper.findTagByNameAndType("서울특별시", TagType.LOCATION)).thenReturn(null);
-			when(tagMapper.findTagByNameAndType("종로구", TagType.LOCATION)).thenReturn(null);
+			when(tagMapper.findTagByNameAndType("서울특별시", TagType.SIDO)).thenReturn(null);
+			when(tagMapper.findTagByNameAndType("종로구", TagType.SIGUNGU)).thenReturn(null);
 			doNothing().when(tagMapper).insertTag(any(Tag.class));
 
 			// when
@@ -266,8 +267,8 @@ class TagServiceTest {
 			sigungu.setSido(sido);
 
 			when(locationService.findSigunguByCoordinate(latitude, longitude)).thenReturn(sigungu);
-			when(tagMapper.findTagByNameAndType("서울특별시", TagType.LOCATION)).thenReturn(null);
-			when(tagMapper.findTagByNameAndType("종로구", TagType.LOCATION)).thenReturn(null);
+			when(tagMapper.findTagByNameAndType("서울특별시", TagType.SIDO)).thenReturn(null);
+			when(tagMapper.findTagByNameAndType("종로구", TagType.SIGUNGU)).thenReturn(null);
 			doNothing().when(tagMapper).insertTag(any(Tag.class));
 			doNothing().when(tagMapper).insertImageTag(any());
 			doNothing().when(tagMapper).incrementTagUseCount(any());
@@ -368,7 +369,7 @@ class TagServiceTest {
 			Long tagId = 1L;
 			Tag systemTag = Tag.builder()
 				.tagName("시스템태그")
-				.tagType(TagType.LOCATION)
+				.tagType(TagType.SIDO)
 				.tagUseCount(0L)
 				.build();
 
@@ -485,19 +486,19 @@ class TagServiceTest {
 	}
 
 	@Nested
-	@DisplayName("기본 태그 생성 테스트")
-	class DefaultTagTest {
+	@DisplayName("계절 태그 생성 테스트")
+	class SeasonTagTest {
 
 		@Test
-		@DisplayName("날짜 기반 기본 태그 생성 성공")
-		void createDefaultTags_Success() {
+		@DisplayName("날짜 기반 계절 태그 생성 성공")
+		void createSeasonTags_Success() {
 			// given
 			String dateTimeStr = "2024/7/15 14:30:25";
 			when(tagMapper.findTagByNameAndType("여름", TagType.SEASON)).thenReturn(null);
 			doNothing().when(tagMapper).insertTag(any(Tag.class));
 
 			// when
-			List<TagNameResponseDto> result = tagService.createDefaultTags(dateTimeStr, null, null);
+			List<TagNameResponseDto> result = tagService.createSeasonTags(dateTimeStr);
 
 			// then
 			assertNotNull(result);
@@ -507,27 +508,27 @@ class TagServiceTest {
 		}
 
 		@Test
-		@DisplayName("잘못된 날짜 형식으로 기본 태그 생성 시 예외 발생")
-		void createDefaultTags_InvalidFormat() {
+		@DisplayName("잘못된 날짜 형식으로 계절 태그 생성 시 예외 발생")
+		void createSeasonTags_InvalidFormat() {
 			// given
 			String invalidDateTimeStr = "invalid-date-format";
 
 			// when & then
 			ApiException exception = assertThrows(ApiException.class, 
-				() -> tagService.createDefaultTags(invalidDateTimeStr, null, null));
+				() -> tagService.createSeasonTags(invalidDateTimeStr));
 			assertEquals(ErrorCode.BAD_REQUEST, exception.getErrorCode());
 		}
 
 		@Test
 		@DisplayName("겨울 계절 태그 생성")
-		void createDefaultTags_Winter() {
+		void createSeasonTags_Winter() {
 			// given
 			String dateTimeStr = "2024/12/25 10:30:25";
 			when(tagMapper.findTagByNameAndType("겨울", TagType.SEASON)).thenReturn(null);
 			doNothing().when(tagMapper).insertTag(any(Tag.class));
 
 			// when
-			List<TagNameResponseDto> result = tagService.createDefaultTags(dateTimeStr, null, null);
+			List<TagNameResponseDto> result = tagService.createSeasonTags(dateTimeStr);
 
 			// then
 			assertEquals(1, result.size());
@@ -536,14 +537,14 @@ class TagServiceTest {
 
 		@Test
 		@DisplayName("봄 계절 태그 생성")
-		void createDefaultTags_Spring() {
+		void createSeasonTags_Spring() {
 			// given
 			String dateTimeStr = "2024/4/15 08:30:25";
 			when(tagMapper.findTagByNameAndType("봄", TagType.SEASON)).thenReturn(null);
 			doNothing().when(tagMapper).insertTag(any(Tag.class));
 
 			// when
-			List<TagNameResponseDto> result = tagService.createDefaultTags(dateTimeStr, null, null);
+			List<TagNameResponseDto> result = tagService.createSeasonTags(dateTimeStr);
 
 			// then
 			assertEquals(1, result.size());
@@ -552,14 +553,14 @@ class TagServiceTest {
 
 		@Test
 		@DisplayName("가을 계절 태그 생성")
-		void createDefaultTags_Autumn() {
+		void createSeasonTags_Autumn() {
 			// given
 			String dateTimeStr = "2024/10/15 19:30:25";
 			when(tagMapper.findTagByNameAndType("가을", TagType.SEASON)).thenReturn(null);
 			doNothing().when(tagMapper).insertTag(any(Tag.class));
 
 			// when
-			List<TagNameResponseDto> result = tagService.createDefaultTags(dateTimeStr, null, null);
+			List<TagNameResponseDto> result = tagService.createSeasonTags(dateTimeStr);
 
 			// then
 			assertEquals(1, result.size());
@@ -568,14 +569,14 @@ class TagServiceTest {
 
 		@Test
 		@DisplayName("밤 시간대에도 계절 태그만 생성")
-		void createDefaultTags_Night() {
+		void createSeasonTags_Night() {
 			// given
 			String dateTimeStr = "2024/7/15 23:30:25";
 			when(tagMapper.findTagByNameAndType("여름", TagType.SEASON)).thenReturn(null);
 			doNothing().when(tagMapper).insertTag(any(Tag.class));
 
 			// when
-			List<TagNameResponseDto> result = tagService.createDefaultTags(dateTimeStr, null, null);
+			List<TagNameResponseDto> result = tagService.createSeasonTags(dateTimeStr);
 
 			// then
 			assertEquals(1, result.size());
@@ -584,18 +585,161 @@ class TagServiceTest {
 
 		@Test
 		@DisplayName("점심 시간대에도 계절 태그만 생성")
-		void createDefaultTags_Lunch() {
+		void createSeasonTags_Lunch() {
 			// given
 			String dateTimeStr = "2024/7/15 12:30:25";
 			when(tagMapper.findTagByNameAndType("여름", TagType.SEASON)).thenReturn(null);
 			doNothing().when(tagMapper).insertTag(any(Tag.class));
 
 			// when
-			List<TagNameResponseDto> result = tagService.createDefaultTags(dateTimeStr, null, null);
+			List<TagNameResponseDto> result = tagService.createSeasonTags(dateTimeStr);
 
 			// then
 			assertEquals(1, result.size());
 			assertEquals("여름", result.get(0).getTagName());
+		}
+	}
+
+	@Nested
+	@DisplayName("태그 이름 기반 연결 테스트")
+	class TagNameConnectionTest {
+
+		@Test
+		@DisplayName("이미지에 태그 이름으로 태그 추가 성공")
+		void addTagToImageByName_Success() {
+			// given
+			Long imageId = 1L;
+			String tagName = "테스트태그";
+			when(tagMapper.findExistingTagByName(tagName)).thenReturn(testTag);
+			doNothing().when(tagMapper).insertImageTag(any());
+			doNothing().when(tagMapper).incrementTagUseCount(testTag.getTagId());
+
+			// when
+			tagService.addTagToImageByName(imageId, tagName);
+
+			// then
+			verify(tagMapper).findExistingTagByName(tagName);
+			verify(tagMapper).insertImageTag(any());
+			verify(tagMapper).incrementTagUseCount(testTag.getTagId());
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 태그 이름으로 새 태그 생성 후 추가")
+		void addTagToImageByName_CreateNewTag() {
+			// given
+			Long imageId = 1L;
+			String tagName = "새로운태그";
+			when(tagMapper.findExistingTagByName(tagName)).thenReturn(null);
+			doNothing().when(tagMapper).insertTag(any(Tag.class));
+			doNothing().when(tagMapper).insertImageTag(any());
+			doNothing().when(tagMapper).incrementTagUseCount(any());
+
+			// when
+			tagService.addTagToImageByName(imageId, tagName);
+
+			// then
+			verify(tagMapper).findExistingTagByName(tagName);
+			verify(tagMapper).insertTag(any(Tag.class));
+			verify(tagMapper).insertImageTag(any());
+			verify(tagMapper).incrementTagUseCount(any());
+		}
+	}
+
+	@Nested
+	@DisplayName("태그 정렬 테스트")
+	class TagSortingTest {
+
+		@Test
+		@DisplayName("태그 타입에 따른 정렬 순서 확인")
+		void getTagsForImageDisplay_SortedByTagType() {
+			// given
+			Long imageId = 1L;
+			Tag sidoTag = Tag.builder()
+				.tagName("서울특별시")
+				.tagType(TagType.SIDO)
+				.tagUseCount(1L)
+				.createdAt(LocalDateTime.now())
+				.build();
+			org.springframework.test.util.ReflectionTestUtils.setField(sidoTag, "tagId", 1L);
+
+			Tag sigunguTag = Tag.builder()
+				.tagName("강남구")
+				.tagType(TagType.SIGUNGU)
+				.tagUseCount(1L)
+				.createdAt(LocalDateTime.now())
+				.build();
+			org.springframework.test.util.ReflectionTestUtils.setField(sigunguTag, "tagId", 2L);
+
+			Tag customTag = Tag.builder()
+				.tagName("커스텀태그")
+				.tagType(TagType.CUSTOM)
+				.tagUseCount(1L)
+				.createdAt(LocalDateTime.now())
+				.build();
+			org.springframework.test.util.ReflectionTestUtils.setField(customTag, "tagId", 3L);
+
+			// 무순서로 리스트 생성
+			List<Tag> unorderedTags = List.of(customTag, sidoTag, sigunguTag);
+			when(tagMapper.findTagsByImageId(imageId)).thenReturn(unorderedTags);
+
+			// when
+			var result = tagService.getTagsForImageDisplay(imageId);
+
+			// then
+			assertNotNull(result);
+			assertEquals(3, result.size());
+			// 정렬 순서 확인: SIDO(1) -> SIGUNGU(2) -> CUSTOM(0)
+			assertEquals("서울특별시", result.get(0).getTagName());
+			assertEquals("강남구", result.get(1).getTagName());
+			assertEquals("커스텀태그", result.get(2).getTagName());
+		}
+	}
+
+	@Nested
+	@DisplayName("태그 타입 핸들러 테스트")
+	class TagTypeHandlerTest {
+
+		@Test
+		@DisplayName("TagType enum의 코드 변환 테스트")
+		void tagTypeFromCode_Success() {
+			// given & when & then
+			assertEquals(TagType.CUSTOM, TagType.fromCode(0));
+			assertEquals(TagType.SIDO, TagType.fromCode(1));
+			assertEquals(TagType.SIGUNGU, TagType.fromCode(2));
+			assertEquals(TagType.SEASON, TagType.fromCode(3));
+			assertEquals(TagType.TIME, TagType.fromCode(4));
+			assertEquals(TagType.WEATHER, TagType.fromCode(5));
+		}
+
+		@Test
+		@DisplayName("잘못된 코드로 TagType 변환 시 예외 발생")
+		void tagTypeFromCode_InvalidCode() {
+			// given
+			int invalidCode = 999;
+
+			// when & then
+			assertThrows(IllegalArgumentException.class, () -> TagType.fromCode(invalidCode));
+		}
+	}
+
+	@Nested
+	@DisplayName("모든 태그 연결 해제 테스트")
+	class RemoveAllTagsTest {
+
+		@Test
+		@DisplayName("이미지의 모든 태그 연결 해제 성공")
+		void removeAllTagsFromImage_Success() {
+			// given
+			Long imageId = 1L;
+			doNothing().when(tagMapper).decrementTagUseCountByImageId(imageId);
+			doNothing().when(tagMapper).deleteImageTagsByImageId(imageId);
+
+			// when
+			tagService.removeAllTagsFromImage(imageId);
+
+			// then
+			verify(tagMapper).decrementTagUseCountByImageId(imageId);
+			verify(tagMapper).deleteImageTagsByImageId(imageId);
 		}
 	}
 }


### PR DESCRIPTION
 1. 태그 위치 정보 구조 변경
    - 기존: locationName (단일 필드)
    - 변경: sidoName, sigunguName (분리된 필드)
    - SQL 쿼리에서 위치 정보를 시도와 시군구로 분리하여 처리
    - 프론트에서 시도와 시군구를 태그네임으로 바꿔서 백엔드로 전달
    
  2. 태그 엔드포인트 변경
    - /api/tags/default → /api/tags/season
    - 좌표로 위치 태그 설정하던 부분 제거후 계절 태그 생성 API로만 이용
    
  3. TagType 정렬 기능 추가
    - 태그 조회 시 타입별 우선순위 적용

  4. sql 인서트문 수정
    - 기존 tag_type: 1로 처리하던 location을 sidoName, sigunguName로 나눠 tag_type: 1 , tag_type: 2로 수정