### PR TITLE
Refactor/코드스멜 및 커버리지

### DIFF
--- a/src/docs/asciidoc/image-api.adoc
+++ b/src/docs/asciidoc/image-api.adoc
@@ -9,7 +9,6 @@
 
 ===== 요청
 include::{snippets}/get-image-by-id-success/http-request.adoc[]
-include::{snippets}/get-image-by-id-success/query-parameters.adoc[]
 
 ===== 응답
 include::{snippets}/get-image-by-id-success/http-response.adoc[]

--- a/src/docs/asciidoc/location-api.adoc
+++ b/src/docs/asciidoc/location-api.adoc
@@ -104,12 +104,12 @@ include::{snippets}/get-sigungu-by-id-success/response-fields.adoc[]
 시군구 ID를 받아서 해당 시군구의 시도명과 시군구명을 분리하여 반환하는 API입니다.
 
 ===== 요청
-include::{snippets}/get-sigungu-location-info-by-id-success/http-request.adoc[]
-include::{snippets}/get-sigungu-location-info-by-id-success/path-parameters.adoc[]
+include::{snippets}/get-sigungu-location-info-success/http-request.adoc[]
+include::{snippets}/get-sigungu-location-info-success/path-parameters.adoc[]
 
 ===== 응답
-include::{snippets}/get-sigungu-location-info-by-id-success/http-response.adoc[]
-include::{snippets}/get-sigungu-location-info-by-id-success/response-fields.adoc[]
+include::{snippets}/get-sigungu-location-info-success/http-response.adoc[]
+include::{snippets}/get-sigungu-location-info-success/response-fields.adoc[]
 '''
 
 === 시도별 사용자 이미지 조회 API

--- a/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtResolverFilter.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/config/filter/JwtResolverFilter.java
@@ -35,11 +35,13 @@ import lombok.extern.slf4j.Slf4j;
  * -----------------------------------------------------------
  * 25. 2. 19.        durururuk       최초 생성
  * 25. 6. 27.        inari      	쿠키 이름과 정책 enum으로 변경
+ * 25. 7. 15.        inari      	"Set-Cookie" 상수 전환
  */
 @Slf4j
 @RequiredArgsConstructor
 public class JwtResolverFilter extends OncePerRequestFilter {
 
+	public static final String SET_COOKIE = "Set-Cookie";
 	private final JwtService jwtService;
 	private final UserService userService;
 
@@ -119,7 +121,7 @@ public class JwtResolverFilter extends OncePerRequestFilter {
 				|| e.getErrorCode() == ErrorCode.INTERNAL_SERVER_ERROR) {
 				ResponseCookie clearCookie = CookieUtil.deleteCookie(
 					CookieName.REFRESH_TOKEN.getValue(), SameSitePolicy.STRICT.getValue());
-				response.addHeader("Set-Cookie", clearCookie.toString());
+				response.addHeader(SET_COOKIE, clearCookie.toString());
 			}
 
 			throw e;
@@ -127,7 +129,7 @@ public class JwtResolverFilter extends OncePerRequestFilter {
 			log.error("토큰 재발행 중 에러 발생", e);
 			ResponseCookie clearCookie = CookieUtil.deleteCookie(
 				CookieName.REFRESH_TOKEN.getValue(), SameSitePolicy.STRICT.getValue());
-			response.addHeader("Set-Cookie", clearCookie.toString());
+			response.addHeader(SET_COOKIE, clearCookie.toString());
 			throw new ApiException(ErrorCode.INTERNAL_SERVER_ERROR);
 		}
 	}
@@ -143,7 +145,7 @@ public class JwtResolverFilter extends OncePerRequestFilter {
 		ResponseCookie refreshTokenCookie = CookieUtil.createHttpOnlyCookie(
 			CookieName.REFRESH_TOKEN.getValue(), authTokenDto.refreshToken(), Duration.ofDays(7));
 
-		response.addHeader("Set-Cookie", accessTokenCookie.toString());
-		response.addHeader("Set-Cookie", refreshTokenCookie.toString());
+		response.addHeader(SET_COOKIE, accessTokenCookie.toString());
+		response.addHeader(SET_COOKIE, refreshTokenCookie.toString());
 	}
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageService.java
@@ -23,7 +23,6 @@ import com.trackery.trackerybackapiserver.domain.image.dto.internal.ImageSearchB
 import com.trackery.trackerybackapiserver.domain.image.entity.Image;
 import com.trackery.trackerybackapiserver.domain.image.event.ImageDeleteEvent;
 import com.trackery.trackerybackapiserver.domain.image.mapper.ImageMapper;
-import com.trackery.trackerybackapiserver.domain.location.dto.CoordinateDto;
 import com.trackery.trackerybackapiserver.domain.location.dto.LocationInfoDto;
 import com.trackery.trackerybackapiserver.domain.location.entity.CoordinatePoint;
 import com.trackery.trackerybackapiserver.domain.location.service.LocationService;
@@ -51,12 +50,13 @@ import lombok.extern.slf4j.Slf4j;
  * 25. 6. 22.		 inari		 이미지 수정시 좌표 인서트가 아닌 업데이트로 변경
  * 25. 7. 7.		 inari		 이미지 좌표 인서트시 태그 추가
  * 25. 7. 9.		 inari		 removeAllTagsFromImage로 메서드 분리
- * 25. 7. 10.        inari       	이미지 단건 조회시 태그 추가
+ * 25. 7. 10.        inari       이미지 단건 조회시 태그 추가
  * 25. 7. 11.		durururuk	 내 이미지 리스트 조회 시 S3에서 이미지 조회 실패한 이미지는 제외하고 결과를 반환하게 수정
  * 25. 7. 11.		durururuk	 중복되는 리스팅 메서드 추출
- * 25. 7. 12.		inari		이미지 수정시 태그 삭제 추가
- * 25. 7. 13.		inari		이미지 수정시 태그 수정 추가
- * 25. 7. 14.		inari		updateImageMetadata 코드 복잡도 수정
+ * 25. 7. 12.		inari		 이미지 수정시 태그 삭제 추가
+ * 25. 7. 13.		inari		 이미지 수정시 태그 수정 추가
+ * 25. 7. 14.		inari		 updateImageMetadata 코드 복잡도 수정
+ * 25. 7. 15.		inari		 updateImageLocation, processTagRemoval, processTagAddition 각 도메인으로 이동
  */
 @Slf4j
 @Service
@@ -224,24 +224,7 @@ public class ImageService {
 	@Transactional
 	@CacheEvict(value = "publicImageUrls", allEntries = true)
 	public ImageDto updateImageMetadata(Long imageId, Long userId, ImageUpdateRequestDto updateRequest) {
-		Image existingImage = validateImageUpdatePermission(imageId, userId);
-
-		updateBasicImageMetadata(imageId, updateRequest);
-		updateLocationIfProvided(imageId, existingImage, updateRequest);
-		processTagRemoval(imageId, updateRequest);
-		processTagAddition(imageId, updateRequest);
-
-		return getOriginalImageByImageId(userId, imageId);
-	}
-
-	/**
-	 * 이미지 수정 권한을 검증합니다.
-	 * @param imageId 이미지 ID
-	 * @param userId 사용자 ID
-	 * @return 검증된 이미지 엔티티
-	 * @throws ApiException 이미지를 찾을 수 없거나 권한이 없는 경우
-	 */
-	private Image validateImageUpdatePermission(Long imageId, Long userId) {
+		// 이미지 수정 권한 검증
 		Image existingImage = imageMapper.findImageByImageId(imageId)
 			.orElseThrow(() -> new ApiException(ErrorCode.NOT_FOUND_IMAGE));
 
@@ -249,15 +232,7 @@ public class ImageService {
 			throw new ApiException(ErrorCode.FORBIDDEN);
 		}
 
-		return existingImage;
-	}
-
-	/**
-	 * 기본 이미지 메타데이터를 수정합니다.
-	 * @param imageId 이미지 ID
-	 * @param updateRequest 수정 요청 데이터
-	 */
-	private void updateBasicImageMetadata(Long imageId, ImageUpdateRequestDto updateRequest) {
+		// 기본 이미지 메타데이터 수정
 		imageMapper.updateImageMetadata(
 			imageId,
 			updateRequest.imageName(),
@@ -265,78 +240,17 @@ public class ImageService {
 			updateRequest.imageDate(),
 			updateRequest.isPublic()
 		);
-	}
 
-	/**
-	 * 위치 정보가 제공된 경우 위치 정보를 수정합니다.
-	 * @param imageId 이미지 ID
-	 * @param existingImage 기존 이미지 정보
-	 * @param updateRequest 수정 요청 데이터
-	 */
-	private void updateLocationIfProvided(Long imageId, Image existingImage, ImageUpdateRequestDto updateRequest) {
-		if (updateRequest.latitude() == null || updateRequest.longitude() == null) {
-			return;
-		}
+		// 위치 정보 수정
+		Long existingCoordPointId = existingImage.getCoordPoint().getCoordinatePointId();
+		locationService.updateImageLocation(existingCoordPointId, updateRequest.latitude(),
+			updateRequest.longitude(), imageId);
 
-		try {
-			CoordinateDto coordinateDto = new CoordinateDto(
-				updateRequest.latitude(),
-				updateRequest.longitude()
-			);
+		// 태그 삭제 및 추가 처리
+		tagService.processTagRemoval(imageId, updateRequest);
+		tagService.processTagAddition(imageId, updateRequest);
 
-			Long existingCoordPointId = existingImage.getCoordPoint().getCoordinatePointId();
-			locationService.updateCoordinatePoint(existingCoordPointId, coordinateDto);
-
-			log.info("이미지 위치 정보 수정 완료 - imageId: {}, coord_point_id: {}, 새로운 위치: {}, {}",
-				imageId, existingCoordPointId, updateRequest.latitude(), updateRequest.longitude());
-		} catch (Exception e) {
-			log.error("이미지 위치 정보 수정 실패 - imageId: {}, 에러: {}", imageId, e.getMessage());
-			throw new ApiException(ErrorCode.UPDATE_FAILED_LOCATION);
-		}
-	}
-
-	/**
-	 * 삭제할 태그들을 처리합니다.
-	 * @param imageId 이미지 ID
-	 * @param updateRequest 수정 요청 데이터
-	 */
-	private void processTagRemoval(Long imageId, ImageUpdateRequestDto updateRequest) {
-		if (updateRequest.tagsToRemove() == null || updateRequest.tagsToRemove().isEmpty()) {
-			return;
-		}
-
-		for (Long tagId : updateRequest.tagsToRemove()) {
-			try {
-				tagService.removeTagFromImage(imageId, tagId);
-				log.info("이미지에서 태그 삭제 완료 - imageId: {}, tagId: {}", imageId, tagId);
-			} catch (Exception e) {
-				log.warn("이미지에서 태그 삭제 실패 - imageId: {}, tagId: {}, 오류: {}",
-					imageId, tagId, e.getMessage());
-			}
-		}
-	}
-
-	/**
-	 * 추가할 태그들을 처리합니다.
-	 * @param imageId 이미지 ID
-	 * @param updateRequest 수정 요청 데이터
-	 */
-	private void processTagAddition(Long imageId, ImageUpdateRequestDto updateRequest) {
-		if (updateRequest.tagsToAdd() == null || updateRequest.tagsToAdd().isEmpty()) {
-			return;
-		}
-
-		for (String tagName : updateRequest.tagsToAdd()) {
-			if (tagName != null && !tagName.trim().isEmpty()) {
-				try {
-					tagService.addTagToImageByName(imageId, tagName.trim());
-					log.info("이미지에 태그 추가 완료 - imageId: {}, tagName: {}", imageId, tagName.trim());
-				} catch (Exception e) {
-					log.warn("이미지에 태그 추가 실패 - imageId: {}, tagName: {}, 오류: {}",
-						imageId, tagName.trim(), e.getMessage());
-				}
-			}
-		}
+		return getOriginalImageByImageId(userId, imageId);
 	}
 
 	/**

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/location/service/LocationService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/location/service/LocationService.java
@@ -43,6 +43,7 @@ import lombok.extern.slf4j.Slf4j;
  * 25. 7. 7.		inari			지역 태그 서비스 추가
  * 25. 7. 8.		inari			시군구 ID로 시도명과 시군구명을 분리한 메서드 추가
  * 25. 7. 10.		inari			태그를 태그 도메인으로 분리
+ * 25. 7. 15.		inari			updateImageLocation을 이미지 서비스에서 이동
  */
 @Slf4j
 @Service
@@ -142,7 +143,6 @@ public class LocationService {
 	 * @param coordinateDto 새로운 좌표 DTO
 	 * @return 업데이트된 행 수
 	 */
-	@Transactional
 	public int updateCoordinatePoint(Long coordinatePointId, CoordinateDto coordinateDto) {
 		Point point = getPointByCoord(coordinateDto);
 		JusoSigungu sigungu = getSigunguByPoint(point);
@@ -264,5 +264,31 @@ public class LocationService {
 		log.debug("사용자 통계 조회 완료 - 이미지 {}개, 앨범 {}개, 시군구 {}개",
 			stats.getImageCount(), stats.getAlbumCount(), stats.getSigunguCount());
 		return stats;
+	}
+
+	/**
+	 * 위치 정보가 제공된 경우 기존 CoordinatePoint의 위치 정보를 수정합니다.
+	 * @param coordinatePointId 수정할 좌표 포인트 ID
+	 * @param latitude 새로운 위도
+	 * @param longitude 새로운 경도
+	 * @param imageId 로그용 이미지 ID
+	 * @throws ApiException 위치 정보 수정 실패 시
+	 */
+	@Transactional
+	public void updateImageLocation(Long coordinatePointId, Double latitude, Double longitude, Long imageId) {
+		if (latitude == null || longitude == null) {
+			return;
+		}
+
+		try {
+			CoordinateDto coordinateDto = new CoordinateDto(latitude, longitude);
+			updateCoordinatePoint(coordinatePointId, coordinateDto);
+
+			log.info("이미지 위치 정보 수정 완료 - imageId: {}, coord_point_id: {}, 새로운 위치: {}, {}",
+				imageId, coordinatePointId, latitude, longitude);
+		} catch (Exception e) {
+			log.error("이미지 위치 정보 수정 실패 - imageId: {}, 에러: {}", imageId, e.getMessage());
+			throw new ApiException(ErrorCode.UPDATE_FAILED_LOCATION);
+		}
 	}
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/tag/mapper/TagMapper.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/tag/mapper/TagMapper.java
@@ -20,6 +20,7 @@ import com.trackery.trackerybackapiserver.domain.tag.enums.TagType;
  * -----------------------------------------------------------
  * 25. 7. 2.        inari           최초 생성
  * 25. 7. 11.       inari           태그 일괄 삭제시 사용 카운트 일괄 감소 추가
+ * 25. 7. 15.       inari           사용하지 않는 매퍼 삭제
  */
 @Mapper
 public interface TagMapper {
@@ -121,13 +122,6 @@ public interface TagMapper {
 	 * @param imageId 이미지 ID
 	 */
 	void deleteImageTagsByImageId(@Param("imageId") Long imageId);
-
-	/**
-	 * 이미지 ID로 이미지-태그 연결 목록을 조회합니다.
-	 * @param imageId 이미지 ID
-	 * @return 이미지-태그 연결 목록
-	 */
-	List<ImageTag> findImageTagsByImrgeId(@Param("imageId") Long imageId);
 
 	/**
 	 * 특정 이미지에 특정 태그가 연결되어 있는지 확인합니다.

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/tag/service/TagService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/tag/service/TagService.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
+import com.trackery.trackerybackapiserver.domain.image.dto.ImageUpdateRequestDto;
 import com.trackery.trackerybackapiserver.domain.location.entity.JusoSigungu;
 import com.trackery.trackerybackapiserver.domain.location.service.LocationService;
 import com.trackery.trackerybackapiserver.domain.tag.dto.TagCreateRequestDto;
@@ -43,6 +44,7 @@ import lombok.extern.slf4j.Slf4j;
  * 25. 7. 12.		inari		태그 수정 구현
  * 25. 7. 14.       inari      	LOCATION태그 시도와 시군구로 분리
  * 25. 7. 14.       inari       프론트에서 태그 요청시 정렬해서 보내게 수정
+ * 25. 7. 15.       inari       processTagRemoval, processTagAddition 이미지 서비스에서 이동
  */
 @Slf4j
 @Service
@@ -550,6 +552,52 @@ public class TagService {
 			.createdAt(LocalDateTime.now(ZoneId.of(ASIA_SEOUL)))
 			.build();
 		tagMapper.insertTag(newTag);
+	}
+
+	/**
+	 * 이미지 수정 요청에서 삭제할 태그들을 처리합니다.
+	 * @param imageId 이미지 ID
+	 * @param updateRequest 수정 요청 데이터
+	 */
+	@Transactional
+	public void processTagRemoval(Long imageId, ImageUpdateRequestDto updateRequest) {
+		if (updateRequest.tagsToRemove() == null || updateRequest.tagsToRemove().isEmpty()) {
+			return;
+		}
+
+		for (Long tagId : updateRequest.tagsToRemove()) {
+			try {
+				removeTagFromImage(imageId, tagId);
+				log.info("이미지에서 태그 삭제 완료 - imageId: {}, tagId: {}", imageId, tagId);
+			} catch (Exception e) {
+				log.warn("이미지에서 태그 삭제 실패 - imageId: {}, tagId: {}, 오류: {}",
+					imageId, tagId, e.getMessage());
+			}
+		}
+	}
+
+	/**
+	 * 이미지 수정 요청에서 추가할 태그들을 처리합니다.
+	 * @param imageId 이미지 ID
+	 * @param updateRequest 수정 요청 데이터
+	 */
+	@Transactional
+	public void processTagAddition(Long imageId, ImageUpdateRequestDto updateRequest) {
+		if (updateRequest.tagsToAdd() == null || updateRequest.tagsToAdd().isEmpty()) {
+			return;
+		}
+
+		for (String tagName : updateRequest.tagsToAdd()) {
+			if (tagName != null && !tagName.trim().isEmpty()) {
+				try {
+					addTagToImageByName(imageId, tagName.trim());
+					log.info("이미지에 태그 추가 완료 - imageId: {}, tagName: {}", imageId, tagName.trim());
+				} catch (Exception e) {
+					log.warn("이미지에 태그 추가 실패 - imageId: {}, tagName: {}, 오류: {}",
+						imageId, tagName.trim(), e.getMessage());
+				}
+			}
+		}
 	}
 
 	/**

--- a/src/main/resources/mapper/ImageMapper.xml
+++ b/src/main/resources/mapper/ImageMapper.xml
@@ -178,7 +178,7 @@
             <if test="imageName != null">image_name = #{imageName},</if>
             <if test="imageContent != null">image_contents = #{imageContent},</if>
             <if test="imageDate != null">image_date = #{imageDate},</if>
-            <if test="isPublic != null">is_public = #{isPublic},</if>
+            <if test="isPublic != null">is_public = #{isPublic}</if>
         </set>
         WHERE image_id = #{imageId}
         AND is_deleted = 0

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/docs/controller/DocsControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/docs/controller/DocsControllerTest.java
@@ -14,11 +14,9 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
 
 import com.trackery.trackerybackapiserver.domain.config.CommonMockMvcControllerTestSetUp;
 
@@ -37,9 +35,6 @@ import com.trackery.trackerybackapiserver.domain.config.CommonMockMvcControllerT
 @WebMvcTest(DocsController.class)
 @DisplayName("DocsController 테스트")
 class DocsControllerTest extends CommonMockMvcControllerTestSetUp {
-
-	@Autowired
-	private MockMvc mockMvc;
 
 	@Nested
 	@DisplayName("API 문서 조회")

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/image/service/ImageServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/image/service/ImageServiceTest.java
@@ -588,7 +588,7 @@ class ImageServiceTest {
 				.build();
 
 			when(imageMapper.findImageByImageId(imageId)).thenReturn(Optional.of(existingImage));
-			when(imageMapper.updateImageMetadata(eq(imageId), eq("수정된 이미지"), eq("수정된 설명"), eq(newDate), eq(1)))
+			when(imageMapper.updateImageMetadata(imageId, "수정된 이미지", "수정된 설명", newDate, 1))
 				.thenReturn(1);
 			when(tagService.getTagsForImageDisplay(imageId)).thenReturn(List.of());
 			when(imageS3Service.generatePreSignedGetUrl(anyString(), eq(userId), eq("original"))).thenReturn(
@@ -598,7 +598,7 @@ class ImageServiceTest {
 
 			assertNotNull(result);
 			verify(imageMapper, times(2)).findImageByImageId(imageId);
-			verify(imageMapper).updateImageMetadata(eq(imageId), eq("수정된 이미지"), eq("수정된 설명"), eq(newDate), eq(1));
+			verify(imageMapper).updateImageMetadata(imageId, "수정된 이미지", "수정된 설명", newDate, 1);
 			verify(tagService, times(1)).getTagsForImageDisplay(imageId);
 		}
 	}

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/image/service/ImageServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/image/service/ImageServiceTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.PrecisionModel;
 import org.mockito.InjectMocks;
@@ -48,11 +49,11 @@ import com.trackery.trackerybackapiserver.domain.tag.service.TagService;
  * ===========================================================
  * DATE              AUTHOR             NOTE
  * -----------------------------------------------------------
- * 25. 2. 14.        inari       최초 생성
+ * 25. 2. 14.       inari       최초 생성
  * 25. 5. 19.		durururuk	이미지 조회 단위 테스트 작성
  * 25. 6. 20.		inari		이미지 삭제 및 수정 테스트 작성
- * 25. 7. 10.       inari       	이미지 단건 조회시 태그 추가
- * 25. 7. 14.       inari       테스트 코드 수정
+ * 25. 7. 10.       inari       이미지 단건 조회시 태그 추가
+ * 25. 7. 14.       inari       누락된 테스트코드 추가
  */
 @ExtendWith(MockitoExtension.class)
 class ImageServiceTest {
@@ -192,7 +193,7 @@ class ImageServiceTest {
 			assertEquals("강남구", result.getSggName());
 
 			verify(imageMapper).findImageByImageId(testImageId);
-			verify(imageS3Service).generatePreSignedGetUrl(testImage1.getImageName(), testUserId, "original");
+			verify(imageS3Service).generatePreSignedGetUrl(eq(testImage1.getImageName()), eq(testUserId), eq("original"));
 		}
 
 		@Test
@@ -243,7 +244,7 @@ class ImageServiceTest {
 				assertEquals(testPresignedUrl, result.getThumbnailUrl());
 
 				verify(imageMapper).findImageThumbnailsByUserId(searchDto);
-				verify(imageS3Service).generatePreSignedGetUrl(testImage1.getImageName(), testUserId, "thumbnail");
+				verify(imageS3Service).generatePreSignedGetUrl((testImage1.getImageName()), testUserId, ("thumbnail"));
 			}
 
 			@Test
@@ -315,7 +316,7 @@ class ImageServiceTest {
 			assertEquals("공개 이미지", result.getImageName());
 
 			verify(imageMapper).findImageByImageId(testImageId);
-			verify(imageS3Service).generatePreSignedGetUrl(publicImage.getImageName(), testUserId, "original");
+			verify(imageS3Service).generatePreSignedGetUrl((publicImage.getImageName()), testUserId, ("original"));
 		}
 	}
 
@@ -349,7 +350,7 @@ class ImageServiceTest {
 			assertEquals(testPresignedUrl, result.get(0).getThumbnailUrl());
 
 			verify(imageMapper).findImagesBySidoIdAndUserId(sidoId, testUserId);
-			verify(imageS3Service).generatePreSignedGetUrl(testImage.getImageName(), testUserId, "thumbnail");
+			verify(imageS3Service).generatePreSignedGetUrl((testImage.getImageName()), testUserId, ("thumbnail"));
 		}
 
 		@Test
@@ -396,7 +397,7 @@ class ImageServiceTest {
 			assertEquals(testPresignedUrl, result.get(0).getThumbnailUrl());
 
 			verify(imageMapper).findImagesBySigunguIdAndUserId(sigunguId, testUserId);
-			verify(imageS3Service).generatePreSignedGetUrl(testImage.getImageName(), testUserId, "thumbnail");
+			verify(imageS3Service).generatePreSignedGetUrl((testImage.getImageName()), testUserId, ("thumbnail"));
 		}
 
 		@Test
@@ -437,7 +438,7 @@ class ImageServiceTest {
 
 			assertEquals(testPresignedUrl, result);
 			verify(imageMapper).findImageByImageId(testImageId);
-			verify(imageS3Service).generatePreSignedGetUrl(testImage.getImageName(), testUserId, "original");
+			verify(imageS3Service).generatePreSignedGetUrl((testImage.getImageName()), testUserId, ("original"));
 		}
 
 		@Test
@@ -507,6 +508,10 @@ class ImageServiceTest {
 			when(imageMapper.findImageByImageId(imageId)).thenReturn(Optional.of(existingImage));
 			when(imageMapper.updateImageMetadata(eq(imageId), eq("수정된 이미지"), eq("수정된 설명"), isNull(), eq(1)))
 				.thenReturn(1);
+			doNothing().when(locationService).updateImageLocation(eq(1L), isNull(), isNull(), eq(imageId));
+			doNothing().when(tagService).processTagRemoval(imageId, (updateRequest));
+			doNothing().when(tagService).processTagAddition(imageId, (updateRequest));
+			when(tagService.getTagsForImageDisplay(imageId)).thenReturn(List.of());
 			when(imageS3Service.generatePreSignedGetUrl(anyString(), eq(userId), eq("original"))).thenReturn(
 				"test-url");
 
@@ -515,6 +520,9 @@ class ImageServiceTest {
 			assertNotNull(result);
 			verify(imageMapper, times(2)).findImageByImageId(imageId);
 			verify(imageMapper).updateImageMetadata(eq(imageId), eq("수정된 이미지"), eq("수정된 설명"), isNull(), eq(1));
+			verify(locationService).updateImageLocation(eq(1L), isNull(), isNull(), eq(imageId));
+			verify(tagService).processTagRemoval(imageId, (updateRequest));
+			verify(tagService).processTagAddition(imageId, (updateRequest));
 		}
 
 		@Test
@@ -565,7 +573,9 @@ class ImageServiceTest {
 			when(imageMapper.findImageByImageId(imageId)).thenReturn(Optional.of(existingImage));
 			when(imageMapper.updateImageMetadata(eq(imageId), eq("수정된 이미지"), eq("수정된 설명"), isNull(), eq(1)))
 				.thenReturn(1);
-			when(locationService.updateCoordinatePoint(eq(1L), any())).thenReturn(1);
+			doNothing().when(locationService).updateImageLocation((1L), (37.5665), (126.978), imageId);
+			doNothing().when(tagService).processTagRemoval(imageId, (updateRequest));
+			doNothing().when(tagService).processTagAddition(imageId, (updateRequest));
 			when(tagService.getTagsForImageDisplay(imageId)).thenReturn(List.of());
 			when(imageS3Service.generatePreSignedGetUrl(anyString(), eq(userId), eq("original"))).thenReturn(
 				"test-url");
@@ -575,7 +585,9 @@ class ImageServiceTest {
 			assertNotNull(result);
 			verify(imageMapper, times(2)).findImageByImageId(imageId);
 			verify(imageMapper).updateImageMetadata(eq(imageId), eq("수정된 이미지"), eq("수정된 설명"), isNull(), eq(1));
-			verify(locationService).updateCoordinatePoint(eq(1L), any());
+			verify(locationService).updateImageLocation((1L), (37.5665), (126.978), (imageId));
+			verify(tagService).processTagRemoval(imageId, (updateRequest));
+			verify(tagService).processTagAddition(imageId, (updateRequest));
 			verify(tagService, times(1)).getTagsForImageDisplay(imageId);
 		}
 
@@ -591,8 +603,11 @@ class ImageServiceTest {
 				.build();
 
 			when(imageMapper.findImageByImageId(imageId)).thenReturn(Optional.of(existingImage));
-			when(imageMapper.updateImageMetadata(imageId, "수정된 이미지", "수정된 설명", newDate, 1))
+			when(imageMapper.updateImageMetadata(eq(imageId), eq("수정된 이미지"), eq("수정된 설명"), eq(newDate), eq(1)))
 				.thenReturn(1);
+			doNothing().when(locationService).updateImageLocation(eq(1L), isNull(), isNull(), eq(imageId));
+			doNothing().when(tagService).processTagRemoval(imageId, (updateRequest));
+			doNothing().when(tagService).processTagAddition(imageId, (updateRequest));
 			when(tagService.getTagsForImageDisplay(imageId)).thenReturn(List.of());
 			when(imageS3Service.generatePreSignedGetUrl(anyString(), eq(userId), eq("original"))).thenReturn(
 				"test-url");
@@ -601,7 +616,10 @@ class ImageServiceTest {
 
 			assertNotNull(result);
 			verify(imageMapper, times(2)).findImageByImageId(imageId);
-			verify(imageMapper).updateImageMetadata(imageId, "수정된 이미지", "수정된 설명", newDate, 1);
+			verify(imageMapper).updateImageMetadata(eq(imageId), eq("수정된 이미지"), eq("수정된 설명"), eq(newDate), eq(1));
+			verify(locationService).updateImageLocation(eq(1L), isNull(), isNull(), eq(imageId));
+			verify(tagService).processTagRemoval(imageId, (updateRequest));
+			verify(tagService).processTagAddition(imageId, (updateRequest));
 			verify(tagService, times(1)).getTagsForImageDisplay(imageId);
 		}
 	}
@@ -680,6 +698,77 @@ class ImageServiceTest {
 	}
 
 	@Nested
+	@DisplayName("convertImageToImageDto 메서드 테스트")
+	class ConvertImageToImageDtoTest {
+		private final Long imageId = 1L;
+		private final Long userId = 2L;
+		
+		@Test
+		@DisplayName("성공 - 이미지 엔티티를 ImageDto로 변환")
+		void convertImageToImageDto_success() {
+			// given
+			JusoSido sido = new JusoSido();
+			ReflectionTestUtils.setField(sido, "sidoId", 1L);
+			ReflectionTestUtils.setField(sido, "sidoName", "서울특별시");
+
+			JusoSigungu sigungu = new JusoSigungu();
+			ReflectionTestUtils.setField(sigungu, "sigunguId", 1L);
+			ReflectionTestUtils.setField(sigungu, "sigunguName", "강남구");
+			ReflectionTestUtils.setField(sigungu, "sido", sido);
+
+			Coordinate coordinate = new Coordinate(127.0495556, 37.5398056);
+			PrecisionModel precisionModel = new PrecisionModel(PrecisionModel.FLOATING);
+		GeometryFactory geometryFactory = new GeometryFactory(precisionModel, 4326);
+			Point testPoint = geometryFactory.createPoint(coordinate);
+
+			CoordinatePoint coordPoint = new CoordinatePoint();
+			ReflectionTestUtils.setField(coordPoint, "coordinatePointId", 1L);
+			ReflectionTestUtils.setField(coordPoint, "coordinatePointName", "테스트 좌표");
+			ReflectionTestUtils.setField(coordPoint, "coordinatePointPoint", testPoint);
+			ReflectionTestUtils.setField(coordPoint, "sigungu", sigungu);
+			
+			LocalDateTime testDate = LocalDateTime.now();
+			Image image = Image.builder()
+				.imageName("테스트 이미지")
+				.imageContent("테스트 내용")
+				.imageDate(testDate)
+				.imageRegDate(testDate)
+				.isPublic(1)
+				.userId(userId)
+				.coordPoint(coordPoint)
+				.build();
+			ReflectionTestUtils.setField(image, "imageId", imageId);
+			
+			String testPresignedUrl = "http://test.url";
+			when(imageS3Service.generatePreSignedGetUrl((image.getImageName()), userId, ("original"))).thenReturn(testPresignedUrl);
+			when(tagService.getTagsForImageDisplay(imageId)).thenReturn(List.of());
+
+			// when
+			ImageDto result = imageService.convertImageToImageDto(image, userId);
+
+			// then
+			assertNotNull(result);
+			assertEquals(imageId, result.getImageId());
+			assertEquals(userId, result.getUserId());
+			assertEquals("테스트 이미지", result.getImageName());
+			assertEquals("테스트 내용", result.getImageContent());
+			assertEquals(testDate, result.getImageDate());
+			assertEquals(testDate, result.getImageRegDate());
+			assertEquals(1, result.getIsPublic());
+			assertEquals(testPresignedUrl, result.getImageUrl());
+			assertEquals("서울특별시", result.getSdName());
+			assertEquals("강남구", result.getSggName());
+			assertEquals(127.0495556, result.getLatitude());
+			assertEquals(37.5398056, result.getLongitude());
+			assertNotNull(result.getTags());
+			
+			verify(imageS3Service).generatePreSignedGetUrl((image.getImageName()), userId, ("original"));
+			verify(tagService).getTagsForImageDisplay(imageId);
+		}
+	}
+
+
+	@Nested
 	@DisplayName("이미지 태그 관련 테스트")
 	class ImageTagTest {
 		private final Long imageId = 1L;
@@ -700,7 +789,7 @@ class ImageServiceTest {
 
 			Coordinate coordinate = new Coordinate(127.0495556, 37.5398056);
 			PrecisionModel precisionModel = new PrecisionModel(PrecisionModel.FLOATING);
-			org.locationtech.jts.geom.GeometryFactory geometryFactory = new org.locationtech.jts.geom.GeometryFactory(precisionModel, 4326);
+			GeometryFactory geometryFactory = new GeometryFactory(precisionModel, 4326);
 			Point testPoint = geometryFactory.createPoint(coordinate);
 
 			CoordinatePoint coordPoint = new CoordinatePoint();
@@ -770,7 +859,7 @@ class ImageServiceTest {
 
 			Coordinate coordinate = new Coordinate(127.0495556, 37.5398056);
 			PrecisionModel precisionModel = new PrecisionModel(PrecisionModel.FLOATING);
-			org.locationtech.jts.geom.GeometryFactory geometryFactory = new org.locationtech.jts.geom.GeometryFactory(precisionModel, 4326);
+			GeometryFactory geometryFactory = new GeometryFactory(precisionModel, 4326);
 			Point testPoint = geometryFactory.createPoint(coordinate);
 
 			CoordinatePoint coordPoint = new CoordinatePoint();
@@ -796,18 +885,16 @@ class ImageServiceTest {
 			when(imageMapper.updateImageMetadata(any(), any(), any(), any(), any())).thenReturn(1);
 			when(tagService.getTagsForImageDisplay(imageId)).thenReturn(List.of());
 			when(imageS3Service.generatePreSignedGetUrl(any(), any(), any())).thenReturn("http://test.url");
-			doNothing().when(tagService).addTagToImageByName(any(), any());
-			doNothing().when(tagService).removeTagFromImage(any(), any());
+			doNothing().when(tagService).processTagRemoval(any(), any());
+			doNothing().when(tagService).processTagAddition(any(), any());
 
 			// when
 			ImageDto result = imageService.updateImageMetadata(imageId, userId, updateRequest);
 
 			// then
 			assertNotNull(result);
-			verify(tagService).addTagToImageByName(imageId, "새태그1");
-			verify(tagService).addTagToImageByName(imageId, "새태그2");
-			verify(tagService).removeTagFromImage(imageId, 1L);
-			verify(tagService).removeTagFromImage(imageId, 2L);
+			verify(tagService).processTagRemoval(imageId, (updateRequest));
+			verify(tagService).processTagAddition(imageId, (updateRequest));
 		}
 
 		@Test
@@ -825,7 +912,7 @@ class ImageServiceTest {
 
 			Coordinate coordinate = new Coordinate(127.0495556, 37.5398056);
 			PrecisionModel precisionModel = new PrecisionModel(PrecisionModel.FLOATING);
-			org.locationtech.jts.geom.GeometryFactory geometryFactory = new org.locationtech.jts.geom.GeometryFactory(precisionModel, 4326);
+			GeometryFactory geometryFactory = new GeometryFactory(precisionModel, 4326);
 			Point testPoint = geometryFactory.createPoint(coordinate);
 
 			CoordinatePoint coordPoint = new CoordinatePoint();
@@ -848,7 +935,9 @@ class ImageServiceTest {
 			
 			when(imageMapper.findImageByImageId(imageId)).thenReturn(Optional.of(existingImage));
 			when(imageMapper.updateImageMetadata(any(), any(), any(), any(), any())).thenReturn(1);
-			when(locationService.updateCoordinatePoint(eq(1L), any())).thenReturn(1);
+			doNothing().when(locationService).updateImageLocation(1L, 37.5665, 126.978, imageId);
+			doNothing().when(tagService).processTagRemoval(imageId, updateRequest);
+			doNothing().when(tagService).processTagAddition(imageId, updateRequest);
 			when(tagService.getTagsForImageDisplay(imageId)).thenReturn(List.of());
 			when(imageS3Service.generatePreSignedGetUrl(any(), any(), any())).thenReturn("http://test.url");
 
@@ -857,7 +946,9 @@ class ImageServiceTest {
 
 			// then
 			assertNotNull(result);
-			verify(locationService).updateCoordinatePoint(eq(1L), any());
+			verify(locationService).updateImageLocation(1L, 37.5665, 126.978, imageId);
+			verify(tagService).processTagRemoval(imageId, (updateRequest));
+			verify(tagService).processTagAddition(imageId, (updateRequest));
 		}
 	}
 }

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/location/controller/LocationControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/location/controller/LocationControllerTest.java
@@ -26,6 +26,7 @@ import com.trackery.trackerybackapiserver.domain.image.dto.ImageThumbnailDto;
 import com.trackery.trackerybackapiserver.domain.image.service.ImageService;
 import com.trackery.trackerybackapiserver.domain.location.dto.CoordinateDto;
 import com.trackery.trackerybackapiserver.domain.location.dto.CoordinateRequestDto;
+import com.trackery.trackerybackapiserver.domain.location.dto.LocationInfoDto;
 import com.trackery.trackerybackapiserver.domain.location.dto.LocationNameResponseDto;
 import com.trackery.trackerybackapiserver.domain.location.dto.MapResponseDto;
 import com.trackery.trackerybackapiserver.domain.location.dto.UserStatsDto;
@@ -411,6 +412,42 @@ public class LocationControllerTest extends CommonMockMvcControllerTestSetUp {
 					fieldWithPath("code").description("응답 코드"),
 					fieldWithPath("message").description("응답 메시지"),
 					fieldWithPath("data").description("이미지 목록").type(JsonFieldType.ARRAY)
+				)
+			));
+		}
+	}
+
+	@Nested
+	@DisplayName("시군구 위치 정보 조회 API 테스트")
+	class getSigunguLocationInfoTest {
+		@Test
+		@DisplayName("시군구 ID로 위치 정보 조회 성공")
+		void success() throws Exception {
+			LocationInfoDto response = new LocationInfoDto(0.0, 0.0, "서울특별시", "동작구");
+
+			when(locationService.getSigunguLocationInfoById(11200L)).thenReturn(response);
+
+			ResultActions result = mockMvc.perform(get("/api/location/sigungu/{sigunguId}/location-info", 11200L)
+				.with(user(customUserDetails)));
+
+			result
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.latitude").value(0.0))
+				.andExpect(jsonPath("$.data.longitude").value(0.0))
+				.andExpect(jsonPath("$.data.sidoName").value("서울특별시"))
+				.andExpect(jsonPath("$.data.sigunguName").value("동작구"));
+
+			result.andDo(document("get-sigungu-location-info-success",
+				pathParameters(
+					parameterWithName("sigunguId").description("시군구 ID")
+				),
+				responseFields(
+					fieldWithPath("code").description("응답 코드"),
+					fieldWithPath("message").description("응답 메시지"),
+					fieldWithPath("data.latitude").description("위도"),
+					fieldWithPath("data.longitude").description("경도"),
+					fieldWithPath("data.sidoName").description("시도명"),
+					fieldWithPath("data.sigunguName").description("시군구명")
 				)
 			));
 		}

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/location/service/LocationServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/location/service/LocationServiceTest.java
@@ -24,6 +24,7 @@ import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
 import com.trackery.trackerybackapiserver.domain.location.dto.CoordinateDto;
 import com.trackery.trackerybackapiserver.domain.location.dto.CoordinateRequestDto;
+import com.trackery.trackerybackapiserver.domain.location.dto.LocationInfoDto;
 import com.trackery.trackerybackapiserver.domain.location.dto.LocationNameResponseDto;
 import com.trackery.trackerybackapiserver.domain.location.dto.MapResponseDto;
 import com.trackery.trackerybackapiserver.domain.location.dto.UserStatsDto;
@@ -44,7 +45,7 @@ import com.trackery.trackerybackapiserver.domain.location.mapper.LocationMapper;
  * 25. 6. 13.		Narilee			최초 생성
  * 25. 6. 22.		Narilee			좌표 업데이트 테스트 추가
  * 25. 7. 11.		inari			태그 제거
- * 25. 7. 14.       inari       	테스트 코드 수정
+ * 25. 7. 14.       inari       	누락된 테스트 코드 추가
  */
 
 @ExtendWith(MockitoExtension.class)
@@ -440,6 +441,80 @@ class LocationServiceTest {
 		}
 	}
 
+	@Nested
+	@DisplayName("좌표로 시군구 조회 테스트")
+	class findSigunguByCoordinateTest {
+		@Test
+		@DisplayName("성공 - 좌표로 시군구 정보 반환")
+		void success() {
+			double latitude = 37.5665;
+			double longitude = 126.9780;
+			JusoSido seoul = createSido(11L, "서울특별시");
+			JusoSigungu dongjak = createSigungu(11200L, "동작구", seoul);
+
+			when(locationMapper.findSigunguByPoint(any(Point.class))).thenReturn(Optional.of(dongjak));
+
+			JusoSigungu result = locationService.findSigunguByCoordinate(latitude, longitude);
+
+			assertNotNull(result);
+			assertEquals("동작구", result.getSigunguName());
+			assertEquals(11200L, result.getSigunguId());
+			assertEquals("서울특별시", result.getSido().getSidoName());
+			assertEquals(11L, result.getSido().getSidoId());
+			verify(locationMapper, times(1)).findSigunguByPoint(any(Point.class));
+		}
+
+		@Test
+		@DisplayName("실패 - 좌표로 시군구를 찾을 수 없는 경우 null 반환")
+		void notFound() {
+			double latitude = 0.0;
+			double longitude = 0.0;
+
+			when(locationMapper.findSigunguByPoint(any(Point.class))).thenReturn(Optional.empty());
+
+			JusoSigungu result = locationService.findSigunguByCoordinate(latitude, longitude);
+
+			assertNull(result);
+			verify(locationMapper, times(1)).findSigunguByPoint(any(Point.class));
+		}
+	}
+
+	@Nested
+	@DisplayName("시군구 ID로 위치 정보 조회 테스트")
+	class getSigunguLocationInfoByIdTest {
+		@Test
+		@DisplayName("성공 - 시군구 ID로 위치 정보 반환")
+		void success() {
+			Long sigunguId = 11200L;
+			JusoSido seoul = createSido(11L, "서울특별시");
+			JusoSigungu dongjak = createSigungu(sigunguId, "동작구", seoul);
+
+			when(locationMapper.findSigunguById(sigunguId)).thenReturn(Optional.of(dongjak));
+
+			LocationInfoDto result = locationService.getSigunguLocationInfoById(sigunguId);
+
+			assertNotNull(result);
+			assertEquals(0.0, result.latitude());
+			assertEquals(0.0, result.longitude());
+			assertEquals("서울특별시", result.sidoName());
+			assertEquals("동작구", result.sigunguName());
+			verify(locationMapper, times(1)).findSigunguById(sigunguId);
+		}
+
+		@Test
+		@DisplayName("실패 - 존재하지 않는 시군구 ID")
+		void notFound() {
+			Long sigunguId = 99999L;
+			when(locationMapper.findSigunguById(sigunguId)).thenReturn(Optional.empty());
+
+			ApiException exception = assertThrows(ApiException.class,
+				() -> locationService.getSigunguLocationInfoById(sigunguId));
+
+			assertEquals(ErrorCode.NOT_FOUND_SIGUNGU, exception.getErrorCode());
+			verify(locationMapper, times(1)).findSigunguById(sigunguId);
+		}
+	}
+
 	private JusoSido createSido(Long sidoId, String sidoName) {
 		JusoSido sido = new JusoSido();
 		sido.setSidoId(sidoId);
@@ -453,6 +528,77 @@ class LocationServiceTest {
 		sigungu.setSigunguName(sigunguName);
 		sigungu.setSido(sido);
 		return sigungu;
+	}
+
+	@Nested
+	@DisplayName("이미지 위치 정보 업데이트 테스트")
+	class updateImageLocationTest {
+		@Test
+		@DisplayName("성공 - 위치 정보 수정")
+		void success() {
+			Long coordinatePointId = 1L;
+			Double latitude = 37.5665;
+			Double longitude = 126.9780;
+			Long imageId = 1L;
+			
+			JusoSido seoul = createSido(11L, "서울특별시");
+			JusoSigungu dongjak = createSigungu(11200L, "동작구", seoul);
+			
+			when(locationMapper.findSigunguByPoint(any(Point.class))).thenReturn(Optional.of(dongjak));
+			when(locationMapper.updateCoordinatePointById(eq(coordinatePointId), eq("서울특별시 동작구"),
+				any(Point.class), eq(11200L), any(LocalDateTime.class))).thenReturn(1);
+			
+			assertDoesNotThrow(() -> locationService.updateImageLocation(coordinatePointId, latitude, longitude, imageId));
+			
+			verify(locationMapper, times(1)).findSigunguByPoint(any(Point.class));
+			verify(locationMapper, times(1)).updateCoordinatePointById(eq(coordinatePointId), eq("서울특별시 동작구"),
+				any(Point.class), eq(11200L), any(LocalDateTime.class));
+		}
+
+		@Test
+		@DisplayName("성공 - latitude가 null인 경우 처리하지 않음")
+		void skipWhenLatitudeIsNull() {
+			Long coordinatePointId = 1L;
+			Double latitude = null;
+			Double longitude = 126.9780;
+			Long imageId = 1L;
+			
+			assertDoesNotThrow(() -> locationService.updateImageLocation(coordinatePointId, latitude, longitude, imageId));
+			
+			verify(locationMapper, never()).findSigunguByPoint(any(Point.class));
+			verify(locationMapper, never()).updateCoordinatePointById(any(), any(), any(), any(), any());
+		}
+
+		@Test
+		@DisplayName("성공 - longitude가 null인 경우 처리하지 않음")
+		void skipWhenLongitudeIsNull() {
+			Long coordinatePointId = 1L;
+			Double latitude = 37.5665;
+			Double longitude = null;
+			Long imageId = 1L;
+			
+			assertDoesNotThrow(() -> locationService.updateImageLocation(coordinatePointId, latitude, longitude, imageId));
+			
+			verify(locationMapper, never()).findSigunguByPoint(any(Point.class));
+			verify(locationMapper, never()).updateCoordinatePointById(any(), any(), any(), any(), any());
+		}
+
+		@Test
+		@DisplayName("실패 - 좌표 업데이트 실패 시 ApiException 발생")
+		void failureWhenUpdateFails() {
+			Long coordinatePointId = 1L;
+			Double latitude = 37.5665;
+			Double longitude = 126.9780;
+			Long imageId = 1L;
+			
+			when(locationMapper.findSigunguByPoint(any(Point.class))).thenThrow(new RuntimeException("Database error"));
+			
+			ApiException exception = assertThrows(ApiException.class,
+				() -> locationService.updateImageLocation(coordinatePointId, latitude, longitude, imageId));
+			
+			assertEquals(ErrorCode.UPDATE_FAILED_LOCATION, exception.getErrorCode());
+			verify(locationMapper, times(1)).findSigunguByPoint(any(Point.class));
+		}
 	}
 
 	@Nested

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/tag/service/TagServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/tag/service/TagServiceTest.java
@@ -5,12 +5,16 @@ import static org.mockito.Mockito.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -36,9 +40,10 @@ import com.trackery.trackerybackapiserver.domain.tag.mapper.TagMapper;
  * ===========================================================
  * DATE              AUTHOR             NOTE
  * -----------------------------------------------------------
- * 25. 7. 8.        inari       최초 생성
+ * 25. 7. 8.         inari       최초 생성
  * 25. 7. 11.        inari       최초 생성
  * 25. 7. 14.        inari       테스트 코드 수정
+ * 25. 7. 15.        inari       코드 스멜 수정
  */
 @ExtendWith(MockitoExtension.class)
 class TagServiceTest {
@@ -519,28 +524,22 @@ class TagServiceTest {
 			assertEquals(ErrorCode.BAD_REQUEST, exception.getErrorCode());
 		}
 
-		@Test
-		@DisplayName("겨울 계절 태그 생성")
-		void createSeasonTags_Winter() {
-			// given
-			String dateTimeStr = "2024/12/25 10:30:25";
-			when(tagMapper.findTagByNameAndType("겨울", TagType.SEASON)).thenReturn(null);
-			doNothing().when(tagMapper).insertTag(any(Tag.class));
-
-			// when
-			List<TagNameResponseDto> result = tagService.createSeasonTags(dateTimeStr);
-
-			// then
-			assertEquals(1, result.size());
-			assertEquals("겨울", result.get(0).getTagName());
+		static Stream<Arguments> provideSeasonTestData() {
+			return Stream.of(
+				Arguments.of("2024/12/25 10:30:25", "겨울", "겨울 계절 태그 생성"),
+				Arguments.of("2024/4/15 08:30:25", "봄", "봄 계절 태그 생성"),
+				Arguments.of("2024/10/15 19:30:25", "가을", "가을 계절 태그 생성"),
+				Arguments.of("2024/7/15 23:30:25", "여름", "밤 시간대에도 계절 태그만 생성"),
+				Arguments.of("2024/7/15 12:30:25", "여름", "점심 시간대에도 계절 태그만 생성")
+			);
 		}
 
-		@Test
-		@DisplayName("봄 계절 태그 생성")
-		void createSeasonTags_Spring() {
+		@ParameterizedTest
+		@MethodSource("provideSeasonTestData")
+		@DisplayName("다양한 날짜와 시간에 따른 계절 태그 생성")
+		void createSeasonTags_VariousSeasons(String dateTimeStr, String expectedSeason, String testDescription) {
 			// given
-			String dateTimeStr = "2024/4/15 08:30:25";
-			when(tagMapper.findTagByNameAndType("봄", TagType.SEASON)).thenReturn(null);
+			when(tagMapper.findTagByNameAndType(expectedSeason, TagType.SEASON)).thenReturn(null);
 			doNothing().when(tagMapper).insertTag(any(Tag.class));
 
 			// when
@@ -548,55 +547,7 @@ class TagServiceTest {
 
 			// then
 			assertEquals(1, result.size());
-			assertEquals("봄", result.get(0).getTagName());
-		}
-
-		@Test
-		@DisplayName("가을 계절 태그 생성")
-		void createSeasonTags_Autumn() {
-			// given
-			String dateTimeStr = "2024/10/15 19:30:25";
-			when(tagMapper.findTagByNameAndType("가을", TagType.SEASON)).thenReturn(null);
-			doNothing().when(tagMapper).insertTag(any(Tag.class));
-
-			// when
-			List<TagNameResponseDto> result = tagService.createSeasonTags(dateTimeStr);
-
-			// then
-			assertEquals(1, result.size());
-			assertEquals("가을", result.get(0).getTagName());
-		}
-
-		@Test
-		@DisplayName("밤 시간대에도 계절 태그만 생성")
-		void createSeasonTags_Night() {
-			// given
-			String dateTimeStr = "2024/7/15 23:30:25";
-			when(tagMapper.findTagByNameAndType("여름", TagType.SEASON)).thenReturn(null);
-			doNothing().when(tagMapper).insertTag(any(Tag.class));
-
-			// when
-			List<TagNameResponseDto> result = tagService.createSeasonTags(dateTimeStr);
-
-			// then
-			assertEquals(1, result.size());
-			assertEquals("여름", result.get(0).getTagName());
-		}
-
-		@Test
-		@DisplayName("점심 시간대에도 계절 태그만 생성")
-		void createSeasonTags_Lunch() {
-			// given
-			String dateTimeStr = "2024/7/15 12:30:25";
-			when(tagMapper.findTagByNameAndType("여름", TagType.SEASON)).thenReturn(null);
-			doNothing().when(tagMapper).insertTag(any(Tag.class));
-
-			// when
-			List<TagNameResponseDto> result = tagService.createSeasonTags(dateTimeStr);
-
-			// then
-			assertEquals(1, result.size());
-			assertEquals("여름", result.get(0).getTagName());
+			assertEquals(expectedSeason, result.get(0).getTagName());
 		}
 	}
 

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/tag/service/TagServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/tag/service/TagServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -18,9 +19,11 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
+import com.trackery.trackerybackapiserver.domain.image.dto.ImageUpdateRequestDto;
 import com.trackery.trackerybackapiserver.domain.location.entity.JusoSido;
 import com.trackery.trackerybackapiserver.domain.location.entity.JusoSigungu;
 import com.trackery.trackerybackapiserver.domain.location.service.LocationService;
@@ -43,7 +46,7 @@ import com.trackery.trackerybackapiserver.domain.tag.mapper.TagMapper;
  * 25. 7. 8.         inari       최초 생성
  * 25. 7. 11.        inari       최초 생성
  * 25. 7. 14.        inari       테스트 코드 수정
- * 25. 7. 15.        inari       코드 스멜 수정
+ * 25. 7. 15.        inari       코드 스멜 수정, 테스트코드 추가
  */
 @ExtendWith(MockitoExtension.class)
 class TagServiceTest {
@@ -69,7 +72,7 @@ class TagServiceTest {
 			.createdAt(LocalDateTime.now())
 			.build();
 		// Set tagId using reflection since it's not included in the builder
-		org.springframework.test.util.ReflectionTestUtils.setField(testTag, "tagId", 1L);
+		ReflectionTestUtils.setField(testTag, "tagId", 1L);
 
 		createRequestDto = new TagCreateRequestDto("새태그", null);
 	}
@@ -426,7 +429,7 @@ class TagServiceTest {
 				.tagUseCount(0L)
 				.createdAt(LocalDateTime.now())
 				.build();
-			org.springframework.test.util.ReflectionTestUtils.setField(newTag, "tagId", 2L);
+			ReflectionTestUtils.setField(newTag, "tagId", 2L);
 
 			when(tagMapper.findTagById(tagId)).thenReturn(testTag);
 			when(tagMapper.isImageTagConnected(imageId, tagId)).thenReturn(true);
@@ -435,7 +438,7 @@ class TagServiceTest {
 			// Mock insertTag to set the ID of the tag after insertion
 			doAnswer(invocation -> {
 				Tag tag = invocation.getArgument(0);
-				org.springframework.test.util.ReflectionTestUtils.setField(tag, "tagId", 2L);
+				ReflectionTestUtils.setField(tag, "tagId", 2L);
 				return null;
 			}).when(tagMapper).insertTag(any(Tag.class));
 			
@@ -611,7 +614,7 @@ class TagServiceTest {
 				.tagUseCount(1L)
 				.createdAt(LocalDateTime.now())
 				.build();
-			org.springframework.test.util.ReflectionTestUtils.setField(sidoTag, "tagId", 1L);
+			ReflectionTestUtils.setField(sidoTag, "tagId", 1L);
 
 			Tag sigunguTag = Tag.builder()
 				.tagName("강남구")
@@ -619,7 +622,7 @@ class TagServiceTest {
 				.tagUseCount(1L)
 				.createdAt(LocalDateTime.now())
 				.build();
-			org.springframework.test.util.ReflectionTestUtils.setField(sigunguTag, "tagId", 2L);
+			ReflectionTestUtils.setField(sigunguTag, "tagId", 2L);
 
 			Tag customTag = Tag.builder()
 				.tagName("커스텀태그")
@@ -627,7 +630,7 @@ class TagServiceTest {
 				.tagUseCount(1L)
 				.createdAt(LocalDateTime.now())
 				.build();
-			org.springframework.test.util.ReflectionTestUtils.setField(customTag, "tagId", 3L);
+			ReflectionTestUtils.setField(customTag, "tagId", 3L);
 
 			// 무순서로 리스트 생성
 			List<Tag> unorderedTags = List.of(customTag, sidoTag, sigunguTag);
@@ -691,6 +694,260 @@ class TagServiceTest {
 			// then
 			verify(tagMapper).decrementTagUseCountByImageId(imageId);
 			verify(tagMapper).deleteImageTagsByImageId(imageId);
+		}
+	}
+
+	@Nested
+	@DisplayName("태그 삭제 처리 테스트")
+	class ProcessTagRemovalTest {
+
+		@Test
+		@DisplayName("이미지 수정 요청에서 태그 삭제 처리 성공")
+		void processTagRemoval_Success() {
+			// given
+			Long imageId = 1L;
+			List<Long> tagsToRemove = List.of(1L, 2L, 3L);
+			
+			// ImageUpdateRequestDto mock
+			com.trackery.trackerybackapiserver.domain.image.dto.ImageUpdateRequestDto updateRequest = 
+				com.trackery.trackerybackapiserver.domain.image.dto.ImageUpdateRequestDto.builder()
+					.tagsToRemove(tagsToRemove)
+					.build();
+			
+			doNothing().when(tagMapper).deleteImageTag(any(), any());
+			doNothing().when(tagMapper).decrementTagUseCount(any());
+
+			// when
+			tagService.processTagRemoval(imageId, updateRequest);
+
+			// then
+			verify(tagMapper, times(3)).deleteImageTag(eq(imageId), any());
+			verify(tagMapper, times(3)).decrementTagUseCount(any());
+		}
+
+		@Test
+		@DisplayName("삭제할 태그가 없는 경우 아무것도 하지 않음")
+		void processTagRemoval_EmptyList() {
+			// given
+			Long imageId = 1L;
+			ImageUpdateRequestDto updateRequest =
+				ImageUpdateRequestDto.builder()
+					.tagsToRemove(List.of())
+					.build();
+
+			// when
+			tagService.processTagRemoval(imageId, updateRequest);
+
+			// then
+			verify(tagMapper, never()).deleteImageTag(any(), any());
+			verify(tagMapper, never()).decrementTagUseCount(any());
+		}
+
+		@Test
+		@DisplayName("삭제할 태그가 null인 경우 아무것도 하지 않음")
+		void processTagRemoval_NullList() {
+			// given
+			Long imageId = 1L;
+			ImageUpdateRequestDto updateRequest =
+				ImageUpdateRequestDto.builder()
+					.tagsToRemove(null)
+					.build();
+
+			// when
+			tagService.processTagRemoval(imageId, updateRequest);
+
+			// then
+			verify(tagMapper, never()).deleteImageTag(any(), any());
+			verify(tagMapper, never()).decrementTagUseCount(any());
+		}
+
+		@Test
+		@DisplayName("태그 삭제 중 예외 발생 시 로그 출력 후 계속 진행")
+		void processTagRemoval_ExceptionHandling() {
+			// given
+			Long imageId = 1L;
+			List<Long> tagsToRemove = List.of(1L, 2L);
+			
+			ImageUpdateRequestDto updateRequest =
+				ImageUpdateRequestDto.builder()
+					.tagsToRemove(tagsToRemove)
+					.build();
+			
+			// 첫 번째 태그 삭제 시 예외 발생
+			doThrow(new RuntimeException("Database error")).when(tagMapper).deleteImageTag(imageId, 1L);
+			// 두 번째 태그 삭제는 정상 처리
+			doNothing().when(tagMapper).deleteImageTag(imageId, 2L);
+			doNothing().when(tagMapper).decrementTagUseCount(2L);
+
+			// when
+			tagService.processTagRemoval(imageId, updateRequest);
+
+			// then
+			verify(tagMapper, times(2)).deleteImageTag(eq(imageId), any());
+			verify(tagMapper, times(1)).decrementTagUseCount(2L);
+		}
+	}
+
+	@Nested
+	@DisplayName("태그 추가 처리 테스트")
+	class ProcessTagAdditionTest {
+
+		@Test
+		@DisplayName("이미지 수정 요청에서 태그 추가 처리 성공")
+		void processTagAddition_Success() {
+			// given
+			Long imageId = 1L;
+			List<String> tagsToAdd = List.of("새태그1", "새태그2", "새태그3");
+			
+			ImageUpdateRequestDto updateRequest =
+				ImageUpdateRequestDto.builder()
+					.tagsToAdd(tagsToAdd)
+					.build();
+			
+			// 각 태그명에 대해 기존 태그 없음으로 설정
+			when(tagMapper.findExistingTagByName(any())).thenReturn(null);
+			doNothing().when(tagMapper).insertTag(any());
+			doNothing().when(tagMapper).insertImageTag(any());
+			doNothing().when(tagMapper).incrementTagUseCount(any());
+
+			// when
+			tagService.processTagAddition(imageId, updateRequest);
+
+			// then
+			verify(tagMapper, times(3)).findExistingTagByName(any());
+			verify(tagMapper, times(3)).insertTag(any());
+			verify(tagMapper, times(3)).insertImageTag(any());
+			verify(tagMapper, times(3)).incrementTagUseCount(any());
+		}
+
+		@Test
+		@DisplayName("기존 태그가 있는 경우 새로 생성하지 않고 기존 태그 사용")
+		void processTagAddition_ExistingTag() {
+			// given
+			Long imageId = 1L;
+			List<String> tagsToAdd = List.of("기존태그");
+			
+			ImageUpdateRequestDto updateRequest =
+				ImageUpdateRequestDto.builder()
+					.tagsToAdd(tagsToAdd)
+					.build();
+			
+			when(tagMapper.findExistingTagByName("기존태그")).thenReturn(testTag);
+			doNothing().when(tagMapper).insertImageTag(any());
+			doNothing().when(tagMapper).incrementTagUseCount(any());
+
+			// when
+			tagService.processTagAddition(imageId, updateRequest);
+
+			// then
+			verify(tagMapper, times(1)).findExistingTagByName("기존태그");
+			verify(tagMapper, never()).insertTag(any());
+			verify(tagMapper, times(1)).insertImageTag(any());
+			verify(tagMapper, times(1)).incrementTagUseCount(any());
+		}
+
+		@Test
+		@DisplayName("추가할 태그가 없는 경우 아무것도 하지 않음")
+		void processTagAddition_EmptyList() {
+			// given
+			Long imageId = 1L;
+			ImageUpdateRequestDto updateRequest =
+				ImageUpdateRequestDto.builder()
+					.tagsToAdd(List.of())
+					.build();
+
+			// when
+			tagService.processTagAddition(imageId, updateRequest);
+
+			// then
+			verify(tagMapper, never()).findExistingTagByName(any());
+			verify(tagMapper, never()).insertTag(any());
+			verify(tagMapper, never()).insertImageTag(any());
+			verify(tagMapper, never()).incrementTagUseCount(any());
+		}
+
+		@Test
+		@DisplayName("추가할 태그가 null인 경우 아무것도 하지 않음")
+		void processTagAddition_NullList() {
+			// given
+			Long imageId = 1L;
+			ImageUpdateRequestDto updateRequest =
+				ImageUpdateRequestDto.builder()
+					.tagsToAdd(null)
+					.build();
+
+			// when
+			tagService.processTagAddition(imageId, updateRequest);
+
+			// then
+			verify(tagMapper, never()).findExistingTagByName(any());
+			verify(tagMapper, never()).insertTag(any());
+			verify(tagMapper, never()).insertImageTag(any());
+			verify(tagMapper, never()).incrementTagUseCount(any());
+		}
+
+		@Test
+		@DisplayName("빈 문자열이나 공백 태그는 무시")
+		void processTagAddition_FilterEmptyAndWhitespace() {
+			// given
+			Long imageId = 1L;
+			List<String> tagsToAdd = new ArrayList<>();
+			tagsToAdd.add("유효한태그");
+			tagsToAdd.add("");
+			tagsToAdd.add("   ");
+			tagsToAdd.add(null);
+			tagsToAdd.add("또다른태그");
+			
+			ImageUpdateRequestDto updateRequest =
+				ImageUpdateRequestDto.builder()
+					.tagsToAdd(tagsToAdd)
+					.build();
+			
+			when(tagMapper.findExistingTagByName(any())).thenReturn(null);
+			doNothing().when(tagMapper).insertTag(any());
+			doNothing().when(tagMapper).insertImageTag(any());
+			doNothing().when(tagMapper).incrementTagUseCount(any());
+
+			// when
+			tagService.processTagAddition(imageId, updateRequest);
+
+			// then
+			// 유효한 태그 2개만 처리되어야 함
+			verify(tagMapper, times(2)).findExistingTagByName(any());
+			verify(tagMapper, times(2)).insertTag(any());
+			verify(tagMapper, times(2)).insertImageTag(any());
+			verify(tagMapper, times(2)).incrementTagUseCount(any());
+		}
+
+		@Test
+		@DisplayName("태그 추가 중 예외 발생 시 로그 출력 후 계속 진행")
+		void processTagAddition_ExceptionHandling() {
+			// given
+			Long imageId = 1L;
+			List<String> tagsToAdd = List.of("실패태그", "성공태그");
+			
+			ImageUpdateRequestDto updateRequest =
+				ImageUpdateRequestDto.builder()
+					.tagsToAdd(tagsToAdd)
+					.build();
+			
+			// 첫 번째 태그 추가 시 예외 발생
+			when(tagMapper.findExistingTagByName("실패태그")).thenReturn(null);
+			doThrow(new RuntimeException("Database error")).when(tagMapper).insertTag(any());
+			
+			// 두 번째 태그는 정상 처리
+			when(tagMapper.findExistingTagByName("성공태그")).thenReturn(testTag);
+			doNothing().when(tagMapper).insertImageTag(any());
+			doNothing().when(tagMapper).incrementTagUseCount(any());
+
+			// when
+			tagService.processTagAddition(imageId, updateRequest);
+
+			// then
+			verify(tagMapper, times(2)).findExistingTagByName(any());
+			verify(tagMapper, times(1)).insertTag(any());
+			verify(tagMapper, times(1)).insertImageTag(any());
+			verify(tagMapper, times(1)).incrementTagUseCount(any());
 		}
 	}
 }


### PR DESCRIPTION
  - 코드 스멜 제거: SonarQube 코드 스멜 제거하고 테스트 커버리지 높였습니다.
  - 사용되지 않는 매퍼 삭제 및 매퍼에 존재하던 오타를 제거하여 버그를 잡았습니다.
  - imageService에 존재하던 위치 변경이나 태그 변경 메서드들을 각 location과 tag 도메인으로 이동후 테스트까지 완료하였습니다.