### PR TITLE
Refactor/태그 삭제 처리

### DIFF
--- a/src/main/java/com/trackery/trackerybackapiserver/domain/tag/service/TagService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/tag/service/TagService.java
@@ -52,6 +52,7 @@ import lombok.extern.slf4j.Slf4j;
  * 25. 7. 14.		inari		TagType enum에 추가하고 locationName 파라미터대신 sidoName, sigunguName으로 분리
  * 25. 7. 14.		inari		TagType에 따른 태그 정렬 추가
  * 25. 7. 15.		inari		ImageService에 있던 updateImageLocation, processTagRemoval, processTagAddition 각 도메인으로 이동
+ * 25. 7. 28.		inari		태그 카운트가 0일떄 자동 삭제 기능 제거
  */
 @Slf4j
 @Service

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/tag/service/TagService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/tag/service/TagService.java
@@ -465,13 +465,6 @@ public class TagService {
 		tagMapper.decrementTagUseCount(tagId);
 		tagMapper.incrementTagUseCount(targetTag.getTagId());
 
-		// 기존 태그가 더 이상 사용되지 않으면 삭제 (CUSTOM 타입만)
-		Tag updatedOldTag = tagMapper.findTagById(tagId);
-		if (updatedOldTag != null && updatedOldTag.getTagUseCount() == 0
-			&& updatedOldTag.getTagType().equals(TagType.CUSTOM)) {
-			tagMapper.deleteUnusedTag(tagId);
-		}
-
 		// 업데이트된 새 태그 정보 반환
 		Tag finalTag = tagMapper.findTagById(targetTag.getTagId());
 		return convertToResponseDto(finalTag);

--- a/src/main/resources/mapper/ImageMapper.xml
+++ b/src/main/resources/mapper/ImageMapper.xml
@@ -179,6 +179,7 @@
             <if test="imageContent != null">image_contents = #{imageContent},</if>
             <if test="imageDate != null">image_date = #{imageDate},</if>
             <if test="isPublic != null">is_public = #{isPublic},</if>
+            image_id = #{imageId}
         </set>
         WHERE image_id = #{imageId}
         AND is_deleted = 0

--- a/src/main/resources/mapper/ImageMapper.xml
+++ b/src/main/resources/mapper/ImageMapper.xml
@@ -178,7 +178,7 @@
             <if test="imageName != null">image_name = #{imageName},</if>
             <if test="imageContent != null">image_contents = #{imageContent},</if>
             <if test="imageDate != null">image_date = #{imageDate},</if>
-            <if test="isPublic != null">is_public = #{isPublic}</if>
+            <if test="isPublic != null">is_public = #{isPublic},</if>
         </set>
         WHERE image_id = #{imageId}
         AND is_deleted = 0

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/tag/service/TagServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/tag/service/TagServiceTest.java
@@ -50,6 +50,7 @@ import com.trackery.trackerybackapiserver.domain.tag.mapper.TagMapper;
  * 25. 7. 14.		inari		테스트코드 수정 및 adoc 변경
  * 25. 7. 15.		inari		단일 테스트로 변경하여 코드스멜 해결
  * 25. 7. 15.		inari		테스트 코드 작성 및 문서 수정
+ * 25. 7. 28.		inari		태그 삭제 기능 제거
  */
 @ExtendWith(MockitoExtension.class)
 class TagServiceTest {
@@ -449,7 +450,6 @@ class TagServiceTest {
 			doNothing().when(tagMapper).insertImageTag(any());
 			doNothing().when(tagMapper).decrementTagUseCount(tagId);
 			doNothing().when(tagMapper).incrementTagUseCount(any());
-			when(tagMapper.deleteUnusedTag(tagId)).thenReturn(1);
 			when(tagMapper.findTagById(2L)).thenReturn(newTag);
 
 			// when


### PR DESCRIPTION
현재 태그 카운트가 0일시 자동으로 삭제되는 코드가 작동되지 않는 문제가 발생중
트랜잭션 문제나 이후 쿠버네티스 도입후 여러 어플리케이션에서 동시 db 삭제요청 문제가 발생할수 있는 문제 발견

- ImageMapper.xml: <set> 태그 빈 SET 절로 인한 SQL 문법 오류 수정
- TagService: 태그 수정 시 카운트 0인 CUSTOM 태그 자동 삭제 기능 제거
  * 분산 환경 동시성 문제 방지
  * 예기치 못한 태그 삭제 방지

이후 자동 태그 삭제기능은 관리자 api를 통한 custom 태그 정리 기능을 구현하거나 외부에서 배치로 처리 도입등 다른방식으로 처리할 예정입니다.