### PR TITLE
Refactor/location batch 시도 이미지 커버리지 조회 API 추가

### DIFF
--- a/src/docs/asciidoc/image-api.adoc
+++ b/src/docs/asciidoc/image-api.adoc
@@ -29,6 +29,23 @@ include::{snippets}/get-my-images-success/http-response.adoc[]
 include::{snippets}/get-my-images-success/response-fields.adoc[]
 '''
 
+=== 내 이미지 시도 커버리지 조회 API
+==== GET /api/images/me/coverage/sido
+
+인증된 사용자가 업로드한 이미지의 시도 커버리지를 조회하는 API입니다.
+모든 시군구에 각각 한 장이라도 이미지가 있으면 COMPLETE,
+어떤 시군구라도 적어도 한 장 이미지가 있으면 PARTIAL 배열에
+시도 ID를 넣어서 반환합니다.
+아무런 이미지도 없는 경우는 반환하지 않습니다.
+
+===== 요청
+include::{snippets}/get-image-sido-coverage-success/httpie-request.adoc[]
+
+===== 응답
+include::{snippets}/get-image-sido-coverage-success/http-response.adoc[]
+include::{snippets}/get-image-sido-coverage-success/response-fields.adoc[]
+'''
+
 === S3 업로드 URL 요청 API
 ==== GET /api/images/presigned-url/put
 

--- a/src/docs/asciidoc/image-api.adoc
+++ b/src/docs/asciidoc/image-api.adoc
@@ -2,7 +2,7 @@
 '''
 
 === 이미지 단건 조회 API
-==== GET /api/images
+==== GET `/api/images`
 
 이미지 ID를 통해 특정 이미지의 상세 정보를 조회하는 API입니다.
 이미지의 메타데이터와 위치 정보, URL 등을 반환합니다.
@@ -16,7 +16,7 @@ include::{snippets}/get-image-by-id-success/response-fields.adoc[]
 '''
 
 === 내 이미지 목록 조회 API
-==== GET /api/images/me
+==== GET `/api/images/me`
 
 인증된 사용자가 업로드한 모든 이미지 목록을 조회하는 API입니다.
 JWT 토큰을 통해 사용자를 식별하고 해당 사용자의 이미지만 반환합니다.
@@ -30,7 +30,7 @@ include::{snippets}/get-my-images-success/response-fields.adoc[]
 '''
 
 === 내 이미지 시도 커버리지 조회 API
-==== GET /api/images/me/coverage/sido
+==== GET `/api/images/me/coverage/sido`
 
 인증된 사용자가 업로드한 이미지의 시도 커버리지를 조회하는 API입니다.
 모든 시군구에 각각 한 장이라도 이미지가 있으면 COMPLETE,
@@ -47,7 +47,7 @@ include::{snippets}/get-image-sido-coverage-success/response-fields.adoc[]
 '''
 
 === S3 업로드 URL 요청 API
-==== GET /api/images/presigned-url/put
+==== GET `/api/images/presigned-url/put`
 
 이미지를 S3에 업로드하기 위한 presigned URL을 요청하는 API입니다.
 클라이언트는 이 URL을 사용하여 직접 S3에 이미지를 업로드할 수 있습니다.
@@ -62,7 +62,7 @@ include::{snippets}/get-presigned-url-success/response-fields.adoc[]
 '''
 
 === 이미지 메타데이터 저장 API
-==== POST /api/images
+==== POST `/api/images`
 
 S3에 업로드된 이미지의 메타데이터를 데이터베이스에 저장하는 API입니다.
 이미지 업로드 후 호출하여 이미지 정보를 시스템에 등록합니다.
@@ -88,7 +88,7 @@ include::{snippets}/save-image-metadata-success/response-fields.adoc[]
 '''
 
 === 공개 이미지 목록 API
-==== GET /api/home/images
+==== GET `/api/home/images`
 
 랜딩 페이지에서 사용할 공개 이미지 URL 목록을 조회하는 API입니다.
 인증이 필요하지 않으며, 공개 설정된 이미지들의 URL을 반환합니다.
