### PR TITLE
이미지 삭제 시 앨범 관련 기능 정보 처리

### DIFF
--- a/src/main/java/com/trackery/trackerybackapiserver/domain/album/event/AlbumEventListener.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/album/event/AlbumEventListener.java
@@ -3,6 +3,7 @@ package com.trackery.trackerybackapiserver.domain.album.event;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
+import com.trackery.trackerybackapiserver.domain.album.service.AlbumService;
 import com.trackery.trackerybackapiserver.domain.album.service.AlbumThumbnailService;
 
 import lombok.RequiredArgsConstructor;
@@ -12,7 +13,7 @@ import lombok.RequiredArgsConstructor;
  * fileName       : AlbumThumbnailEventListener
  * author         : durururuk
  * date           : 25. 6. 20.
- * description    : 앨범 썸네일 이벤트 리스너
+ * description    : 앨범 이벤트 리스너
  * ===========================================================
  * DATE              AUTHOR             NOTE
  * -----------------------------------------------------------
@@ -20,8 +21,9 @@ import lombok.RequiredArgsConstructor;
  */
 @Component
 @RequiredArgsConstructor
-public class AlbumThumbnailEventListener {
+public class AlbumEventListener {
 	private final AlbumThumbnailService albumThumbnailService;
+	private final AlbumService albumService;
 
 	/**
 	 * 앨범 이미지가 추가/삭제됐을 때 썸네일 서비스로 이벤트를 전달해주는 이벤트리스너

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/album/event/AlbumImageEditEvent.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/album/event/AlbumImageEditEvent.java
@@ -21,4 +21,3 @@ public record AlbumImageEditEvent(
 	AlbumImageEditOperation albumImageEditOperation
 ) {
 }
-

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/album/mapper/AlbumMapper.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/album/mapper/AlbumMapper.java
@@ -98,6 +98,13 @@ public interface AlbumMapper {
 	 */
 	List<ImageInfoForThumbnailDto> findImagesForThumbnailByAlbumId(@Param("albumId") Long albumId);
 
+	/**
+	 * 이미지 ID로 해당 이미지가 포함된 앨범 ID 목록 조회
+	 * @param imageId 이미지 ID
+	 * @return 앨범 ID 목록
+	 */
+	List<Long> findAlbumIdsByImageId(@Param("imageId") Long imageId);
+
 	//모든 앨범에서 어떤 이미지 삭제
 	void deleteAllAlbumImagesByImageId(@Param("imageId") Long imageId);
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/album/mapper/AlbumMapper.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/album/mapper/AlbumMapper.java
@@ -97,4 +97,7 @@ public interface AlbumMapper {
 	 * @return 썸네일 생성에 필요한 이미지 기본 정보
 	 */
 	List<ImageInfoForThumbnailDto> findImagesForThumbnailByAlbumId(@Param("albumId") Long albumId);
+
+	//모든 앨범에서 어떤 이미지 삭제
+	void deleteAllAlbumImagesByImageId(@Param("imageId") Long imageId);
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/album/service/AlbumService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/album/service/AlbumService.java
@@ -200,8 +200,10 @@ public class AlbumService {
 		return result;
 	}
 
-	/*
-	모든 앨범에서 어떤 이미지 삭제
+	/**
+	 * 모든 앨범에서 특정 이미지를 삭제하는 메서드
+	 * 이미지 삭제 후 앨범 썸네일 서비스로 이벤트를 발행합니다.
+	 * @param imageId 삭제할 이미지 ID
 	 */
 	public void deleteImageFromAllAlbum(Long imageId) {
 		List<Long> affectedAlbumIds = albumMapper.findAlbumIdsByImageId(imageId);

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/album/service/AlbumService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/album/service/AlbumService.java
@@ -200,6 +200,14 @@ public class AlbumService {
 		return result;
 	}
 
+	/*
+	모든 앨범에서 어떤 이미지 삭제
+	 */
+	public void deleteAllImageFromAlbum(Long imageId) {
+		albumMapper.deleteAllAlbumImagesByImageId(imageId);
+	}
+
+
 	/**
 	 * 앨범 메타데이터 조회
 	 * @param userId 요청한 유저 ID

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/album/service/AlbumService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/album/service/AlbumService.java
@@ -203,10 +203,28 @@ public class AlbumService {
 	/*
 	모든 앨범에서 어떤 이미지 삭제
 	 */
-	public void deleteAllImageFromAlbum(Long imageId) {
-		albumMapper.deleteAllAlbumImagesByImageId(imageId);
-	}
+	public void deleteImageFromAllAlbum(Long imageId) {
+		List<Long> affectedAlbumIds = albumMapper.findAlbumIdsByImageId(imageId);
 
+		albumMapper.deleteAllAlbumImagesByImageId(imageId);
+
+		for (Long albumId : affectedAlbumIds) {
+			Album album = albumMapper.findByAlbumId(albumId).orElse(null);
+			if (album != null) {
+				AlbumImageEditResponseDto responseDto = AlbumImageEditResponseDto.builder()
+					.albumId(albumId)
+					.succeededImageCount(1)
+					.failedImageCount(0)
+					.succeededImageIds(Set.of(imageId))
+					.failedImageIds(Map.of())
+					.build();
+
+				applicationEventPublisher.publishEvent(
+					new AlbumImageEditEvent(album, responseDto, AlbumImageEditOperation.DELETE)
+				);
+			}
+		}
+	}
 
 	/**
 	 * 앨범 메타데이터 조회

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/event/ImageDeleteEvent.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/event/ImageDeleteEvent.java
@@ -1,0 +1,15 @@
+package com.trackery.trackerybackapiserver.domain.image.event;
+
+/**
+ * packageName    : com.trackery.trackerybackapiserver.domain.image.event
+ * fileName       : ImageDeleteEvent
+ * author         : durururuk
+ * date           : 25. 7. 14.
+ * description    : 이미지 삭제 시 발행될 이벤트
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 25. 7. 14.		durururuk		최초 생성
+ */
+public record ImageDeleteEvent(Long imageId) {
+}

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/event/ImageEventListener.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/event/ImageEventListener.java
@@ -28,7 +28,7 @@ public class ImageEventListener {
 	@EventListener
 	public void handleImageDeleteEvent(ImageDeleteEvent event) {
 		try {
-			albumService.deleteAllImageFromAlbum(event.imageId());
+			albumService.deleteImageFromAllAlbum(event.imageId());
 			log.info("모든 앨범에서 이미지 삭제 완료 - imageId: {}", event.imageId());
 		} catch (Exception e) {
 			log.error("앨범에서 이미지 삭제 실패 - imageId: {}, 오류: {}", event.imageId(), e.getMessage());

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/event/ImageEventListener.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/event/ImageEventListener.java
@@ -1,0 +1,38 @@
+package com.trackery.trackerybackapiserver.domain.image.event;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import com.trackery.trackerybackapiserver.domain.album.service.AlbumService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * packageName    : com.trackery.trackerybackapiserver.domain.image.event
+ * fileName       : ImageEventListener
+ * author         : durururuk
+ * date           : 25. 7. 15.
+ * description    : 이미지 관련 이벤트를 처리하는 리스너
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 25. 7. 15.		durururuk		최초 생성
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ImageEventListener {
+	private final AlbumService albumService;
+
+	@EventListener
+	public void handleImageDeleteEvent(ImageDeleteEvent event) {
+		try {
+			albumService.deleteAllImageFromAlbum(event.imageId());
+			log.info("모든 앨범에서 이미지 삭제 완료 - imageId: {}", event.imageId());
+		} catch (Exception e) {
+			log.error("앨범에서 이미지 삭제 실패 - imageId: {}, 오류: {}", event.imageId(), e.getMessage());
+			throw e;
+		}
+	}
+}

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageService.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
@@ -19,6 +20,7 @@ import com.trackery.trackerybackapiserver.domain.image.dto.ImageUpdateRequestDto
 import com.trackery.trackerybackapiserver.domain.image.dto.internal.ImageInfoForThumbnailDto;
 import com.trackery.trackerybackapiserver.domain.image.dto.internal.ImageSearchByUserIdDto;
 import com.trackery.trackerybackapiserver.domain.image.entity.Image;
+import com.trackery.trackerybackapiserver.domain.image.event.ImageDeleteEvent;
 import com.trackery.trackerybackapiserver.domain.image.mapper.ImageMapper;
 import com.trackery.trackerybackapiserver.domain.location.dto.CoordinateDto;
 import com.trackery.trackerybackapiserver.domain.location.dto.LocationInfoDto;
@@ -63,6 +65,7 @@ public class ImageService {
 	private final ImageS3Service imageS3Service;
 	private final LocationService locationService;
 	private final TagService tagService;
+	private final ApplicationEventPublisher applicationEventPublisher;
 
 	/**
 	 * 공개된 이미지 URL 목록을 조회합니다.
@@ -356,6 +359,8 @@ public class ImageService {
 		if (deletedRows == 0) {
 			throw new ApiException(ErrorCode.NOT_FOUND_IMAGE);
 		}
+
+		applicationEventPublisher.publishEvent(new ImageDeleteEvent(imageId));
 
 		log.info("이미지 삭제 완료 - imageId: {}, userId: {}", imageId, userId);
 	}

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageService.java
@@ -8,6 +8,7 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.github.pagehelper.PageHelper;
 import com.github.pagehelper.PageInfo;
@@ -74,6 +75,7 @@ public class ImageService {
 	 *
 	 * @return 공개된 이미지 URL 목록
 	 */
+	@Transactional(readOnly = true)
 	@Cacheable(value = "publicImageUrls")
 	public List<String> getPublicImageUrls() {
 		log.info("공개된 이미지의 주소들을 가져옵니다.");
@@ -103,6 +105,7 @@ public class ImageService {
 	 * @return 이미지 정보 DTO
 	 * @throws ApiException 이미지를 찾을 수 없거나 권한이 없는 경우
 	 */
+	@Transactional(readOnly = true)
 	public ImageDto getOriginalImageByImageId(Long userId, Long imageId) {
 		Image image = imageMapper.findImageByImageId(imageId).orElseThrow(
 			() -> new ApiException(ErrorCode.NOT_FOUND_IMAGE)
@@ -137,6 +140,7 @@ public class ImageService {
 	 * @return 썸네일 DTO 목록을 포함한 페이지네이션 정보
 	 */
 	@SuppressWarnings("squid:S3252")
+	@Transactional(readOnly = true)
 	public PageInfo<ImageThumbnailDto> getImageListByUserId(ImageSearchByUserIdDto imageSearchByUserIdDto) {
 		PageHelper.startPage(imageSearchByUserIdDto.getPageNum(), imageSearchByUserIdDto.getPageSize());
 
@@ -184,6 +188,7 @@ public class ImageService {
 	 * @param userId 사용자 ID
 	 * @return 이미지 썸네일 목록
 	 */
+	@Transactional(readOnly = true)
 	public List<ImageThumbnailDto> getImagesBySido(Long sidoId, Long userId) {
 		log.debug("시도 ID {}의 사용자 ID {} 이미지 목록 조회", sidoId, userId);
 		List<Image> images = imageMapper.findImagesBySidoIdAndUserId(sidoId, userId);
@@ -199,6 +204,7 @@ public class ImageService {
 	 * @param userId 사용자 ID
 	 * @return 이미지 썸네일 목록
 	 */
+	@Transactional(readOnly = true)
 	public List<ImageThumbnailDto> getImagesBySigungu(Long sigunguId, Long userId) {
 		log.debug("시군구 ID {}의 사용자 ID {} 이미지 목록 조회", sigunguId, userId);
 		List<Image> images = imageMapper.findImagesBySigunguIdAndUserId(sigunguId, userId);
@@ -215,6 +221,7 @@ public class ImageService {
 	 * @param updateRequest 수정할 데이터
 	 * @return 수정된 이미지 정보
 	 */
+	@Transactional
 	@CacheEvict(value = "publicImageUrls", allEntries = true)
 	public ImageDto updateImageMetadata(Long imageId, Long userId, ImageUpdateRequestDto updateRequest) {
 		Image existingImage = validateImageUpdatePermission(imageId, userId);
@@ -337,6 +344,7 @@ public class ImageService {
 	 * @param imageId 삭제할 이미지 ID
 	 * @param userId 요청하는 사용자 ID (권한 확인용)
 	 */
+	@Transactional
 	@CacheEvict(value = "publicImageUrls", allEntries = true)
 	public void deleteImage(Long imageId, Long userId) {
 		Image existingImage = imageMapper.findImageByImageId(imageId)
@@ -371,6 +379,7 @@ public class ImageService {
 	 * @return S3 Presigned URL
 	 * @throws ApiException 이미지를 찾을 수 없는 경우
 	 */
+	@Transactional(readOnly = true)
 	public String fetchS3PresignedUrlByImageId(Long imageId) {
 		Image image = imageMapper.findImageByImageId(imageId).orElseThrow(
 			() -> new ApiException(ErrorCode.NOT_FOUND_IMAGE));

--- a/src/main/resources/mapper/AlbumMapper.xml
+++ b/src/main/resources/mapper/AlbumMapper.xml
@@ -110,6 +110,12 @@
           AND i.is_deleted = 0
     </select>
 
+    <select id="findAlbumIdsByImageId" resultType="Long">
+        SELECT album_id
+        FROM album_image
+        WHERE image_id = #{imageId}
+    </select>
+
     <delete id="deleteAllAlbumImagesByImageId">
         DELETE FROM album_image
         WHERE image_id = #{imageId}

--- a/src/main/resources/mapper/AlbumMapper.xml
+++ b/src/main/resources/mapper/AlbumMapper.xml
@@ -109,4 +109,9 @@
         WHERE ai.album_id = #{albumId}
           AND i.is_deleted = 0
     </select>
+
+    <delete id="deleteAllAlbumImagesByImageId">
+        DELETE FROM album_image
+        WHERE image_id = #{imageId}
+    </delete>
 </mapper>

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/album/listener/AlbumEventListenerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/album/listener/AlbumEventListenerTest.java
@@ -16,7 +16,7 @@ import com.trackery.trackerybackapiserver.domain.album.dto.response.AlbumImageEd
 import com.trackery.trackerybackapiserver.domain.album.entity.Album;
 import com.trackery.trackerybackapiserver.domain.album.enums.AlbumImageEditOperation;
 import com.trackery.trackerybackapiserver.domain.album.event.AlbumImageEditEvent;
-import com.trackery.trackerybackapiserver.domain.album.event.AlbumThumbnailEventListener;
+import com.trackery.trackerybackapiserver.domain.album.event.AlbumEventListener;
 import com.trackery.trackerybackapiserver.domain.album.service.AlbumThumbnailService;
 
 /**
@@ -32,13 +32,13 @@ import com.trackery.trackerybackapiserver.domain.album.service.AlbumThumbnailSer
  * 25. 6. 28.		inari			코드 스멜 수정
  */
 @ExtendWith(MockitoExtension.class)
-class AlbumThumbnailEventListenerTest {
+class AlbumEventListenerTest {
 
 	@Mock
 	private AlbumThumbnailService albumThumbnailService;
 
 	@InjectMocks
-	private AlbumThumbnailEventListener albumThumbnailEventListener;
+	private AlbumEventListener albumEventListener;
 
 	private static final Long ALBUM_ID = 1L;
 	private static final Long IMAGE_ID = 2L;
@@ -69,7 +69,7 @@ class AlbumThumbnailEventListenerTest {
 		doNothing().when(albumThumbnailService).handleAlbumThumbnailChange(album, dto, AlbumImageEditOperation.ADD);
 
 		// when
-		albumThumbnailEventListener.handleAlbumEditEvent(addEvent);
+		albumEventListener.handleAlbumEditEvent(addEvent);
 
 		// then
 		verify(albumThumbnailService, times(1)).handleAlbumThumbnailChange(album, dto, AlbumImageEditOperation.ADD);
@@ -79,14 +79,14 @@ class AlbumThumbnailEventListenerTest {
 	void 이미지_삭제_이벤트_처리_성공() {
 		doNothing().when(albumThumbnailService).handleAlbumThumbnailChange(album, dto, AlbumImageEditOperation.DELETE);
 
-		albumThumbnailEventListener.handleAlbumEditEvent(deleteEvent);
+		albumEventListener.handleAlbumEditEvent(deleteEvent);
 
 		verify(albumThumbnailService, times(1)).handleAlbumThumbnailChange(album, dto, AlbumImageEditOperation.DELETE);
 	}
 
 	@Test
 	void 서비스_메서드에_올바른_파라미터_전달_확인() {
-		albumThumbnailEventListener.handleAlbumEditEvent(addEvent);
+		albumEventListener.handleAlbumEditEvent(addEvent);
 
 		verify(albumThumbnailService).handleAlbumThumbnailChange(
 			// eq(album)이 불필요한 이유는 album이 객체 참조이고, Mockito가 기본적으로 equals() 메서드로 객체를 비교하기 때문

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/album/service/AlbumServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/album/service/AlbumServiceTest.java
@@ -2,7 +2,6 @@ package com.trackery.trackerybackapiserver.domain.album.service;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
-import static org.mockito.ArgumentMatchers.*;
 
 import java.util.HashSet;
 import java.util.List;
@@ -30,6 +29,7 @@ import com.trackery.trackerybackapiserver.domain.album.dto.response.AlbumImageEd
 import com.trackery.trackerybackapiserver.domain.album.dto.response.MyAlbumResponseDto;
 import com.trackery.trackerybackapiserver.domain.album.entity.Album;
 import com.trackery.trackerybackapiserver.domain.album.entity.AlbumImage;
+import com.trackery.trackerybackapiserver.domain.album.event.AlbumImageEditEvent;
 import com.trackery.trackerybackapiserver.domain.album.mapper.AlbumMapper;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
@@ -593,6 +593,84 @@ class AlbumServiceTest {
 			assertEquals(ErrorCode.FORBIDDEN, exception.getErrorCode());
 			verify(albumMapper).findByAlbumId(ALBUM_ID);
 			verify(albumMapper, never()).deleteAlbumByAlbumId(anyLong());
+		}
+	}
+
+	@Nested
+	@DisplayName("모든 앨범에서 이미지 삭제 테스트")
+	class DeleteImageFromAllAlbumTest {
+
+		@Test
+		@DisplayName("성공 - 이미지가 여러 앨범에 있을 때 모든 앨범에서 삭제되고 이벤트 발행")
+		void testDeleteImageFromAllAlbum_Success() {
+			Long imageId = 1L;
+			List<Long> affectedAlbumIds = List.of(1L, 2L, 3L);
+			
+			Album album1 = Album.builder().userId(USER_ID).build();
+			ReflectionTestUtils.setField(album1, "albumId", 1L);
+			
+			Album album2 = Album.builder().userId(USER_ID).build();
+			ReflectionTestUtils.setField(album2, "albumId", 2L);
+			
+			Album album3 = Album.builder().userId(USER_ID).build();
+			ReflectionTestUtils.setField(album3, "albumId", 3L);
+
+			when(albumMapper.findAlbumIdsByImageId(imageId)).thenReturn(affectedAlbumIds);
+			when(albumMapper.findByAlbumId(1L)).thenReturn(Optional.of(album1));
+			when(albumMapper.findByAlbumId(2L)).thenReturn(Optional.of(album2));
+			when(albumMapper.findByAlbumId(3L)).thenReturn(Optional.of(album3));
+			
+			doNothing().when(albumMapper).deleteAllAlbumImagesByImageId(imageId);
+
+			assertDoesNotThrow(() -> albumService.deleteImageFromAllAlbum(imageId));
+
+			verify(albumMapper).findAlbumIdsByImageId(imageId);
+			verify(albumMapper).deleteAllAlbumImagesByImageId(imageId);
+			verify(albumMapper).findByAlbumId(1L);
+			verify(albumMapper).findByAlbumId(2L);
+			verify(albumMapper).findByAlbumId(3L);
+			verify(applicationEventPublisher, times(3)).publishEvent(any(AlbumImageEditEvent.class));
+		}
+
+		@Test
+		@DisplayName("성공 - 이미지가 아무 앨범에도 없을 때")
+		void testDeleteImageFromAllAlbum_NoAlbums() {
+			Long imageId = 1L;
+			List<Long> affectedAlbumIds = List.of();
+
+			when(albumMapper.findAlbumIdsByImageId(imageId)).thenReturn(affectedAlbumIds);
+			doNothing().when(albumMapper).deleteAllAlbumImagesByImageId(imageId);
+
+			assertDoesNotThrow(() -> albumService.deleteImageFromAllAlbum(imageId));
+
+			verify(albumMapper).findAlbumIdsByImageId(imageId);
+			verify(albumMapper).deleteAllAlbumImagesByImageId(imageId);
+			verify(albumMapper, never()).findByAlbumId(any());
+			verify(applicationEventPublisher, never()).publishEvent(any(AlbumImageEditEvent.class));
+		}
+
+		@Test
+		@DisplayName("성공 - 일부 앨범이 삭제된 경우 해당 앨범은 건너뛰기")
+		void testDeleteImageFromAllAlbum_SomeAlbumsDeleted() {
+			Long imageId = 1L;
+			List<Long> affectedAlbumIds = List.of(1L, 2L);
+			
+			Album album1 = Album.builder().userId(USER_ID).build();
+			ReflectionTestUtils.setField(album1, "albumId", 1L);
+
+			when(albumMapper.findAlbumIdsByImageId(imageId)).thenReturn(affectedAlbumIds);
+			when(albumMapper.findByAlbumId(1L)).thenReturn(Optional.of(album1));
+			when(albumMapper.findByAlbumId(2L)).thenReturn(Optional.empty());
+			
+			doNothing().when(albumMapper).deleteAllAlbumImagesByImageId(imageId);
+
+			assertDoesNotThrow(() -> albumService.deleteImageFromAllAlbum(imageId));
+
+			verify(albumMapper).findAlbumIdsByImageId(imageId);
+			verify(albumMapper).deleteAllAlbumImagesByImageId(imageId);
+			verify(albumMapper).findByAlbumId(1L);
+			verify(albumMapper).findByAlbumId(2L);
+			verify(applicationEventPublisher, times(1)).publishEvent(any(AlbumImageEditEvent.class));
 		}
 	}
 }

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/image/service/ImageServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/image/service/ImageServiceTest.java
@@ -20,6 +20,7 @@ import org.locationtech.jts.geom.PrecisionModel;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.github.pagehelper.PageInfo;
@@ -64,6 +65,8 @@ class ImageServiceTest {
 	private LocationService locationService;
 	@Mock
 	private TagService tagService;
+	@Mock
+	private ApplicationEventPublisher applicationEventPublisher;
 	@InjectMocks
 	private ImageService imageService;
 


### PR DESCRIPTION
이미지를 삭제했을 때 이벤트를 발행하여 그 이미지가 포함돼있는 앨범에서 이미지를 제거하고 썸네일을 재설정할 수 있도록 수정했습니다.