### PR TITLE
Feature/유저 중복 유효성

### DIFF
--- a/src/main/java/com/trackery/trackerybackapiserver/domain/common/response/enums/ErrorCode.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/common/response/enums/ErrorCode.java
@@ -58,6 +58,10 @@ public enum ErrorCode {
 	 */
 	BAD_REQUEST(HttpStatus.BAD_REQUEST, 400, "Bad Request"),
 	/**
+	 * 유효하지 않은 입력값 (HttpStatus.BAD_REQUEST, 400, "유저명은 4~15자 길이에 영문 대소문자, 숫자, 밑줄(_)로 작성해주세요.")
+	 */
+	INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, 400, "유저명은 4~15자 길이에 영문 대소문자, 숫자, 밑줄(_)로 작성해주세요."),
+	/**
 	 * 인증되지 않은 요청 (HttpStatus.UNAUTHORIZED, 401, "Unauthorized")
 	 */
 	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 401, "Unauthorized"),

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/controller/UserController.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/controller/UserController.java
@@ -30,6 +30,7 @@ import com.trackery.trackerybackapiserver.domain.user.entity.CustomUserDetails;
 import com.trackery.trackerybackapiserver.domain.user.service.UserService;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -153,7 +154,10 @@ public class UserController {
 	 * @return : 유저명 토큰과 boolean 값을 담은 응답
 	 */
 	@GetMapping("/exists/username")
-	public ResponseEntity<ApiResponse<Boolean>> checkUsernameAvailability(@RequestParam String value) {
+	public ResponseEntity<ApiResponse<Boolean>> checkUsernameAvailability(
+		@RequestParam
+		@Pattern(regexp = "^\\w{4,15}$",
+			message = "유저명은 4~15자 길이에 영문 대소문자, 숫자, 밑줄(_)로 작성해주세요.") String value) {
 		UserNameAvailabilityResponseDto result = userService.checkUsernameAvailability(value);
 
 		if (result.available()) {

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/dto/UserRegisterDto.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/dto/UserRegisterDto.java
@@ -23,10 +23,11 @@ import lombok.NoArgsConstructor;
  * 25. 2. 14.		durururuk		비밀번호에 공백 허용하지 않게 수정
  * 25. 2. 14.		durururuk		userName -> username 오타 수정
  * 25. 2. 17.		durururuk		Java 컨벤션에 맞게 username -> userName 수정
- * 25. 2. 18.		inari		dev 병합후 랜딩페이지 엔드포인트 수정
- * 25. 2. 24.		inari		자바독 주석 추가
+ * 25. 2. 18.		inari			dev 병합후 랜딩페이지 엔드포인트 수정
+ * 25. 2. 24.		inari			자바독 주석 추가
  * 25. 3. 14.		durururuk		수정된 로직에 맞게 테스트 코드 수정
  * 25. 3. 20.		durururuk		사용하지 않는 import 제거
+ * 25. 8. 7.		inari			닉네임 패턴 추가
  */
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -36,12 +37,14 @@ public class UserRegisterDto {
 	 * 필수 입력값 입니다.
 	 */
 	@NotBlank(message = "닉네임은 공백일 수 없습니다.")
+	@Pattern(regexp = "^.{1,20}$", message = "닉네임은 최대 20자까지 입력 가능합니다.")
 	private String nickname;
 
 	/**
 	 * 사용자의 비밀번호입니다.
 	 * 비밀번호는 최소 16자리이며, 대문자, 소문자, 숫자, 밑줄(_)을 제외한 특수문자를 1개이상 포함해야 합니다.
 	 */
+	@NotBlank
 	@Pattern(
 		regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^\\w\\s])^\\S{16,}$",
 		message = "비밀번호는 최소 16자리이며, 대문자, 소문자, 숫자, 밑줄(_)을 제외한 특수문자를 포함해야 합니다."

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/dto/update/UpdateNicknameDto.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/dto/update/UpdateNicknameDto.java
@@ -1,6 +1,7 @@
 package com.trackery.trackerybackapiserver.domain.user.dto.update;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -16,11 +17,13 @@ import lombok.NoArgsConstructor;
  * 25. 4. 11.		durururuk		최초 생성
  * 25. 4. 12.		durururuk		닉네임 변경 기능 구현
  * 25. 4. 12.		durururuk		유저명 변경 기능 구현
- * 25. 4. 14.		durururuk		UpdateUserInfo Controller, Serivce 단위테스트 작성
+ * 25. 4. 14.		durururuk		UpdateUserInfo Controller, Service 단위테스트 작성
+ * 25. 8. 7.		inari			닉네임 패턴 추가
  */
 @Getter
 @NoArgsConstructor
 public class UpdateNicknameDto {
 	@NotBlank
+	@Pattern(regexp = "^.{1,20}$", message = "닉네임은 최대 20자까지 입력 가능합니다.")
 	private String nickname;
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/dto/update/UpdateUserNameDto.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/dto/update/UpdateUserNameDto.java
@@ -1,5 +1,7 @@
 package com.trackery.trackerybackapiserver.domain.user.dto.update;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -13,9 +15,12 @@ import lombok.NoArgsConstructor;
  * DATE              AUTHOR             NOTE
  * -----------------------------------------------------------
  * 25. 4. 12.		durururuk		최초 생성
+ * 25. 8. 7.		inari			아이디 패턴 추가
  */
 @Getter
 @NoArgsConstructor
 public class UpdateUserNameDto {
+	@NotBlank
+	@Pattern(regexp = "^[a-zA-Z0-9_]{4,15}$", message = "아이디는 4~15자 길이에 영문 대소문자, 숫자, 밑줄(_)로 작성해주세요.")
 	private String userName;
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/UserService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/UserService.java
@@ -51,13 +51,13 @@ import lombok.extern.slf4j.Slf4j;
  * 25. 2. 17.		durururuk		userName -> username 오타 수정
  * 25. 2. 17.		durururuk		username 중복 체크 SQL count(*) -> EXISTS()로 수정
  * 25. 2. 17.		durururuk		Java 컨벤션에 맞게 username -> userName 수정
- * 25. 2. 18.		inari		dev 병합후 랜딩페이지 엔드포인트 수정
+ * 25. 2. 18.		inari			dev 병합후 랜딩페이지 엔드포인트 수정
  * 25. 2. 19.		durururuk		회원가입 시 UserRole에 기본값 인서트되게 기능 추가
  * 25. 2. 20.		durururuk		회원가입 시 JWT를 담은 헤더를 같이 반환하도록 추가
  * 25. 2. 21.		durururuk		사용자명 중복체크 메서드명 더 명확하게 수정, 반대로 작동하던 로직 수정
  * 25. 2. 21.		durururuk		사용자명 중복체크 예외 처리 추가
  * 25. 2. 21.		durururuk		중복체크 실패 시 예외처리 -> data : false로 다시 변경
- * 25. 2. 24.		inari		자바독 주석 추가
+ * 25. 2. 24.		inari			자바독 주석 추가
  * 25. 2. 24.		durururuk		회원가입 시 인증 헤더 -> http-only 쿠키 방식으로 변경
  * 25. 2. 25.		durururuk		로그인 서비스, 컨트롤러 추가
  * 25. 2. 26.		durururuk		로그인 서비스 단위테스트 작성
@@ -89,15 +89,16 @@ import lombok.extern.slf4j.Slf4j;
  * 25. 4. 10.		durururuk		이메일 기반 비밀번호 변경 변경된 로직에 맞게 테스트 코드 수정
  * 25. 4. 12.		durururuk		닉네임 변경 기능 구현
  * 25. 4. 12.		durururuk		유저명 변경 기능 구현
- * 25. 4. 28.		inari		완성
+ * 25. 4. 28.		inari			완성
  * 25. 4. 29.		durururuk		유저 프로필 조회 기능에서 프로필사진 객체명이 아닌 s3 presigned url을 요청해서 반환합니다.
  * 25. 6. 19.		durururuk		기존 액세스 토큰의 시간 1시간을 그대로 가져오던 이메일 인증 토큰, 유저명 중복 확인 토큰을 각각 처리하게 수정
- * 25. 6. 25.		inari		로그아웃 기능 추가
- * 25. 6. 26.		inari		회원 탈퇴 기능 작성
- * 25. 6. 26.		inari		탈퇴시 간편로그인 삭제
- * 25. 6. 26.		inari		탈퇴시 서비스에서 컨트롤러로 쿠키삭제 처리 피드백 반영
- * 25. 6. 27.		inari		로그인시 마지막 로그인 갱신되도록 수정
+ * 25. 6. 25.		inari			로그아웃 기능 추가
+ * 25. 6. 26.		inari			회원 탈퇴 기능 작성
+ * 25. 6. 26.		inari			탈퇴시 간편로그인 삭제
+ * 25. 6. 26.		inari			탈퇴시 서비스에서 컨트롤러로 쿠키삭제 처리 피드백 반영
+ * 25. 6. 27.		inari			로그인시 마지막 로그인 갱신되도록 수정
  * 25. 7. 1.		durururuk		다른 서비스 클래스에서도 변경된 로직에 맞게끔 수정
+ * 25. 8. 7.		inari			아이디 유효성 체크 추가
  */
 @Slf4j
 @Service
@@ -180,6 +181,10 @@ public class UserService {
 	 * @return : boolean, jwt 토큰을 담은 DTO
 	 */
 	public UserNameAvailabilityResponseDto checkUsernameAvailability(String userName) {
+		if (!userName.matches("^\\w{4,15}$")) {
+			throw new ApiException(ErrorCode.INVALID_INPUT_VALUE);
+		}
+		
 		if (!userMapper.isExistsUserName(userName)) {
 			String jwt = jwtService.generateTokenWithSubject(userName, JwtExpirationTime.USER_NAME_VERIFICATION_TOKEN);
 			return new UserNameAvailabilityResponseDto(true, jwt);

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/UserService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/UserService.java
@@ -182,10 +182,6 @@ public class UserService {
 	 * @return : boolean, jwt 토큰을 담은 DTO
 	 */
 	public UserNameAvailabilityResponseDto checkUsernameAvailability(String userName) {
-		if (!userName.matches("^\\w{4,15}$")) {
-			throw new ApiException(ErrorCode.INVALID_INPUT_VALUE);
-		}
-		
 		if (!userMapper.isExistsUserName(userName)) {
 			String jwt = jwtService.generateTokenWithSubject(userName, JwtExpirationTime.USER_NAME_VERIFICATION_TOKEN);
 			return new UserNameAvailabilityResponseDto(true, jwt);

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/UserService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/user/service/UserService.java
@@ -99,6 +99,7 @@ import lombok.extern.slf4j.Slf4j;
  * 25. 6. 27.		inari			로그인시 마지막 로그인 갱신되도록 수정
  * 25. 7. 1.		durururuk		다른 서비스 클래스에서도 변경된 로직에 맞게끔 수정
  * 25. 8. 7.		inari			아이디 유효성 체크 추가
+ * 25. 8. 7.		inari			중복 코드 제거
  */
 @Slf4j
 @Service
@@ -287,12 +288,6 @@ public class UserService {
 
 		oAuthMapper.deleteByUserId(userId);
 
-		DecodedJWT decodedAccessToken = jwtService.verifyJwt(accessToken);
-		String jti = decodedAccessToken.getId();
-		long expirationTime = decodedAccessToken.getExpiresAt().getTime() / 1000 - System.currentTimeMillis() / 1000;
-		if (expirationTime > 0) {
-			jwtRedisService.addAccessTokenToBlacklist(jti, expirationTime);
-		}
-		jwtRedisService.deleteRefreshToken(refreshToken);
+		logout(accessToken, refreshToken);
 	}
 }

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/user/controller/OAuthControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/user/controller/OAuthControllerTest.java
@@ -533,4 +533,43 @@ class OAuthControllerTest extends CommonMockMvcControllerTestSetUp {
 			.andExpect(jsonPath("$.data.existingEmail").value(false))
 			.andExpect(jsonPath("$.data.newUser").value(true));
 	}
+
+	@Test
+	@DisplayName("네이버 직접 linkToken 파라미터로 연동 성공")
+	void 네이버_직접_linkToken_파라미터로_연동_성공() throws Exception {
+		// given
+		final String AUTH_CODE = "auth_code";
+		final String LINK_TOKEN = "valid-link-token";
+		final Long USER_ID = 1L;
+		final String JWT = "jwt_token";
+
+		OAuthResponseDto responseDto = OAuthResponseDto.builder()
+			.isExistingEmail(false)
+			.isNewUser(false)
+			.build();
+
+		AuthTokenDto authTokenDto = new AuthTokenDto(JWT, "refresh_token");
+		OAuthService.OAuthLoginResult result = new OAuthService.OAuthLoginResult(responseDto, JWT, authTokenDto);
+
+		when(oAuthLinkTokenService.validateToken(LINK_TOKEN)).thenReturn(USER_ID);
+		when(oAuthService.processOAuthLogin(any(OAuthLoginDto.class))).thenReturn(result);
+
+		// when
+		ResultActions resultActions = mockMvc
+			.perform(get("/api/users/oauth/login/naver")
+				.queryParam("code", AUTH_CODE)
+				.queryParam("linkToken", LINK_TOKEN)
+				.contentType(MediaType.APPLICATION_JSON));
+
+		// then
+		resultActions
+			.andExpect(status().isOk())
+			.andExpect(cookie().exists("accessToken"))
+			.andExpect(cookie().value("accessToken", JWT))
+			.andExpect(jsonPath("$.data.existingEmail").value(false))
+			.andExpect(jsonPath("$.data.newUser").value(false));
+
+		verify(oAuthLinkTokenService).validateToken(LINK_TOKEN);
+		verify(oAuthLinkTokenService).deleteToken(LINK_TOKEN);
+	}
 }

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/user/controller/UpdateUserInfoControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/user/controller/UpdateUserInfoControllerTest.java
@@ -2,8 +2,8 @@ package com.trackery.trackerybackapiserver.domain.user.controller;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -41,9 +41,10 @@ import jakarta.servlet.http.Cookie;
  * 25. 4. 14.		durururuk		최초 생성
  * 25. 4. 14.		durururuk		UpdateUserInfo Controller, Serivce 단위테스트 작성
  * 25. 4. 14.		durururuk		사용되지 않는 변수 삭제
- * 25. 6. 17.		inari		user 도메인 테스트를 Spring-Rest-Docs에 맞게 리팩터링 및 문서 추가하였습니다.
- * 25. 6. 25.		inari		문서화 추가
+ * 25. 6. 17.		inari			user 도메인 테스트를 Spring-Rest-Docs에 맞게 리팩터링 및 문서 추가하였습니다.
+ * 25. 6. 25.		inari			문서화 추가
  * 25. 7. 29.		durururuk		updateProfileImage 컨트롤러 테스트 코드 작성
+ * 25. 8. 7.		inari			아이디 조건 테스트코드 수정
  */
 @WebMvcTest(UpdateUserInfoController.class)
 class UpdateUserInfoControllerTest extends CommonMockMvcControllerTestSetUp {
@@ -101,7 +102,7 @@ class UpdateUserInfoControllerTest extends CommonMockMvcControllerTestSetUp {
 		@Test
 		@DisplayName("성공")
 		void success() throws Exception {
-			String newUserName = "새 유저명";
+			String newUserName = "newusername";
 			UpdateUserNameDto dto = new UpdateUserNameDto();
 			ReflectionTestUtils.setField(dto, "userName", newUserName);
 

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/user/controller/UserControllerTest.java
@@ -48,7 +48,7 @@ import jakarta.servlet.http.Cookie;
  * 25. 2. 14.		durururuk		UserController 성공 케이스 테스트 코드 작성
  * 25. 2. 17.		durururuk		Java 컨벤션에 맞게 username -> userName 수정
  * 25. 2. 17.		durururuk		클래스 JavaDoc 설명 추가
- * 25. 2. 18.		inari		dev 병합후 랜딩페이지 엔드포인트 수정
+ * 25. 2. 18.		inari			dev 병합후 랜딩페이지 엔드포인트 수정
  * 25. 2. 19.		durururuk		MockMvc 테스트코드 작성을 도와주는 추상 클래스 추가
  * 25. 2. 19.		durururuk		코딩 컨벤션에 맞게 정리
  * 25. 2. 19.		durururuk		테스트 하고자 하는 컨트롤러만 로드하게 수정
@@ -70,10 +70,11 @@ import jakarta.servlet.http.Cookie;
  * 25. 4. 10.		durururuk		final이 될 수 있는 변수 final화, 로직 수정으로 사용되지 않는 메서드 삭제
  * 25. 4. 12.		durururuk		유저명 변경 기능 구현
  * 25. 4. 14.		durururuk		UpdateUserInfo Controller, Serivce 단위테스트 작성
- * 25. 6. 17.		inari		user 도메인 테스트를 Spring-Rest-Docs에 맞게 리팩터링 및 문서 추가하였습니다.
- * 25. 6. 25.		inari		테스트 코드 추가
- * 25. 6. 26.		inari		탈퇴시 테스트코드 작성 및 문서화
- * 25. 6. 26.		inari		탈퇴시 서비스에서 컨트롤러로 쿠키삭제 처리 피드백 반영
+ * 25. 6. 17.		inari			user 도메인 테스트를 Spring-Rest-Docs에 맞게 리팩터링 및 문서 추가하였습니다.
+ * 25. 6. 25.		inari			테스트 코드 추가
+ * 25. 6. 26.		inari			탈퇴시 테스트코드 작성 및 문서화
+ * 25. 6. 26.		inari			탈퇴시 서비스에서 컨트롤러로 쿠키삭제 처리 피드백 반영
+ * 25. 8. 7.		inari			중복체크 실패 테스트 코드 추가
  */
 @WebMvcTest(UserController.class)
 class UserControllerTest extends CommonMockMvcControllerTestSetUp {
@@ -147,6 +148,30 @@ class UserControllerTest extends CommonMockMvcControllerTestSetUp {
 			.andExpect(cookie().value("userNameToken", "jwt"))
 			.andExpect(jsonPath("$.data").value(true))
 			.andDo(document("check-username-availability-success",
+				queryParameters(
+					parameterWithName("value").description("확인할 사용자명")
+				),
+				responseFields(
+					fieldWithPath("code").description("상태 코드"),
+					fieldWithPath("message").description("응답 메시지"),
+					fieldWithPath("data").description("사용자명 사용 가능 여부")
+				)
+			));
+	}
+
+	@Test
+	void 유저명_중복체크_실패() throws Exception {
+		UserNameAvailabilityResponseDto dto = new UserNameAvailabilityResponseDto(false, null);
+		when(userService.checkUsernameAvailability(anyString())).thenReturn(dto);
+
+		ResultActions result = mockMvc
+			.perform(get("/api/users/exists/username")
+				.queryParam("value", "existinguser"));
+
+		result.andExpect(status().isOk())
+			.andExpect(cookie().doesNotExist("userNameToken"))
+			.andExpect(jsonPath("$.data").value(false))
+			.andDo(document("check-username-availability-failure",
 				queryParameters(
 					parameterWithName("value").description("확인할 사용자명")
 				),

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/user/service/UserServiceTest.java
@@ -57,7 +57,7 @@ import com.trackery.trackerybackapiserver.domain.user.mapper.UserRoleMapper;
  * 25. 2. 17.		durururuk		username 중복 체크 SQL count(*) -> EXISTS()로 수정
  * 25. 2. 17.		durururuk		Java 컨벤션에 맞게 username -> userName 수정
  * 25. 2. 17.		durururuk		클래스 JavaDoc 설명 추가
- * 25. 2. 18.		inari		dev 병합후 랜딩페이지 엔드포인트 수정
+ * 25. 2. 18.		inari			dev 병합후 랜딩페이지 엔드포인트 수정
  * 25. 2. 19.		durururuk		회원가입 시 UserRole에 기본값 인서트되게 기능 추가
  * 25. 2. 20.		durururuk		회원가입 시 JWT를 담은 헤더를 같이 반환하도록 추가
  * 25. 2. 21.		durururuk		사용자명 중복체크 메서드명 더 명확하게 수정, 반대로 작동하던 로직 수정
@@ -83,15 +83,16 @@ import com.trackery.trackerybackapiserver.domain.user.mapper.UserRoleMapper;
  * 25. 4. 10.		durururuk		final이 될 수 있는 변수 final화, 로직 수정으로 사용되지 않는 메서드 삭제
  * 25. 4. 12.		durururuk		유저명 변경 기능 구현
  * 25. 4. 14.		durururuk		UpdateUserInfo Controller, Serivce 단위테스트 작성
- * 25. 4. 28.		inari		완성
+ * 25. 4. 28.		inari			완성
  * 25. 4. 29.		durururuk		유저 프로필 조회 기능에서 프로필사진 객체명이 아닌 s3 presigned url을 요청해서 반환합니다.
  * 25. 4. 29.		durururuk		변경된 로직에 맞게 테스트 코드 수정
  * 25. 6. 19.		durururuk		기존 액세스 토큰의 시간 1시간을 그대로 가져오던 이메일 인증 토큰, 유저명 중복 확인 토큰을 각각 처리하게 수정
- * 25. 6. 25.		inari		테스트 코드 추가
- * 25. 6. 26.		inari		탈퇴시 테스트코드 작성 및 문서화
- * 25. 6. 26.		inari		탈퇴시 서비스에서 컨트롤러로 쿠키삭제 처리 피드백 반영
- * 25. 6. 27.		inari		테스트에 마지막 로그인 시간 추가
+ * 25. 6. 25.		inari			테스트 코드 추가
+ * 25. 6. 26.		inari			탈퇴시 테스트코드 작성 및 문서화
+ * 25. 6. 26.		inari			탈퇴시 서비스에서 컨트롤러로 쿠키삭제 처리 피드백 반영
+ * 25. 6. 27.		inari			테스트에 마지막 로그인 시간 추가
  * 25. 7. 1.		durururuk		변경된 서비스 로직에 맞게 테스트코드 수정
+ * 25. 8. 7.		inari			아이디 조건 테스트코드 수정
  */
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
@@ -177,6 +178,33 @@ class UserServiceTest {
 
 		assertTrue(result.available());
 		assertEquals("jwt", result.token());
+	}
+
+	@Test
+	void 유저명_유효성_검사_실패_너무_짧음() {
+		ApiException exception = assertThrows(ApiException.class, () -> {
+			userService.checkUsernameAvailability("ab");
+		});
+		assertEquals(ErrorCode.INVALID_INPUT_VALUE, exception.getErrorCode());
+		verify(userMapper, never()).isExistsUserName(anyString());
+	}
+
+	@Test
+	void 유저명_유효성_검사_실패_너무_김() {
+		ApiException exception = assertThrows(ApiException.class, () -> {
+			userService.checkUsernameAvailability("abcdefghijklmnop");
+		});
+		assertEquals(ErrorCode.INVALID_INPUT_VALUE, exception.getErrorCode());
+		verify(userMapper, never()).isExistsUserName(anyString());
+	}
+
+	@Test
+	void 유저명_유효성_검사_실패_특수문자_포함() {
+		ApiException exception = assertThrows(ApiException.class, () -> {
+			userService.checkUsernameAvailability("abcd@");
+		});
+		assertEquals(ErrorCode.INVALID_INPUT_VALUE, exception.getErrorCode());
+		verify(userMapper, never()).isExistsUserName(anyString());
 	}
 
 	@Test

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/user/service/UserServiceTest.java
@@ -181,33 +181,6 @@ class UserServiceTest {
 	}
 
 	@Test
-	void 유저명_유효성_검사_실패_너무_짧음() {
-		ApiException exception = assertThrows(ApiException.class, () -> {
-			userService.checkUsernameAvailability("ab");
-		});
-		assertEquals(ErrorCode.INVALID_INPUT_VALUE, exception.getErrorCode());
-		verify(userMapper, never()).isExistsUserName(anyString());
-	}
-
-	@Test
-	void 유저명_유효성_검사_실패_너무_김() {
-		ApiException exception = assertThrows(ApiException.class, () -> {
-			userService.checkUsernameAvailability("abcdefghijklmnop");
-		});
-		assertEquals(ErrorCode.INVALID_INPUT_VALUE, exception.getErrorCode());
-		verify(userMapper, never()).isExistsUserName(anyString());
-	}
-
-	@Test
-	void 유저명_유효성_검사_실패_특수문자_포함() {
-		ApiException exception = assertThrows(ApiException.class, () -> {
-			userService.checkUsernameAvailability("abcd@");
-		});
-		assertEquals(ErrorCode.INVALID_INPUT_VALUE, exception.getErrorCode());
-		verify(userMapper, never()).isExistsUserName(anyString());
-	}
-
-	@Test
 	void 로그인_테스트() {
 		ReflectionTestUtils.setField(loginDto, "userName", "abcdfg");
 		ReflectionTestUtils.setField(loginDto, "password", "Qwerasdf1234!");


### PR DESCRIPTION
  - 유저 아이디 유효성 추가(4~15자 길이에 영문 대소문자, 숫자, 밑줄(_))
  - 닉네임 최대 20자로 제한
  - 중복 코드 리팩토링
  - 관련 테스트 코드 추가