@@ -107,7 +107,7 @@ include::{snippets}/get-public-images/response-fields.adoc[]
 '''
 
 === 이미지 메타데이터 수정 API
-==== PATCH /api/images/{imageId}
+==== PATCH `/api/images/+++{imageId}+++`
 
 업로드된 이미지의 메타데이터를 부분 수정하는 API입니다.
 이미지 이름, 설명, 촬영 날짜, 공개 여부, 위치 정보를 선택적으로 수정할 수 있습니다.
@@ -135,7 +135,7 @@ include::{snippets}/update-image-metadata-success/response-fields.adoc[]
 '''
 
 === 이미지 지역 정보 포함 메타데이터 수정 API
-==== PATCH /api/images/{imageId} (위치 정보 포함)
+==== PATCH `/api/images/++{imageId}++ (위치 정보 포함)`
 
 이미지의 메타데이터와 함께 위치 정보도 수정하는 API입니다.
 위도와 경도를 함께 제공하면 해당 좌표의 행정구역 정보가 자동으로 업데이트됩니다.
@@ -156,7 +156,7 @@ include::{snippets}/update-image-metadata-with-location-success/response-fields.
 '''
 
 === 이미지 삭제 API
-==== DELETE /api/images/{imageId}
+==== `DELETE /api/images/++{imageId}++`
 
 업로드된 이미지를 삭제하는 API입니다.
 실제로는 논리적 삭제(is_deleted = 1)를 수행하여 데이터 복구가 가능합니다.
@@ -181,7 +181,7 @@ include::{snippets}/delete-image-success/response-fields.adoc[]
 '''
 
 === 이미지별 태그 조회 API
-==== GET /api/images/{imageId}/tags
+==== GET `/api/images/++{imageId}++/tags`
 
 특정 이미지에 연결된 태그들을 조회합니다.
 
@@ -195,7 +195,7 @@ include::{snippets}/image-get-tags/response-fields.adoc[]
 '''
 
 === 이미지에 태그 추가 API
-==== POST /api/images/{imageId}/tags/{tagId}
+==== POST `/api/images/++{imageId}++/tags/++{tagId}++`
 
 특정 이미지에 태그를 연결합니다.
 
@@ -209,7 +209,7 @@ include::{snippets}/image-add-tag/response-fields.adoc[]
 '''
 
 === 이미지에서 태그 제거 API
-==== DELETE /api/images/{imageId}/tags/{tagId}
+==== DELETE `/api/images/++{imageId}++/tags/++{tagId}++`
 
 특정 이미지에서 태그 연결을 해제합니다.
 
@@ -223,7 +223,7 @@ include::{snippets}/image-remove-tag/response-fields.adoc[]
 '''
 
 === 이미지 태그 수정 API
-==== PUT /api/images/{imageId}/tags/{tagId}
+==== PUT `/api/images/+++{imageId}+++/tags/+++{tagId}+++`
 
 특정 이미지에 연결된 태그를 다른 태그로 수정합니다.
 

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/controller/ImageController.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/controller/ImageController.java
@@ -19,6 +19,7 @@ import com.github.pagehelper.PageInfo;
 import com.trackery.trackerybackapiserver.domain.common.response.ApiResponse;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.SuccessCode;
 import com.trackery.trackerybackapiserver.domain.image.dto.ImageDto;
+import com.trackery.trackerybackapiserver.domain.image.dto.ImageSidoCoverageResponseDto;
 import com.trackery.trackerybackapiserver.domain.image.dto.ImageThumbnailDto;
 import com.trackery.trackerybackapiserver.domain.image.dto.ImageUpdateRequestDto;
 import com.trackery.trackerybackapiserver.domain.image.dto.internal.ImageSearchByUserIdDto;
@@ -57,6 +58,7 @@ import lombok.RequiredArgsConstructor;
  * 25. 7. 9.		inari		태그 컨트롤러에 있던 일부 매핑을 이미지로 이전함으로써 RESTful한 URL 구조로 변경
  * 25. 7. 10.		durururuk		PageSize 파라미터 검증 추가
  * 25. 7. 10.		inari		이미지 단건 조회시 태그 추가
+ * 25. 9. 5.		durururuk		이미지 시도 커버리지 조회 API 작성
  */
 @RestController
 @RequiredArgsConstructor
@@ -212,6 +214,17 @@ public class ImageController {
 		// 이미지 소유자 확인
 		imageService.getOriginalImageByImageId(userDetails.getUserId(), imageId);
 		TagResponseDto response = tagService.updateImageTag(imageId, tagId, request.getNewTagName());
+		return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+	}
+
+	/**
+	 * 인증된 유저의 시도 이미지 커버리지를 조회합니다.
+	 * @param userDetails 인증된 사용자 정보
+	 * @return 시도별 커버리지 정보 DTO (PARTIAL/COMPLETE)
+	 */
+	@GetMapping("/me/coverage/sido")
+	public ResponseEntity<ApiResponse<ImageSidoCoverageResponseDto>> getImageSidoCoverage(@AuthenticationPrincipal CustomUserDetails userDetails) {
+		ImageSidoCoverageResponseDto response = imageService.getImageSidoCoverageData(userDetails.getUserId());
 		return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
 	}
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/dto/ImageSidoCoverageResponseDto.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/dto/ImageSidoCoverageResponseDto.java
@@ -1,0 +1,42 @@
+package com.trackery.trackerybackapiserver.domain.image.dto;
+
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * packageName    : com.trackery.trackerybackapiserver.domain.image.dto
+ * fileName       : ImageSidoCoverageResponseDto
+ * author         : durururuk
+ * date           : 25. 9. 5.
+ * description    : 시도별 이미지 커버리지 현황을 나타내는 응답 DTO
+ * 					- 이미지가 전혀 없는 시도는 응답에 포함되지 않음
+ * 					- PARTIAL: 해당 시도의 일부 시군구에만 이미지가 존재
+ *                  - COMPLETE: 해당 시도의 모든 시군구에 이미지가 1장 이상 존재
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * -----------------------------------------------------------
+ * 25. 9. 5.		durururuk		최초 생성
+ * 25. 9. 5.		durururuk		필드 구성
+ * 25. 9. 5.		durururuk		javadoc 주석 작성
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ImageSidoCoverageResponseDto {
+	/**
+	 * 일부 시군구에만 이미지가 있는 시도 ID Set
+	 */
+	@JsonProperty("PARTIAL")
+	private Set<Long> partialSidoIdSet;
+	
+	/**
+	 * 모든 시군구에 이미지가 있는 시도 ID Set
+	 */
+	@JsonProperty("COMPLETE")
+	private Set<Long> completeSidoIdSet;
+}

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/mapper/ImageMapper.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/mapper/ImageMapper.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+import com.trackery.trackerybackapiserver.domain.image.dto.ImageSidoCoverageResponseDto;
 import com.trackery.trackerybackapiserver.domain.image.dto.internal.ImageInfoForThumbnailDto;
 import com.trackery.trackerybackapiserver.domain.image.dto.internal.ImageSearchByUserIdDto;
 import com.trackery.trackerybackapiserver.domain.image.entity.Image;
@@ -110,4 +111,6 @@ public interface ImageMapper {
 	 */
 	void changeImageProcessingStatus(@Param("imageName") String imageName,
 		@Param("processingStatus") int processingStatus);
+
+	ImageSidoCoverageResponseDto selectSidoCoverage(@Param("userId") Long userId);
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/mapper/ImageMapper.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/mapper/ImageMapper.java
@@ -36,6 +36,9 @@ import com.trackery.trackerybackapiserver.domain.image.entity.Image;
  * 25. 7. 8.		durururuk		내 이미지 조회 시 조회 결과에서 제외될 앨범 ID 파라미터 추가
  * 25. 7. 8.		durururuk		사용되지 않는 메서드 정리
  * 25. 7. 11.		inari		사용되지 않는 매퍼 삭제
+ * 25. 9. 5.		durururuk		시도 커버리지 조회 메서드 추가
+ * 25. 9. 5.		durururuk		시도 커버리지 조회 메서드 옵셔널로 수정
+ * 25. 9. 5.		durururuk		Javadoc 주석 작성
  */
 @Mapper
 public interface ImageMapper {
@@ -112,5 +115,11 @@ public interface ImageMapper {
 	void changeImageProcessingStatus(@Param("imageName") String imageName,
 		@Param("processingStatus") int processingStatus);
 
-	ImageSidoCoverageResponseDto selectSidoCoverage(@Param("userId") Long userId);
+	/**
+	 * 사용자별 시도 이미지 커버리지를 조회합니다.
+	 * 각 시도를 COMPLETE(모든 시군구에 이미지 존재) 또는 PARTIAL(일부 시군구에만 이미지 존재)로 분류합니다.
+	 * @param userId 사용자 ID
+	 * @return 시도별 이미지 커버리지 정보를 담은 DTO (Optional)
+	 */
+	Optional<ImageSidoCoverageResponseDto> selectSidoCoverage(@Param("userId") Long userId);
 }

--- a/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageService.java
+++ b/src/main/java/com/trackery/trackerybackapiserver/domain/image/service/ImageService.java
@@ -16,6 +16,7 @@ import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
 import com.trackery.trackerybackapiserver.domain.common.util.PageUtil;
 import com.trackery.trackerybackapiserver.domain.image.dto.ImageDto;
+import com.trackery.trackerybackapiserver.domain.image.dto.ImageSidoCoverageResponseDto;
 import com.trackery.trackerybackapiserver.domain.image.dto.ImageThumbnailDto;
 import com.trackery.trackerybackapiserver.domain.image.dto.ImageUpdateRequestDto;
 import com.trackery.trackerybackapiserver.domain.image.dto.internal.ImageInfoForThumbnailDto;
@@ -84,6 +85,10 @@ import lombok.extern.slf4j.Slf4j;
  * 25. 7. 15.		durururuk		ImageService @Transactional 어노테이션 추가
  * 25. 7. 15.		inari		ImageService에 있던 updateImageLocation, processTagRemoval, processTagAddition 각 도메인으로 이동
  * 25. 8. 14.		durururuk		changeImageProcessingStatus javadoc 주석 보충
+ * 25. 9. 5.		durururuk		이미지 시도 커버리지 조회 서비스 메서드 작성
+ * 25. 9. 5.		durururuk		Javadoc 주석 작성
+ * 25. 9. 5.		durururuk		시도 커버리지 조회 메서드 Optional처리로 null 처리 강화
+ * 25. 9. 5.		durururuk		시도 커버리지 조회 메서드 Set null 예외 처리 강화
  */
 @Slf4j
 @Service
@@ -379,5 +384,29 @@ public class ImageService {
 	//TODO 처리 실패시 처리 보완
 	public void changeImageProcessingStatus(String imageName, int processingStatus) {
 		imageMapper.changeImageProcessingStatus(imageName, processingStatus);
+	}
+
+	/**
+	 * 사용자별 시도 이미지 커버리지 데이터를 조회합니다.
+	 * 각 시도별로 모든 시군구에 이미지가 있으면 COMPLETE, 일부만 있으면 PARTIAL로 분류합니다.
+	 * @param userId 사용자 ID
+	 * @return 시도별 이미지 커버리지 정보 (PARTIAL/COMPLETE 시도 ID 목록)
+	 */
+	@Transactional(readOnly = true)
+	public ImageSidoCoverageResponseDto getImageSidoCoverageData(Long userId) {
+		log.debug("사용자 ID {}의 시도 이미지 커버리지 조회 시작", userId);
+
+		ImageSidoCoverageResponseDto result = imageMapper.selectSidoCoverage(userId).orElseThrow(
+			() -> new ApiException(ErrorCode.INTERNAL_SERVER_ERROR)
+		);
+
+		if (result.getPartialSidoIdSet() == null || result.getCompleteSidoIdSet() == null) {
+			throw new ApiException(ErrorCode.INTERNAL_SERVER_ERROR);
+		}
+
+		log.debug("사용자 ID {} 커버리지 조회 완료 - PARTIAL: {}개, COMPLETE: {}개",
+			userId, result.getPartialSidoIdSet().size(), result.getCompleteSidoIdSet().size());
+
+		return result;
 	}
 }

--- a/src/main/resources/mapper/ImageMapper.xml
+++ b/src/main/resources/mapper/ImageMapper.xml
@@ -191,4 +191,56 @@
         AND is_deleted = 0
     </update>
 
+    <!-- 유저의 시도 이미지 커버리지 조회 -->
+    <resultMap id="SidoCoverageResultMap" type="com.trackery.trackerybackapiserver.domain.image.dto.ImageSidoCoverageResponseDto">
+        <collection property="partialSidoIdSet" ofType="Long" 
+                    column="userId" select="selectPartialSidoIds"/>
+        <collection property="completeSidoIdSet" ofType="Long" 
+                    column="userId" select="selectCompleteSidoIds"/>
+    </resultMap>
+
+    <!-- 메인 쿼리 - userId 파라미터를 하위 쿼리로 전달 -->
+    <select id="selectSidoCoverage" resultMap="SidoCoverageResultMap">
+        SELECT #{userId} as userId
+    </select>
+
+    <!-- 일부 시군구에만 이미지가 있는 시도 조회 (PARTIAL) -->
+    <select id="selectPartialSidoIds" resultType="Long">
+        WITH sido_coverage AS (
+            SELECT 
+                sd.sd_id,
+                COUNT(DISTINCT sgg.sgg_id) as total_sgg_count,
+                COUNT(DISTINCT CASE WHEN i.image_id IS NOT NULL THEN sgg.sgg_id END) as image_sgg_count
+            FROM juso_sido sd
+            JOIN juso_sigungu sgg ON sd.sd_id = sgg.sd_id
+            LEFT JOIN coord_poi c ON sgg.sgg_id = c.sgg_id
+            LEFT JOIN image i ON c.coord_point_id = i.coord_point_id 
+                AND i.user_id = #{userId}
+                AND i.is_deleted = 0
+            GROUP BY sd.sd_id
+        )
+        SELECT sd_id 
+        FROM sido_coverage 
+        WHERE image_sgg_count > 0 AND image_sgg_count &lt; total_sgg_count
+    </select>
+
+    <!-- 모든 시군구에 이미지가 있는 시도 조회 (COMPLETE) -->
+    <select id="selectCompleteSidoIds" resultType="Long">
+        WITH sido_coverage AS (
+            SELECT 
+                sd.sd_id,
+                COUNT(DISTINCT sgg.sgg_id) as total_sgg_count,
+                COUNT(DISTINCT CASE WHEN i.image_id IS NOT NULL THEN sgg.sgg_id END) as image_sgg_count
+            FROM juso_sido sd
+            JOIN juso_sigungu sgg ON sd.sd_id = sgg.sd_id
+            LEFT JOIN coord_poi c ON sgg.sgg_id = c.sgg_id
+            LEFT JOIN image i ON c.coord_point_id = i.coord_point_id 
+                AND i.user_id = #{userId}
+                AND i.is_deleted = 0
+            GROUP BY sd.sd_id
+        )
+        SELECT sd_id 
+        FROM sido_coverage 
+        WHERE image_sgg_count = total_sgg_count AND total_sgg_count > 0
+    </select>
 </mapper>

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/image/controller/ImageControllerTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/image/controller/ImageControllerTest.java
@@ -13,6 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -25,6 +26,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.pagehelper.PageInfo;
 import com.trackery.trackerybackapiserver.domain.config.CommonMockMvcControllerTestSetUp;
 import com.trackery.trackerybackapiserver.domain.image.dto.ImageDto;
+import com.trackery.trackerybackapiserver.domain.image.dto.ImageSidoCoverageResponseDto;
 import com.trackery.trackerybackapiserver.domain.image.dto.ImageThumbnailDto;
 import com.trackery.trackerybackapiserver.domain.image.dto.ImageUpdateRequestDto;
 import com.trackery.trackerybackapiserver.domain.image.dto.internal.ImageSearchByUserIdDto;
@@ -61,6 +63,7 @@ import com.trackery.trackerybackapiserver.domain.user.entity.CustomUserDetails;
  * 25. 7. 10.		inari		이미지 단건 조회시 태그 추가
  * 25. 7. 10.		durururuk		변경된 로직에 맞게 테스트 코드 수정
  * 25. 7. 14.		inari		테스트코드 수정 및 adoc 변경
+ * 25. 9. 5.		durururuk		이미지 시도 커버리지 조회 API 테스트코드, 문서화 코드 작성
  */
 @WebMvcTest(ImageController.class)
 class ImageControllerTest extends CommonMockMvcControllerTestSetUp {
@@ -547,5 +550,43 @@ class ImageControllerTest extends CommonMockMvcControllerTestSetUp {
 
 		verify(imageService).getOriginalImageByImageId(USER_ID, IMAGE_ID);
 		verify(tagService).updateImageTag(IMAGE_ID, tagId, "수정된태그");
+	}
+
+	@Test
+	@DisplayName("시도별 이미지 커버리지 조회 성공")
+	void getImageSidoCoverageSuccess() throws Exception {
+		// Given
+		Set<Long> partialSidoIds = Set.of(11L, 26L, 31L);
+		Set<Long> completeSidoIds = Set.of(41L, 28L);
+		ImageSidoCoverageResponseDto coverageData = new ImageSidoCoverageResponseDto(partialSidoIds, completeSidoIds);
+		
+		when(imageService.getImageSidoCoverageData(USER_ID)).thenReturn(coverageData);
+
+		// When
+		ResultActions result = mockMvc.perform(get("/api/images/me/coverage/sido")
+			.with(user(userDetails)));
+
+		// Then
+		result
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value(200))
+			.andExpect(jsonPath("$.message").value("Ok"))
+			.andExpect(jsonPath("$.data.PARTIAL").isArray())
+			.andExpect(jsonPath("$.data.PARTIAL.length()").value(3))
+			.andExpect(jsonPath("$.data.COMPLETE").isArray())
+			.andExpect(jsonPath("$.data.COMPLETE.length()").value(2))
+			.andDo(document("get-image-sido-coverage-success",
+				responseFields(
+					fieldWithPath("code").description("응답 코드"),
+					fieldWithPath("message").description("응답 메시지"),
+					fieldWithPath("data").description("시도별 이미지 커버리지 데이터"),
+					fieldWithPath("data.PARTIAL").description("일부 시군구에만 이미지가 있는 시도 ID 배열"),
+					fieldWithPath("data.PARTIAL[]").description("PARTIAL 시도 ID"),
+					fieldWithPath("data.COMPLETE").description("모든 시군구에 이미지가 있는 시도 ID 배열"),
+					fieldWithPath("data.COMPLETE[]").description("COMPLETE 시도 ID")
+				)
+			));
+
+		verify(imageService, times(1)).getImageSidoCoverageData(USER_ID);
 	}
 }

--- a/src/test/java/com/trackery/trackerybackapiserver/domain/image/service/ImageServiceTest.java
+++ b/src/test/java/com/trackery/trackerybackapiserver/domain/image/service/ImageServiceTest.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -28,6 +29,7 @@ import com.github.pagehelper.PageInfo;
 import com.trackery.trackerybackapiserver.domain.common.response.enums.ErrorCode;
 import com.trackery.trackerybackapiserver.domain.common.response.exception.ApiException;
 import com.trackery.trackerybackapiserver.domain.image.dto.ImageDto;
+import com.trackery.trackerybackapiserver.domain.image.dto.ImageSidoCoverageResponseDto;
 import com.trackery.trackerybackapiserver.domain.image.dto.ImageThumbnailDto;
 import com.trackery.trackerybackapiserver.domain.image.dto.ImageUpdateRequestDto;
 import com.trackery.trackerybackapiserver.domain.image.dto.internal.ImageInfoForThumbnailDto;
@@ -72,6 +74,7 @@ import com.trackery.trackerybackapiserver.domain.tag.service.TagService;
  * 25. 7. 15.		inari		필요없는 eq 삭제
  * 25. 7. 15.		durururuk		이벤트 publish 관련 모킹 추가
  * 25. 7. 15.		inari		ImageServiceTest 테스트 코드 작성
+ * 25. 9. 5.		durururuk		시도 커버리지 메서드 테스트 코드 작성
  */
 @ExtendWith(MockitoExtension.class)
 class ImageServiceTest {
@@ -915,6 +918,110 @@ class ImageServiceTest {
 			verify(locationService).updateImageLocation(1L, 37.5665, 126.978, imageId);
 			verify(tagService).processTagRemoval(imageId, updateRequest);
 			verify(tagService).processTagAddition(imageId, updateRequest);
+		}
+	}
+
+	@Nested
+	@DisplayName("시도 이미지 커버리지 조회 테스트")
+	class GetImageSidoCoverageDataTest {
+		private final Long testUserId = 1L;
+
+		@Test
+		@DisplayName("성공 - 정상 커버리지 데이터 반환")
+		void getImageSidoCoverageData_success() {
+			// Given
+			Set<Long> partialSidoIds = Set.of(1L, 2L);
+			Set<Long> completeSidoIds = Set.of(3L, 4L, 5L);
+			ImageSidoCoverageResponseDto expectedDto = new ImageSidoCoverageResponseDto(partialSidoIds, completeSidoIds);
+			
+			when(imageMapper.selectSidoCoverage(testUserId)).thenReturn(Optional.of(expectedDto));
+
+			// When
+			ImageSidoCoverageResponseDto result = imageService.getImageSidoCoverageData(testUserId);
+
+			// Then
+			assertThat(result).isNotNull();
+			assertThat(result.getPartialSidoIdSet()).isEqualTo(partialSidoIds);
+			assertThat(result.getCompleteSidoIdSet()).isEqualTo(completeSidoIds);
+			verify(imageMapper).selectSidoCoverage(testUserId);
+		}
+
+		@Test
+		@DisplayName("성공 - 빈 커버리지 데이터 반환")
+		void getImageSidoCoverageData_emptyResult() {
+			// Given
+			Set<Long> emptySidoIds = Set.of();
+			ImageSidoCoverageResponseDto expectedDto = new ImageSidoCoverageResponseDto(emptySidoIds, emptySidoIds);
+			
+			when(imageMapper.selectSidoCoverage(testUserId)).thenReturn(Optional.of(expectedDto));
+
+			// When
+			ImageSidoCoverageResponseDto result = imageService.getImageSidoCoverageData(testUserId);
+
+			// Then
+			assertThat(result).isNotNull();
+			assertThat(result.getPartialSidoIdSet()).isEmpty();
+			assertThat(result.getCompleteSidoIdSet()).isEmpty();
+			verify(imageMapper).selectSidoCoverage(testUserId);
+		}
+
+		@Test
+		@DisplayName("실패 - Mapper가 Optional.empty() 반환")
+		void getImageSidoCoverageData_mapperReturnsEmpty() {
+			// Given
+			when(imageMapper.selectSidoCoverage(testUserId)).thenReturn(Optional.empty());
+
+			// When & Then
+			assertThatThrownBy(() -> imageService.getImageSidoCoverageData(testUserId))
+				.isInstanceOf(ApiException.class)
+				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.INTERNAL_SERVER_ERROR);
+
+			verify(imageMapper).selectSidoCoverage(testUserId);
+		}
+
+		@Test
+		@DisplayName("실패 - PARTIAL Set이 null")
+		void getImageSidoCoverageData_partialSetIsNull() {
+			// Given
+			ImageSidoCoverageResponseDto dtoWithNullPartial = new ImageSidoCoverageResponseDto(null, Set.of(1L, 2L));
+			when(imageMapper.selectSidoCoverage(testUserId)).thenReturn(Optional.of(dtoWithNullPartial));
+
+			// When & Then
+			assertThatThrownBy(() -> imageService.getImageSidoCoverageData(testUserId))
+				.isInstanceOf(ApiException.class)
+				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.INTERNAL_SERVER_ERROR);
+
+			verify(imageMapper).selectSidoCoverage(testUserId);
+		}
+
+		@Test
+		@DisplayName("실패 - COMPLETE Set이 null")
+		void getImageSidoCoverageData_completeSetIsNull() {
+			// Given
+			ImageSidoCoverageResponseDto dtoWithNullComplete = new ImageSidoCoverageResponseDto(Set.of(1L, 2L), null);
+			when(imageMapper.selectSidoCoverage(testUserId)).thenReturn(Optional.of(dtoWithNullComplete));
+
+			// When & Then
+			assertThatThrownBy(() -> imageService.getImageSidoCoverageData(testUserId))
+				.isInstanceOf(ApiException.class)
+				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.INTERNAL_SERVER_ERROR);
+
+			verify(imageMapper).selectSidoCoverage(testUserId);
+		}
+
+		@Test
+		@DisplayName("실패 - 양쪽 Set이 모두 null")
+		void getImageSidoCoverageData_bothSetsAreNull() {
+			// Given
+			ImageSidoCoverageResponseDto dtoWithBothNull = new ImageSidoCoverageResponseDto(null, null);
+			when(imageMapper.selectSidoCoverage(testUserId)).thenReturn(Optional.of(dtoWithBothNull));
+
+			// When & Then
+			assertThatThrownBy(() -> imageService.getImageSidoCoverageData(testUserId))
+				.isInstanceOf(ApiException.class)
+				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.INTERNAL_SERVER_ERROR);
+
+			verify(imageMapper).selectSidoCoverage(testUserId);
 		}
 	}
 }


### PR DESCRIPTION
인증된 유저의 이미지 시도별 커버리지를 조회하는 API를 구현했습니다.
각 시도를 COMPLETE(모든 시군구에 이미지 존재) 또는 PARTIAL(일부 시군구에만 이미지 존재)로 분류해서
배열에 시도 ID를 넣어서 반환합니다 
이미지가 없는 시도 ID는 따로 반환하지 않습니다.

다음 작업 예정
 - 시군구 커버리지 조회
 - 시도/시군구 이미지 조회 페이지네이션 적용